### PR TITLE
RSSI support for JS target

### DIFF
--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -62,7 +62,7 @@ public class JsPeripheral internal constructor(
     public override suspend fun rssi(): Int = suspendCancellableCoroutine { continuation ->
         check(supportsAdvertisements) { "watchAdvertisements unavailable" }
 
-        var listener: ((JsEvent) -> Unit)? = null
+        lateinit var listener: (JsEvent) -> Unit
         val cleanup = {
             bluetoothDevice.removeEventListener(ADVERTISEMENT_RECEIVED, listener)
             // At the time of writing `unwatchAdvertisements()` remains unimplemented
@@ -75,7 +75,7 @@ public class JsPeripheral internal constructor(
             val event = it as BluetoothAdvertisingEvent
             cleanup()
             if (continuation.isActive) {
-                continuation.resume(event.rssi, null)
+                continuation.resume(event.rssi, onCancellation = null)
             }
         }
 

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -4,6 +4,7 @@ package com.juul.kable
 
 import com.juul.kable.WriteType.WithResponse
 import com.juul.kable.WriteType.WithoutResponse
+import com.juul.kable.external.BluetoothAdvertisingEvent
 import com.juul.kable.external.BluetoothDevice
 import com.juul.kable.external.BluetoothRemoteGATTCharacteristic
 import com.juul.kable.external.BluetoothRemoteGATTDescriptor
@@ -20,6 +21,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.DataView
 import org.khronos.webgl.Int8Array
@@ -27,6 +29,7 @@ import kotlin.coroutines.CoroutineContext
 import org.w3c.dom.events.Event as JsEvent
 
 private const val GATT_SERVER_DISCONNECTED = "gattserverdisconnected"
+private const val ADVERTISEMENT_RECEIVED = "advertisementreceived"
 
 public actual fun CoroutineScope.peripheral(
     advertisement: Advertisement,
@@ -59,8 +62,36 @@ public class JsPeripheral internal constructor(
     public override val services: List<DiscoveredService>?
         get() = platformServices?.map { it.toDiscoveredService() }
 
-    public override suspend fun rssi(): Int {
-        TODO("Not yet implemented")
+    private val supportsAdvertisements = js("BluetoothDevice.prototype.watchAdvertisements") != null
+
+    public override suspend fun rssi(): Int = suspendCancellableCoroutine { continuation ->
+        check(supportsAdvertisements) { "watchAdvertisements unavailable" }
+
+        var listener: ((JsEvent) -> Unit)? = null
+        val cleanup = {
+            bluetoothDevice.removeEventListener(ADVERTISEMENT_RECEIVED, listener)
+            // At the time of writing `unwatchAdvertisements()` remains unimplemented
+            if (bluetoothDevice.watchingAdvertisements && js("BluetoothDevice.prototype.unwatchAdvertisements") != null) {
+                bluetoothDevice.unwatchAdvertisements()
+            }
+        }
+
+        listener = {
+            val event = it as BluetoothAdvertisingEvent
+            cleanup()
+            if (continuation.isActive) {
+                continuation.resume(event.rssi, null)
+            }
+        }
+
+        if (!bluetoothDevice.watchingAdvertisements) {
+            bluetoothDevice.watchAdvertisements()
+        }
+        bluetoothDevice.addEventListener(ADVERTISEMENT_RECEIVED, listener)
+
+        continuation.invokeOnCancellation {
+            cleanup()
+        }
     }
 
     private val gatt: BluetoothRemoteGATTServer

--- a/core/src/jsMain/kotlin/external/BluetoothDevice.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothDevice.kt
@@ -1,6 +1,7 @@
 package com.juul.kable.external
 
 import org.w3c.dom.events.EventTarget
+import kotlin.js.Promise
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice
@@ -10,6 +11,13 @@ internal abstract external class BluetoothDevice : EventTarget {
     val id: String
     val name: String?
     val gatt: BluetoothRemoteGATTServer?
+
+    // Experimental advertisement features
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-watchadvertisements
+    // Requires chrome://flags/#enable-experimental-web-platform-features
+    fun watchAdvertisements(): Promise<Unit>
+    fun unwatchAdvertisements(): Promise<Unit>
+    val watchingAdvertisements: Boolean
 }
 
 internal fun BluetoothDevice.string(): String =


### PR DESCRIPTION
Closes #19 

Uses the experimental Web API `watchAdvertisements` to obtain the RSSI value from a peripheral advertisement packet.