### PR TITLE
Add ability to configure writing to config descriptor for observations

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -153,8 +153,10 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 }
 
 public final class com/juul/kable/PeripheralKt {
-	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;)Lcom/juul/kable/Peripheral;
+	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;Lcom/juul/kable/WriteNotificationDescriptor;)Lcom/juul/kable/Peripheral;
 	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;)Lcom/juul/kable/Peripheral;
+	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;Lcom/juul/kable/WriteNotificationDescriptor;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun peripheral$default (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;Lcom/juul/kable/WriteNotificationDescriptor;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 }
 
 public final class com/juul/kable/ScanFailedException : java/lang/IllegalStateException {
@@ -241,6 +243,14 @@ public final class com/juul/kable/State$Disconnected$Status$UnknownDevice : com/
 
 public final class com/juul/kable/State$Disconnecting : com/juul/kable/State {
 	public static final field INSTANCE Lcom/juul/kable/State$Disconnecting;
+}
+
+public final class com/juul/kable/WriteNotificationDescriptor : java/lang/Enum {
+	public static final field Always Lcom/juul/kable/WriteNotificationDescriptor;
+	public static final field Auto Lcom/juul/kable/WriteNotificationDescriptor;
+	public static final field Never Lcom/juul/kable/WriteNotificationDescriptor;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/WriteNotificationDescriptor;
+	public static fun values ()[Lcom/juul/kable/WriteNotificationDescriptor;
 }
 
 public final class com/juul/kable/WriteType : java/lang/Enum {

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -9,7 +9,6 @@ import android.bluetooth.BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
 import com.benasher44.uuid.uuidFrom
 import com.juul.kable.WriteNotificationDescriptor.Always
-import com.juul.kable.WriteNotificationDescriptor.Auto
 import com.juul.kable.WriteNotificationDescriptor.Never
 import com.juul.kable.WriteType.WithResponse
 import com.juul.kable.WriteType.WithoutResponse
@@ -38,6 +37,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
 
 private val clientCharacteristicConfigUuid = uuidFrom(CLIENT_CHARACTERISTIC_CONFIG_UUID)
+private val writeNotificationDescriptorDefault = Always
 
 public actual fun CoroutineScope.peripheral(
     advertisement: Advertisement,
@@ -50,13 +50,13 @@ public fun CoroutineScope.peripheral(
 
 public fun CoroutineScope.peripheral(
     bluetoothDevice: BluetoothDevice,
-    writeObserveDescriptor: WriteNotificationDescriptor = Auto,
+    writeObserveDescriptor: WriteNotificationDescriptor = writeNotificationDescriptorDefault,
 ): Peripheral = AndroidPeripheral(coroutineContext, bluetoothDevice, writeObserveDescriptor)
 
 public class AndroidPeripheral internal constructor(
     parentCoroutineContext: CoroutineContext,
     private val bluetoothDevice: BluetoothDevice,
-    private val writeObserveDescriptor: WriteNotificationDescriptor = Auto,
+    private val writeObserveDescriptor: WriteNotificationDescriptor = writeNotificationDescriptorDefault,
 ) : Peripheral {
 
     private val job = SupervisorJob(parentCoroutineContext[Job]).apply {

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -10,6 +10,7 @@ import android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
 import com.benasher44.uuid.uuidFrom
 import com.juul.kable.WriteNotificationDescriptor.Always
 import com.juul.kable.WriteNotificationDescriptor.Auto
+import com.juul.kable.WriteNotificationDescriptor.Never
 import com.juul.kable.WriteType.WithResponse
 import com.juul.kable.WriteType.WithoutResponse
 import com.juul.kable.external.CLIENT_CHARACTERISTIC_CONFIG_UUID
@@ -220,19 +221,19 @@ public class AndroidPeripheral internal constructor(
         characteristic: Characteristic,
         value: ByteArray
     ) {
-        if (writeObserveDescriptor == Auto || writeObserveDescriptor == Always) {
-            val descriptor = LazyDescriptor(
-                serviceUuid = characteristic.serviceUuid,
-                characteristicUuid = characteristic.characteristicUuid,
-                descriptorUuid = clientCharacteristicConfigUuid
-            )
-            val bluetoothGattDescriptor = bluetoothGattDescriptorOrNullFrom(descriptor)
+        if (writeObserveDescriptor == Never) return
 
-            if (bluetoothGattDescriptor != null) {
-                write(bluetoothGattDescriptor, value)
-            } else if (writeObserveDescriptor == Always) {
-                error("Unable to start observation for $characteristic, config descriptor not found.")
-            }
+        val descriptor = LazyDescriptor(
+            serviceUuid = characteristic.serviceUuid,
+            characteristicUuid = characteristic.characteristicUuid,
+            descriptorUuid = clientCharacteristicConfigUuid
+        )
+        val bluetoothGattDescriptor = bluetoothGattDescriptorOrNullFrom(descriptor)
+
+        if (bluetoothGattDescriptor != null) {
+            write(bluetoothGattDescriptor, value)
+        } else if (writeObserveDescriptor == Always) {
+            error("Unable to start observation for $characteristic, config descriptor not found.")
         }
     }
 

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -1,7 +1,6 @@
 package com.juul.kable
 
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
 import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
@@ -38,26 +37,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
 
 private val clientCharacteristicConfigUuid = uuidFrom(CLIENT_CHARACTERISTIC_CONFIG_UUID)
-
-/** Mode specifying if config descriptor (0x2902) should be written to when starting/stopping an observation. */
-public enum class WriteNotificationDescriptor {
-
-    /**
-     * If config descriptor exists for characteristic being observed, then it will be written to when starting/stopping
-     * observations. If it does not exist, then automatically fallback to only enabling/disabling notifications (via
-     * [BluetoothGatt.setCharacteristicNotification].
-     */
-    Auto,
-
-    /**
-     * Always write to config descriptor for characteristic being observed. If it does not exist then an exception is
-     * thrown when starting/stopping the observation.
-     */
-    Always,
-
-    /** Never write to config descriptor for characteristic being observed, regardless of its availability. */
-    Never,
-}
 
 public actual fun CoroutineScope.peripheral(
     advertisement: Advertisement,

--- a/core/src/androidMain/kotlin/WriteNotificationDescriptor.kt
+++ b/core/src/androidMain/kotlin/WriteNotificationDescriptor.kt
@@ -1,23 +1,33 @@
 package com.juul.kable
 
-import android.bluetooth.BluetoothGatt
-
 /** Mode specifying if config descriptor (0x2902) should be written to when starting/stopping an observation. */
 public enum class WriteNotificationDescriptor {
 
     /**
-     * If config descriptor exists for characteristic being observed, then it will be written to when starting/stopping
-     * observations. If it does not exist, then automatically fallback to only enabling/disabling notifications (via
-     * [BluetoothGatt.setCharacteristicNotification]).
-     */
-    Auto,
-
-    /**
      * Always write to config descriptor for characteristic being observed. If it does not exist then an exception is
      * thrown when starting/stopping the observation.
+     *
+     * This is the default configuration on Android and matches the only supported behavior for Apple and JavaScript.
      */
     Always,
 
-    /** Never write to config descriptor for characteristic being observed, regardless of its availability. */
+    /**
+     * Never write to config descriptor for characteristic being observed, regardless of its availability.
+     *
+     * **Warning:** This option is only supported on Android. If the remote peripheral does not have a config descriptor
+     * associated with characteristic being observed, then the observation will only work on Android and will fail on
+     * other targets (e.g. Apple, JavaScript).
+     */
     Never,
+
+    /**
+     * If config descriptor exists for characteristic being observed, then it will be written to when starting/stopping
+     * observations. If it does not exist, then automatically fallback to only enabling/disabling notifications (without
+     * writing to config descriptor).
+     *
+     * **Warning:** This option is only supported on Android. If the remote peripheral does not have a config descriptor
+     * associated with characteristic being observed, then the observation will only work on Android and will fail on
+     * other targets (e.g. Apple, JavaScript).
+     */
+    Auto,
 }

--- a/core/src/androidMain/kotlin/WriteNotificationDescriptor.kt
+++ b/core/src/androidMain/kotlin/WriteNotificationDescriptor.kt
@@ -1,0 +1,23 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothGatt
+
+/** Mode specifying if config descriptor (0x2902) should be written to when starting/stopping an observation. */
+public enum class WriteNotificationDescriptor {
+
+    /**
+     * If config descriptor exists for characteristic being observed, then it will be written to when starting/stopping
+     * observations. If it does not exist, then automatically fallback to only enabling/disabling notifications (via
+     * [BluetoothGatt.setCharacteristicNotification]).
+     */
+    Auto,
+
+    /**
+     * Always write to config descriptor for characteristic being observed. If it does not exist then an exception is
+     * thrown when starting/stopping the observation.
+     */
+    Always,
+
+    /** Never write to config descriptor for characteristic being observed, regardless of its availability. */
+    Never,
+}


### PR DESCRIPTION
Adds ability to configure if the config descriptor for a characteristic is written to when starting/stopping an observation.

> ~I do not have a peripheral that supports notifications on a characteristic that is missing the config descriptor, so I am unable to testes this, nor can I confirm behavior for Apple and JavaScript platforms (which do not have this as configurable).~

**UPDATE:** Tested via Android test app (see https://github.com/JuulLabs/kable/issues/42#issuecomment-757428891 for details).

> ~I suspect that Apple and JavaScript only write to config descriptor if it exists, otherwise many peripherals that violate this requirement (presence of config descriptor) would not work with characteristic notifications.~

**UPDATE:** This assumption was found to be incorrect.

> ~In trying to make behavior consistent across platforms, I'm running with the assumption that Apple and JavaScript both fail gracefully, therefor making the default on Android as `Auto` (which only writes to config descriptor if present — i.e. its presence is not required).~

**UPDATE:** It was found that Apple and JavaScript exhibit behavior that matches `Always`, PR has been updated to use `Always` as default.

Closes #42
Closes #43