### PR TITLE
Establish code owners for code targeting the Apple platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 
-* @JuulLabs/conx-app-reviewers @twyatt
+*                @JuulLabs/conx-app-reviewers @twyatt
+macosX64Main/    @davidtaylor-juul @Phoenix7351


### PR DESCRIPTION
Figured it'd be good to have our Apple-platform experts oversee code targeting the 🍎 -platform. 😄 