### PR TITLE
Fix BluetoothLeException to have message and cause

### DIFF
--- a/core/src/commonMain/kotlin/Exceptions.kt
+++ b/core/src/commonMain/kotlin/Exceptions.kt
@@ -4,7 +4,7 @@ package com.juul.kable
 public open class BluetoothLeException internal constructor(
     message: String? = null,
     cause: Throwable? = null,
-) : Exception()
+) : Exception(message, cause)
 
 public expect open class IOException internal constructor(
     message: String? = null,


### PR DESCRIPTION
Oversight where `message` and `cause` were not passed through to the parent `Exception`.