### PR TITLE
Use 'main' branch for documentation deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,8 @@
 name: Documentation
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
The `$default-branch` variable does not seem to work.