### PR TITLE
Fix SNAPSHOT deployments

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,8 @@
 name: Snapshot
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - main
 
 jobs:
   snapshot:


### PR DESCRIPTION
`$default-branch` didn't seem to work.
Calling out `main` branch explicitly instead.