### PR TITLE
Support Core Bluetooth 16-bit UUID representation

### DIFF
--- a/core/src/macosX64Main/kotlin/Uuid.kt
+++ b/core/src/macosX64Main/kotlin/Uuid.kt
@@ -7,4 +7,7 @@ import platform.Foundation.NSUUID
 
 internal fun Uuid.toNSUUID(): NSUUID = NSUUID(toString())
 internal fun Uuid.toCBUUID(): CBUUID = CBUUID.UUIDWithString(toString())
-internal fun CBUUID.toUuid(): Uuid = uuidFrom(UUIDString)
+internal fun CBUUID.toUuid(): Uuid = when (UUIDString.length) {
+    4 -> uuidFrom("0000$UUIDString-0000-1000-8000-00805F9B34FB")
+    else -> uuidFrom(UUIDString)
+}


### PR DESCRIPTION
The `String` (`UUIDString` property) representation of `CBUUID` will sometimes be in the [16-bit UUID form](https://stackoverflow.com/a/36212021), resulting in `IllegalArgumentException: Uuid string has invalid length` failure.

<details>
<summary>Stacktrace</summary>

```
Uncaught Kotlin exception: kotlin.IllegalArgumentException: Uuid string has invalid length: 180A
    at 0   sensortag.kexe                      0x000000010c205ebf kfun:kotlin.Throwable#<init>(kotlin.String?){} + 95 (/Users/teamcity1/teamcity_work/f01984a9f5203417/runtime/src/main/kotlin/kotlin/Throwable.kt:23:37)
    at 1   sensortag.kexe                      0x000000010c1ff89d kfun:kotlin.Exception#<init>(kotlin.String?){} + 93 (/Users/teamcity1/teamcity_work/f01984a9f5203417/runtime/src/main/kotlin/kotlin/Exceptions.kt:23:44)
    at 2   sensortag.kexe                      0x000000010c1ffa7d kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 93 (/Users/teamcity1/teamcity_work/f01984a9f5203417/runtime/src/main/kotlin/kotlin/Exceptions.kt:34:44)
Unfinished workers detected, 1 workers leaked!
Use `Platform.isMemoryLeakCheckerActive = false` to avoid this check.
    at 3   sensortag.kexe                      0x000000010c1ffe2d kfun:kotlin.IllegalArgumentException#<init>(kotlin.String?){} + 93 (/Users/teamcity1/teamcity_work/f01984a9f5203417/runtime/src/main/kotlin/kotlin/Exceptions.kt:59:44)
    at 4   sensortag.kexe                      0x000000010c3aa98e kfun:com.benasher44.uuid#uuidFrom(kotlin.String){}com.benasher44.uuid.Uuid + 2782 (/Users/runner/work/uuid/uuid/src/nonJvmMain/kotlin/uuid.kt:153:6)
    at 5   sensortag.kexe                      0x000000010c3fc959 kfun:com.juul.kable#toUuid@platform.CoreBluetooth.CBUUID(){}com.benasher44.uuid.Uuid + 313 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Uuid.kt:10:38)
    at 6   sensortag.kexe                      0x000000010c3f568b kfun:com.juul.kable#toPlatformService@platform.CoreBluetooth.CBService(){}com.juul.kable.PlatformService + 603 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/PlatformService.kt:19:28)
    at 7   sensortag.kexe                      0x000000010c3c8403 kfun:com.juul.kable.ApplePeripheral#<get-platformServices>(){}kotlin.collections.List<com.juul.kable.PlatformService>? + 1027 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Peripheral.kt:94:30)
    at 8   sensortag.kexe                      0x000000010c3e6615 kfun:com.juul.kable#cbCharacteristicFrom@com.juul.kable.ApplePeripheral(com.juul.kable.Characteristic){}platform.CoreBluetooth.CBCharacteristic + 645 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Peripheral.kt:312:33)
    at 9   sensortag.kexe                      0x000000010c3d0a32 kfun:com.juul.kable.ApplePeripheral.$writeCOROUTINE$30#invokeSuspend(kotlin.Result<kotlin.Any?>){}kotlin.Any? + 1730 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Peripheral.kt:<unknown>)
    at 10  sensortag.kexe                      0x000000010c3d1a9d kfun:com.juul.kable.ApplePeripheral#write(com.juul.kable.Characteristic;platform.Foundation.NSData;com.juul.kable.WriteType){} + 477 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Peripheral.kt:208:20)
    at 11  sensortag.kexe                      0x000000010c3d0058 kfun:com.juul.kable.ApplePeripheral#write(com.juul.kable.Characteristic;kotlin.ByteArray;com.juul.kable.WriteType){} + 424 (/Users/travis/Projects/kable/core/src/macosX64Main/kotlin/Peripheral.kt:205:15)
    at 12  sensortag.kexe                      0x000000010c3af6e0 kfun:com.juul.kable.Peripheral#write$default(com.juul.kable.Characteristic;kotlin.ByteArray;com.juul.kable.WriteType?;kotlin.Int){} + 656 (/Users/travis/Projects/kable/core/src/commonMain/kotlin/Peripheral.kt:79:20)
    at 13  sensortag.kexe                      0x000000010c1bd3b4 kfun:com.juul.sensortag.SensorTag.$writeGyroPeriodCOROUTINE$1#invokeSuspend(kotlin.Result<kotlin.Any?>){}kotlin.Any? + 1860 (/Users/travis/Projects/sensortag/app/src/commonMain/kotlin/SensorTag.kt:48:20)
    at 14  sensortag.kexe                      0x000000010c1bd6f3 kfun:com.juul.sensortag.SensorTag#writeGyroPeriod(kotlin.Long){} + 291 (/Users/travis/Projects/sensortag/app/src/commonMain/kotlin/SensorTag.kt:43:13)
    at 15  sensortag.kexe                      0x000000010c1c0cd0 kfun:com.juul.sensortag.$main$lambda-3$connectCOROUTINE$6.invokeSuspend#internal + 1264 (/Users/travis/Projects/sensortag/app/src/macosX64Main/kotlin/main.kt:30:19)
    at 16  sensortag.kexe                      0x000000010c22609c kfun:kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith(kotlin.Result<kotlin.Any?>){} + 748 (/Users/teamcity1/teamcity_work/f01984a9f5203417/runtime/src/main/kotlin/kotlin/coroutines/ContinuationImpl.kt:30:39)
    at 17  sensortag.kexe                      0x000000010c360ef3 kfun:kotlinx.coroutines.DispatchedTask#run(){} + 2659 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt:40:3)
    at 18  sensortag.kexe                      0x000000010c2dd72f kfun:kotlinx.coroutines.EventLoopImplBase#processNextEvent(){}kotlin.Long + 831 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/EventLoop.common.kt:274:18)
    at 19  sensortag.kexe                      0x000000010c386e1f kfun:kotlinx.coroutines#runEventLoop(kotlinx.coroutines.EventLoop?;kotlin.Function0<kotlin.Boolean>){} + 831 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Builders.kt:80:40)
    at 20  sensortag.kexe                      0x000000010c3887be kfun:kotlinx.coroutines.BlockingCoroutine.joinBlocking#internal + 430 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Builders.kt:67:9)
    at 21  sensortag.kexe                      0x000000010c386519 kfun:kotlinx.coroutines#runBlocking(kotlin.coroutines.CoroutineContext;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}0:0 + 1273 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Builders.kt:50:22)
    at 22  sensortag.kexe                      0x000000010c386a0e kfun:kotlinx.coroutines#runBlocking$default(kotlin.coroutines.CoroutineContext?;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>;kotlin.Int){0§<kotlin.Any?&kotlin.Any?>}0:0 + 350 (/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Builders.kt:33:15)
    at 23  sensortag.kexe                      0x000000010c1bf62a kfun:com.juul.sensortag#main(){} + 170 (/Users/travis/Projects/sensortag/app/src/macosX64Main/kotlin/main.kt:11:14)
    at 24  sensortag.kexe                      0x000000010c1c3492 Konan_start + 146 (/Users/travis/Projects/sensortag/app/src/macosX64Main/kotlin/main.kt:11:1)
    at 25  sensortag.kexe                      0x000000010c1c914b Init_and_run_start + 107
    at 26  libdyld.dylib                       0x00007fff71972cc9 start + 1
```
</details>