### PR TITLE
Expose Web BLE advertisement data

### DIFF
--- a/core/src/jsMain/kotlin/Advertisement.kt
+++ b/core/src/jsMain/kotlin/Advertisement.kt
@@ -1,12 +1,22 @@
 package com.juul.kable
 
 import com.juul.kable.external.BluetoothDevice
+import org.khronos.webgl.DataView
 
 public actual class Advertisement internal constructor(
     internal val bluetoothDevice: BluetoothDevice,
+    public val uuids: Array<String>,
     public actual val rssi: Int,
+    internal val manufacturerData: Any?,
+    internal val serviceData: Any?,
 ) {
 
     public actual val name: String?
         get() = bluetoothDevice.name
+
+    public fun getServiceData(key: String): DataView? =
+        serviceData.asDynamic().get(key) as? DataView
+
+    public fun getManufacturerData(key: String): DataView? =
+        manufacturerData.asDynamic().get(key) as? DataView
 }

--- a/core/src/jsMain/kotlin/Scanner.kt
+++ b/core/src/jsMain/kotlin/Scanner.kt
@@ -6,7 +6,11 @@ import kotlinx.coroutines.await
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.DataView
+import org.khronos.webgl.Int8Array
 import org.w3c.dom.events.Event
+import kotlin.js.Json
 
 private const val ADVERTISEMENT_RECEIVED_EVENT = "advertisementreceived"
 
@@ -31,8 +35,7 @@ public class JsScanner internal constructor(
 
         val scan = bluetooth.requestLEScan(options.toDynamic()).await()
         val listener: (Event) -> Unit = {
-            val event = it as BluetoothAdvertisingEvent
-            offer(Advertisement(event.device, event.rssi))
+            offer((it as BluetoothAdvertisingEvent).toAdvertisement())
         }
         bluetooth.addEventListener(ADVERTISEMENT_RECEIVED_EVENT, listener)
 
@@ -41,6 +44,16 @@ public class JsScanner internal constructor(
             bluetooth.removeEventListener(ADVERTISEMENT_RECEIVED_EVENT, listener)
         }
     }
+}
+
+private fun BluetoothAdvertisingEvent.toAdvertisement(): Advertisement {
+    return Advertisement(
+        this.device,
+        this.uuids,
+        this.rssi,
+        this.manufacturerData,
+        this.serviceData,
+    )
 }
 
 // TODO: dedicated scan options class with the additional properties instead of re-using `Options`

--- a/core/src/jsMain/kotlin/external/BluetoothAdvertisingEvent.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothAdvertisingEvent.kt
@@ -1,11 +1,16 @@
 package com.juul.kable.external
 
+import org.khronos.webgl.DataView
 import org.w3c.dom.events.Event
 
 /**
  * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothadvertisingevent
  */
 internal abstract external class BluetoothAdvertisingEvent : Event {
-    val rssi: Int
     val device: BluetoothDevice
+    val uuids: Array<String>
+    val name: String?
+    val rssi: Int
+    val manufacturerData: Any?
+    val serviceData: Any?
 }


### PR DESCRIPTION
Exposes the additional fields available on the advertisement packets.

The `serviceData` and `manufacturerData` are javascript objects that can be thought of as `Map<String,DataView>` objects but they only expose this one `get()` lookup method. This is likely sufficient as the data only has meaning for a given key, and we can assume consumers know what keys they wish to query.
