### PR TITLE
Use macOS runner for CI and publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle
+            ~/.gradle/caches
+            ~/.gradle/wrapper
             ~/.konan
           key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Gradle cache
         uses: actions/cache@v2
         with:
-          path: ~/.gradle
+          path: |
+            ~/.gradle
+            ~/.konan
           key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-build-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,17 @@
-# Each virtual machine has the same hardware resources available.
-#
-# - 2-core CPU
-# - 7 GB of RAM memory
-# - 14 GB of SSD disk space
-#
-# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners
-
 name: CI
 on:
   push:
 
-env:
-  SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-  SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15]
+    runs-on: ${{ matrix.os }}
+
     env:
       GRADLE_ARGS: >-
-        --stacktrace
         --no-daemon
-        --no-parallel
         --max-workers 2
         -Pkotlin.incremental=false
 
@@ -38,30 +28,23 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.gradle
-          key: grade-${{ hashFiles('**/build.gradle') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
-      - name: Check
+      - name: Compile (macOS)
+        if: runner.os == 'macOS'
+        run: ./gradlew $GRADLE_ARGS compileKotlinMacosX64
+
+      - name: Test (macOS)
+        if: runner.os == 'macOS'
+        run: ./gradlew $GRADLE_ARGS macosX64Test
+
+      - name: Assemble (Linux)
+        if: runner.os == 'Linux'
+        run: ./gradlew $GRADLE_ARGS assemble
+
+      - name: Check (Linux)
+        if: runner.os == 'Linux'
         run: ./gradlew $GRADLE_ARGS check
-
-      - name: Snapshot
-        if: github.ref == 'refs/heads/main'
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          uploadArchives
-          -PVERSION_NAME=main-SNAPSHOT
-
-      - name: Keyring
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
-
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/')
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          uploadArchives
-          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/secring.gpg"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: macos-10.15
+
+    env:
+      SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+      SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+      GRADLE_ARGS: >-
+        --no-daemon
+        --max-workers 2
+        -Pkotlin.incremental=false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Gradle cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-publish-
+            ${{ runner.os }}-
+
+      - name: Check
+        run: ./gradlew $GRADLE_ARGS check
+
+      - name: Keyring
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
+
+      - name: Publish
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+          uploadArchives

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,7 @@ on:
 jobs:
   publish:
     runs-on: macos-10.15
-
     env:
-      SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-      SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
       GRADLE_ARGS: >-
         --no-daemon
         --max-workers 2
@@ -40,6 +37,9 @@ jobs:
         run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
 
       - name: Publish
+        env:
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
         run: >-
           ./gradlew
           $GRADLE_ARGS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Gradle cache
         uses: actions/cache@v1
         with:
-          path: ~/.gradle
+          path: |
+            ~/.gradle
+            ~/.konan
           key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-publish-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: |
-            ~/.gradle
+            ~/.gradle/caches
+            ~/.gradle/wrapper
             ~/.konan
           key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle
+            ~/.gradle/caches
+            ~/.gradle/wrapper
             ~/.konan
           key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Gradle cache
         uses: actions/cache@v2
         with:
-          path: ~/.gradle
+          path: |
+            ~/.gradle
+            ~/.konan
           key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-snapshot-

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: macos-10.15
 
     env:
-      SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-      SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
       GRADLE_ARGS: >-
         --no-daemon
         --max-workers 2
@@ -37,4 +35,7 @@ jobs:
         run: ./gradlew $GRADLE_ARGS check
 
       - name: Snapshot
+        env:
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
         run: ./gradlew $GRADLE_ARGS --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,40 @@
+name: Snapshot
+on:
+  push:
+    branches: [ $default-branch ]
+
+jobs:
+  snapshot:
+    runs-on: macos-10.15
+
+    env:
+      SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+      SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+      GRADLE_ARGS: >-
+        --no-daemon
+        --max-workers 2
+        -Pkotlin.incremental=false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-snapshot-
+            ${{ runner.os }}-
+
+      - name: Check
+        run: ./gradlew $GRADLE_ARGS check
+
+      - name: Snapshot
+        run: ./gradlew $GRADLE_ARGS --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives


### PR DESCRIPTION
On every push (commit) Linux and macOS runners run in parallel.
For SNAPSHOTs and publication, only macOS runner is used.

_The publication portion is difficult to test, so may have to create subsequent PRs if there are issues with this configuration._

Closes #27