### PR TITLE
Add core module with commonMain

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    kotlin("multiplatform")
+    `maven-publish`
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+                api("com.benasher44:uuid:0.2.2")
+            }
+        }
+    }
+
+    explicitApi()
+}

--- a/core/src/commonMain/kotlin/Advertisement.kt
+++ b/core/src/commonMain/kotlin/Advertisement.kt
@@ -1,0 +1,6 @@
+package com.juul.kable
+
+public expect class Advertisement {
+    public val name: String?
+    public val rssi: Int
+}

--- a/core/src/commonMain/kotlin/Central.kt
+++ b/core/src/commonMain/kotlin/Central.kt
@@ -1,0 +1,14 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+
+public expect class Central {
+
+    public fun scanner(
+        services: List<Uuid>? = null,
+    ): Scanner
+
+    public fun peripheral(
+        advertisement: Advertisement,
+    ): Peripheral
+}

--- a/core/src/commonMain/kotlin/Characteristic.kt
+++ b/core/src/commonMain/kotlin/Characteristic.kt
@@ -1,0 +1,27 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
+
+public enum class WriteType {
+    WithResponse,
+    WithoutResponse,
+}
+
+public expect class Characteristic {
+    public val uuid: Uuid
+    public val descriptors: List<Descriptor>
+}
+
+public operator fun List<Characteristic>?.get(
+    uuid: String,
+): Characteristic = getOrNull(uuid)
+    ?: throw NoSuchElementException("Characteristic $uuid")
+
+public fun List<Characteristic>?.getOrNull(
+    uuid: String,
+): Characteristic? {
+    if (this == null) return null
+    val searchUuid = uuidFrom(uuid)
+    return firstOrNull { it.uuid == searchUuid }
+}

--- a/core/src/commonMain/kotlin/Characteristic.kt
+++ b/core/src/commonMain/kotlin/Characteristic.kt
@@ -13,15 +13,10 @@ public expect class Characteristic {
     public val descriptors: List<Descriptor>
 }
 
