### PR TITLE
Fix function used when writing characteristic 'WithoutResponse'

### DIFF
--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -151,7 +151,7 @@ public class JsPeripheral internal constructor(
         bluetoothRemoteGATTCharacteristicFrom(characteristic).run {
             when (writeType) {
                 WithResponse -> writeValueWithResponse(data)
-                WithoutResponse -> writeValueWithResponse(data)
+                WithoutResponse -> writeValueWithoutResponse(data)
             }
         }.await()
     }


### PR DESCRIPTION
Fixes which function is called when writing characteristic (JS target).

Thanks to @davidtaylor-juul for spotting this.