### PR TITLE
Improve connection handling after a disconnect

### DIFF
--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -52,7 +52,13 @@ internal class Observers(
             }
         } finally {
             if (observers.decrementAndGet(characteristic) < 1) {
-                peripheral.stopNotifications(characteristic)
+                try {
+                    peripheral.stopNotifications(characteristic)
+                } catch (e: NotReadyException) {
+                    // Silently ignore as it is assumed that failure is due to connection drop, in which case Android
+                    // will clear the notifications.
+                    println("Stop notification failure ignored.")
+                }
             }
         }
     }

--- a/core/src/androidMain/kotlin/gatt/Callback.kt
+++ b/core/src/androidMain/kotlin/gatt/Callback.kt
@@ -46,7 +46,7 @@ internal class Callback(
 ) : BluetoothGattCallback() {
 
     private var disconnectedAction: DisconnectedAction? = null
-    fun invokeOnDisconnected(action: () -> Unit) {
+    fun invokeOnDisconnected(action: DisconnectedAction) {
         disconnectedAction = action
     }
 
@@ -92,7 +92,7 @@ internal class Callback(
         }
 
         if (newState == STATE_DISCONNECTING || newState == STATE_DISCONNECTED) {
-            _onCharacteristicChanged.close(ConnectionLostException())
+            _onCharacteristicChanged.close()
             onResponse.close(ConnectionLostException())
         }
     }


### PR DESCRIPTION
Unifies clean up of connection when no longer needed.

It's a bit of a callback dance, but there are a number of causes for disconnection when we have to be sure we've cleaned up the underlying `BluetoothGatt` (via `close`):

- `STATE_DISCONNECTED` from Android (connection dropped, e.g. device went out of range)
- `Peripheral.disconnect` (developer has explicitly requested a disconnect, in `finally` we `dispose` to be sure we clean up if disconnect process is cancelled)
- `Peripheral`'s parent `CoroutineScope` is cancelled
- `Peripheral.connect` is cancelled (e.g. user leaves current screen and connect was being performed via `viewModelScope`)