-public operator fun List<Characteristic>?.get(
+public operator fun List<Descriptor>.get(
     uuid: String,
-): Characteristic = getOrNull(uuid)
-    ?: throw NoSuchElementException("Characteristic $uuid")
-
-public fun List<Characteristic>?.getOrNull(
-    uuid: String,
-): Characteristic? {
-    if (this == null) return null
+): Descriptor {
     val searchUuid = uuidFrom(uuid)
     return firstOrNull { it.uuid == searchUuid }
+        ?: throw NoSuchElementException("Descriptor $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/Characteristic.kt
+++ b/core/src/commonMain/kotlin/Characteristic.kt
@@ -1,7 +1,6 @@
 package com.juul.kable
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuidFrom
 
 public enum class WriteType {
     WithResponse,
@@ -11,12 +10,4 @@ public enum class WriteType {
 public expect class Characteristic {
     public val uuid: Uuid
     public val descriptors: List<Descriptor>
-}
-
-public operator fun List<Descriptor>.get(
-    uuid: String,
-): Descriptor {
-    val searchUuid = uuidFrom(uuid)
-    return firstOrNull { it.uuid == searchUuid }
-        ?: throw NoSuchElementException("Descriptor $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/Descriptor.kt
+++ b/core/src/commonMain/kotlin/Descriptor.kt
@@ -1,7 +1,6 @@
 package com.juul.kable
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuidFrom
 
 public expect class Descriptor {
     public val uuid: Uuid

--- a/core/src/commonMain/kotlin/Descriptor.kt
+++ b/core/src/commonMain/kotlin/Descriptor.kt
@@ -6,16 +6,3 @@ import com.benasher44.uuid.uuidFrom
 public expect class Descriptor {
     public val uuid: Uuid
 }
-
-public operator fun List<Descriptor>?.get(
-    uuid: String,
-): Descriptor = getOrNull(uuid)
-    ?: throw NoSuchElementException("Descriptor $uuid")
-
-public fun List<Descriptor>?.getOrNull(
-    uuid: String,
-): Descriptor? {
-    if (this == null) return null
-    val searchUuid = uuidFrom(uuid)
-    return firstOrNull { it.uuid == searchUuid }
-}

--- a/core/src/commonMain/kotlin/Descriptor.kt
+++ b/core/src/commonMain/kotlin/Descriptor.kt
@@ -1,0 +1,21 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
+
+public expect class Descriptor {
+    public val uuid: Uuid
+}
+
+public operator fun List<Descriptor>?.get(
+    uuid: String,
+): Descriptor = getOrNull(uuid)
+    ?: throw NoSuchElementException("Descriptor $uuid")
+
+public fun List<Descriptor>?.getOrNull(
+    uuid: String,
+): Descriptor? {
+    if (this == null) return null
+    val searchUuid = uuidFrom(uuid)
+    return firstOrNull { it.uuid == searchUuid }
+}

--- a/core/src/commonMain/kotlin/Error.kt
+++ b/core/src/commonMain/kotlin/Error.kt
@@ -1,3 +1,0 @@
-package com.juul.kable
-
-public expect class Error

--- a/core/src/commonMain/kotlin/Error.kt
+++ b/core/src/commonMain/kotlin/Error.kt
@@ -1,0 +1,3 @@
+package com.juul.kable
+
+public expect class Error

--- a/core/src/commonMain/kotlin/Event.kt
+++ b/core/src/commonMain/kotlin/Event.kt
@@ -1,0 +1,45 @@
+package com.juul.kable
+
+public sealed class Event {
+
+    /** Triggered upon a connection being successfully established. */
+    public data class Connected(
+        val peripheral: Peripheral,
+    ) : Event()
+
+    /**
+     * Triggered either immediately after an established connection has dropped or after a failed
+     * connection attempt.
+     *
+     * @param wasConnected is `true` if event follows an established connection, or `false` if previous connection attempt failed.
+     */
+    public data class Disconnected(
+        val wasConnected: Boolean,
+    ) : Event()
+
+    /**
+     * Triggered when the connection request was rejected by the system (e.g. bluetooth hardware
+     * unavailable).
+     */
+    public data class Rejected(
+        val cause: Throwable,
+    ) : Event()
+}
+
+public suspend fun Event.onConnected(
+    action: suspend Peripheral.() -> Unit,
+) {
+    if (this is Event.Connected) action.invoke(peripheral)
+}
+
+public suspend fun Event.onDisconnected(
+    action: suspend (Event.Disconnected) -> Unit,
+) {
+    if (this is Event.Disconnected) action.invoke(this)
+}
+
+public suspend fun Event.onRejected(
+    action: suspend (Event.Rejected) -> Unit,
+) {
+    if (this is Event.Rejected) action.invoke(this)
+}

--- a/core/src/commonMain/kotlin/IOException.kt
+++ b/core/src/commonMain/kotlin/IOException.kt
@@ -1,0 +1,5 @@
+package com.juul.kable
+
+public expect open class IOException(
+    message: String? = null,
+) : Exception

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -2,6 +2,7 @@
 
 package com.juul.kable
 
+import com.benasher44.uuid.uuidFrom
 import kotlinx.coroutines.flow.Flow
 
 public expect class Peripheral {
@@ -9,7 +10,8 @@ public expect class Peripheral {
     public val state: Flow<State>
     public val events: Flow<Event>
 
-    public val services: List<Service>?
+    /** @throws IllegalStateException if accessed prior to [service discovery][discoverServices]. */
+    public val services: List<Service>
 
     public suspend fun connect(): Unit
 
@@ -41,4 +43,12 @@ public expect class Peripheral {
     public fun observe(
         characteristic: Characteristic,
     ): Flow<ByteArray>
+}
+
+public operator fun List<Service>.get(
+    uuid: String
+): Service {
+    val searchUuid = uuidFrom(uuid)
+    return firstOrNull { it.uuid == searchUuid }
+        ?: throw NoSuchElementException("Service $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -10,16 +10,14 @@ public expect class Peripheral {
     public val state: Flow<State>
     public val events: Flow<Event>
 
+    public suspend fun connect(): Unit
+
+    public suspend fun discoverServices(): Unit
+
     /** @throws IllegalStateException if accessed prior to [service discovery][discoverServices]. */
     public val services: List<Service>
 
-    public suspend fun connect(): Unit
-
-    public suspend fun disconnect(): Unit
-
     public suspend fun rssi(): Int
-
-    public suspend fun discoverServices(): Unit
 
     public suspend fun write(
         characteristic: Characteristic,
@@ -43,6 +41,8 @@ public expect class Peripheral {
     public fun observe(
         characteristic: Characteristic,
     ): Flow<ByteArray>
+
+    public suspend fun disconnect(): Unit
 }
 
 public operator fun List<Service>.get(

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -2,7 +2,6 @@
 
 package com.juul.kable
 
-import com.benasher44.uuid.uuidFrom
 import kotlinx.coroutines.flow.Flow
 
 public expect class Peripheral {
@@ -14,8 +13,8 @@ public expect class Peripheral {
 
     public suspend fun discoverServices(): Unit
 
-    /** @throws IllegalStateException if accessed prior to [service discovery][discoverServices]. */
-    public val services: List<Service>
+    /** @return discovered services, or `null` if services have not yet been [discovered][discoverServices]. */
+    public val services: List<Service>?
 
     public suspend fun rssi(): Int
 
@@ -43,12 +42,4 @@ public expect class Peripheral {
     ): Flow<ByteArray>
 
     public suspend fun disconnect(): Unit
-}
-
-public operator fun List<Service>.get(
-    uuid: String
-): Service {
-    val searchUuid = uuidFrom(uuid)
-    return firstOrNull { it.uuid == searchUuid }
-        ?: throw NoSuchElementException("Service $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -1,0 +1,44 @@
+@file:Suppress("RedundantUnitReturnType")
+
+package com.juul.kable
+
+import kotlinx.coroutines.flow.Flow
+
+public expect class Peripheral {
+
+    public val state: Flow<State>
+    public val events: Flow<Event>
+
+    public val services: List<Service>?
+
+    public suspend fun connect(): Unit
+
+    public suspend fun disconnect(): Unit
+
+    public suspend fun rssi(): Int
+
+    public suspend fun discoverServices(): Unit
+
+    public suspend fun write(
+        characteristic: Characteristic,
+        data: ByteArray,
+        writeType: WriteType,
+    ): Unit
+
+    public suspend fun read(
+        characteristic: Characteristic,
+    ): ByteArray
+
+    public suspend fun write(
+        descriptor: Descriptor,
+        data: ByteArray,
+    ): Unit
+
+    public suspend fun read(
+        descriptor: Descriptor,
+    ): ByteArray
+
+    public fun observe(
+        characteristic: Characteristic,
+    ): Flow<ByteArray>
+}

--- a/core/src/commonMain/kotlin/Scanner.kt
+++ b/core/src/commonMain/kotlin/Scanner.kt
@@ -1,0 +1,7 @@
+package com.juul.kable
+
+import kotlinx.coroutines.flow.Flow
+
+public expect class Scanner {
+    public val peripherals: Flow<Advertisement>
+}

--- a/core/src/commonMain/kotlin/Service.kt
+++ b/core/src/commonMain/kotlin/Service.kt
@@ -8,15 +8,10 @@ public expect class Service {
     public val characteristics: List<Characteristic>
 }
 
-public operator fun List<Service>?.get(
-    uuid: String
-): Service = getOrNull(uuid)
-    ?: throw NoSuchElementException("Service $uuid")
-
-public fun List<Service>?.getOrNull(
-    uuid: String
-): Service? {
-    if (this == null) return null
+public operator fun List<Characteristic>.get(
+    uuid: String,
+): Characteristic {
     val searchUuid = uuidFrom(uuid)
     return firstOrNull { it.uuid == searchUuid }
+        ?: throw NoSuchElementException("Characteristic $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/Service.kt
+++ b/core/src/commonMain/kotlin/Service.kt
@@ -1,0 +1,22 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
+
+public expect class Service {
+    public val uuid: Uuid
+    public val characteristics: List<Characteristic>
+}
+
+public operator fun List<Service>?.get(
+    uuid: String
+): Service = getOrNull(uuid)
+    ?: throw NoSuchElementException("Service $uuid")
+
+public fun List<Service>?.getOrNull(
+    uuid: String
+): Service? {
+    if (this == null) return null
+    val searchUuid = uuidFrom(uuid)
+    return firstOrNull { it.uuid == searchUuid }
+}

--- a/core/src/commonMain/kotlin/Service.kt
+++ b/core/src/commonMain/kotlin/Service.kt
@@ -1,17 +1,8 @@
 package com.juul.kable
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuidFrom
 
 public expect class Service {
     public val uuid: Uuid
     public val characteristics: List<Characteristic>
-}
-
-public operator fun List<Characteristic>.get(
-    uuid: String,
-): Characteristic {
-    val searchUuid = uuidFrom(uuid)
-    return firstOrNull { it.uuid == searchUuid }
-        ?: throw NoSuchElementException("Characteristic $uuid not found.")
 }

--- a/core/src/commonMain/kotlin/State.kt
+++ b/core/src/commonMain/kotlin/State.kt
@@ -1,0 +1,18 @@
+package com.juul.kable
+
+public sealed class State {
+
+    public object Connecting : State()
+
+    public object Connected : State()
+
+    public object Disconnecting : State()
+
+    public data class Disconnected internal constructor(
+        val cause: Error?,
+    ) : State()
+
+    public data class Cancelled internal constructor(
+        val cause: Error?,
+    ) : State()
+}

--- a/core/src/commonMain/kotlin/State.kt
+++ b/core/src/commonMain/kotlin/State.kt
@@ -9,10 +9,10 @@ public sealed class State {
     public object Disconnecting : State()
 
     public data class Disconnected internal constructor(
-        val cause: Error?,
+        val cause: Throwable?,
     ) : State()
 
     public data class Cancelled internal constructor(
-        val cause: Error?,
+        val cause: Throwable?,
     ) : State()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+# https://kotlinlang.org/docs/reference/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false
+
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+group=com.juul.kable
+version=master-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+include("core")


### PR DESCRIPTION
Sets up the initial multiplatform project with just the `common` code. Intended to establish the foundation for Kable's public API. More PRs to follow with the platform specific implementations.

## Design

Naming generally follows Bluetooth Low Energy naming conventions.

![ble_intro](https://user-images.githubusercontent.com/98017/94753107-10d43680-0342-11eb-8309-3e1dee8a665a.png)

The following guide provides a good overview: https://embedded.fm/blog/ble-roles

## General usage flow

1. Create Coroutine scoped `Central`
2. Acquire `Scanner` from `Central`
3. Scan for nearby peripherals by `collect`ing `Advertisement`s from `Scanner`'s `peripherals` `Flow`
4. Use `Central` to convert `Advertisement` to a `Peripheral`
5. Connect to peripheral via `Peripheral`'s `connect` function
6. Communicate with peripheral via `Peripheral` functions

## Example usage

_(example OS X command line app)_

```kotlin
fun main() = runBlocking<Unit> {
    val central = central()
    val advertisement = central.scanner()
        .peripherals
        .first { /** todo: Search criteria. */ }
    val peripheral = central.peripheral(advertisement)

    peripheral.connect() // suspends until connected
    peripheral.discoverServices()
    val characteristic = peripheral
        .services["f000aa80-0451-4000-b000-000000000000"]
        .characteristics["f000aa81-0451-4000-b000-000000000000"]

    sensorTag
        .observe(characteristic)
        .onEach { data -> /** todo: Process characteristic change. */ }
}
```