### PR TITLE
Simplify/optimize characteristic and descriptor lookups

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -240,7 +240,8 @@ public class AndroidPeripheral internal constructor(
         if (bluetoothGattDescriptor != null) {
             write(bluetoothGattDescriptor, value)
         } else if (writeObserveDescriptor == Always) {
-            error("Unable to start observation for characteristic ${characteristic.characteristicUuid}, config descriptor not found.")
+            val uuid = characteristic.characteristicUuid
+            error("Unable to start observation for characteristic $uuid, config descriptor not found.")
         }
     }
 

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -1,7 +1,6 @@
 package com.juul.kable
 
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
 import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
 import android.bluetooth.BluetoothGattDescriptor
@@ -70,9 +69,12 @@ public class AndroidPeripheral internal constructor(
     private val observers = Observers(this)
 
     @Volatile
-    internal var platformServices: List<PlatformService>? = null
+    private var _platformServices: List<PlatformService>? = null
+    private val platformServices: List<PlatformService>
+        get() = checkNotNull(_platformServices) { "Services have not been discovered for $this" }
+
     public override val services: List<DiscoveredService>?
-        get() = platformServices?.map { it.toDiscoveredService() }
+        get() = _platformServices?.map { it.toDiscoveredService() }
 
     @Volatile
     private var _connection: Connection? = null
@@ -144,7 +146,7 @@ public class AndroidPeripheral internal constructor(
         connection.execute<OnServicesDiscovered> {
             discoverServices()
         }
-        platformServices = connection.bluetoothGatt
+        _platformServices = connection.bluetoothGatt
             .services
             .map { it.toPlatformService() }
     }
@@ -206,36 +208,49 @@ public class AndroidPeripheral internal constructor(
     ): Flow<ByteArray> = observers.acquire(characteristic)
 
     internal suspend fun startNotifications(characteristic: Characteristic) {
-        val bluetoothGattCharacteristic = bluetoothGattCharacteristicFrom(characteristic)
-        connection.bluetoothGatt.setCharacteristicNotification(bluetoothGattCharacteristic, true)
-        writeConfigDescriptor(characteristic, ENABLE_NOTIFICATION_VALUE)
+        val platformCharacteristic = platformServices.findCharacteristic(characteristic)
+        connection
+            .bluetoothGatt
+            .setCharacteristicNotification(platformCharacteristic.bluetoothGattCharacteristic, true)
+
+        writeConfigDescriptor(platformCharacteristic, ENABLE_NOTIFICATION_VALUE)
     }
 
     internal suspend fun stopNotifications(characteristic: Characteristic) {
-        writeConfigDescriptor(characteristic, DISABLE_NOTIFICATION_VALUE)
-        val bluetoothGattCharacteristic = bluetoothGattCharacteristicFrom(characteristic)
-        connection.bluetoothGatt.setCharacteristicNotification(bluetoothGattCharacteristic, false)
+        val platformCharacteristic = platformServices.findCharacteristic(characteristic)
+        writeConfigDescriptor(platformCharacteristic, DISABLE_NOTIFICATION_VALUE)
+
+        val bluetoothGattCharacteristic = platformCharacteristic.bluetoothGattCharacteristic
+        connection
+            .bluetoothGatt
+            .setCharacteristicNotification(bluetoothGattCharacteristic, false)
     }
 
     private suspend fun writeConfigDescriptor(
-        characteristic: Characteristic,
+        characteristic: PlatformCharacteristic,
         value: ByteArray
     ) {
         if (writeObserveDescriptor == Never) return
 
-        val descriptor = LazyDescriptor(
-            serviceUuid = characteristic.serviceUuid,
-            characteristicUuid = characteristic.characteristicUuid,
-            descriptorUuid = clientCharacteristicConfigUuid
-        )
-        val bluetoothGattDescriptor = bluetoothGattDescriptorOrNullFrom(descriptor)
+        val bluetoothGattDescriptor = characteristic
+            .descriptors
+            .firstOrNull(clientCharacteristicConfigUuid)
+            ?.bluetoothGattDescriptor
 
         if (bluetoothGattDescriptor != null) {
             write(bluetoothGattDescriptor, value)
         } else if (writeObserveDescriptor == Always) {
-            error("Unable to start observation for $characteristic, config descriptor not found.")
+            error("Unable to start observation for characteristic ${characteristic.characteristicUuid}, config descriptor not found.")
         }
     }
+
+    private fun bluetoothGattCharacteristicFrom(
+        characteristic: Characteristic
+    ) = platformServices.findCharacteristic(characteristic).bluetoothGattCharacteristic
+
+    private fun bluetoothGattDescriptorFrom(
+        descriptor: Descriptor
+    ) = platformServices.findDescriptor(descriptor).bluetoothGattDescriptor
 
     override fun toString(): String = "Peripheral(bluetoothDevice=$bluetoothDevice)"
 }
@@ -248,57 +263,6 @@ private suspend fun Peripheral.suspendUntilConnected() {
 
 private suspend fun Peripheral.suspendUntilDisconnected() {
     state.first { it is State.Disconnected }
-}
-
-private fun AndroidPeripheral.bluetoothGattCharacteristicFrom(
-    characteristic: Characteristic,
-): BluetoothGattCharacteristic {
-    val services = checkNotNull(platformServices) {
-        "Services have not been discovered for $this"
-    }
-
-    val characteristics = services
-        .first { characteristic.serviceUuid == it.serviceUuid }
-        .characteristics
-    return characteristics
-        .first { characteristic.characteristicUuid == it.characteristicUuid }
-        .bluetoothGattCharacteristic
-}
-
-private fun AndroidPeripheral.bluetoothGattDescriptorFrom(
-    descriptor: Descriptor,
-): BluetoothGattDescriptor {
-    val services = checkNotNull(platformServices) {
-        "Services have not been discovered for $this"
-    }
-
-    val characteristics = services
-        .first { descriptor.serviceUuid == it.serviceUuid }
-        .characteristics
-    val descriptors = characteristics
-        .first { descriptor.characteristicUuid == it.characteristicUuid }
-        .descriptors
-    return descriptors
-        .first { descriptor.descriptorUuid == it.descriptorUuid }
-        .bluetoothGattDescriptor
-}
-
-private fun AndroidPeripheral.bluetoothGattDescriptorOrNullFrom(
-    descriptor: Descriptor,
-): BluetoothGattDescriptor? {
-    val services = checkNotNull(platformServices) {
-        "Services have not been discovered for $this"
-    }
-
-    val characteristics = services
-        .firstOrNull { descriptor.serviceUuid == it.serviceUuid }
-        ?.characteristics
-    val descriptors = characteristics
-        ?.firstOrNull { descriptor.characteristicUuid == it.characteristicUuid }
-        ?.descriptors
-    return descriptors
-        ?.firstOrNull { descriptor.descriptorUuid == it.descriptorUuid }
-        ?.bluetoothGattDescriptor
 }
 
 private val WriteType.intValue: Int

--- a/core/src/androidMain/kotlin/PlatformService.kt
+++ b/core/src/androidMain/kotlin/PlatformService.kt
@@ -26,3 +26,39 @@ internal fun BluetoothGattService.toPlatformService(): PlatformService {
         bluetoothGattService = this,
     )
 }
+
+/** @throws IOException if service or characteristic is not found. */
+internal fun List<PlatformService>.findCharacteristic(
+    characteristic: Characteristic
+) = findCharacteristic(
+    serviceUuid = characteristic.serviceUuid,
+    characteristicUuid = characteristic.characteristicUuid
+)
+
+/** @throws IOException if service or characteristic is not found. */
+private fun List<PlatformService>.findCharacteristic(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid
+): PlatformCharacteristic = this
+    .first(serviceUuid)
+    .characteristics
+    .first(characteristicUuid)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+internal fun List<PlatformService>.findDescriptor(
+    descriptor: Descriptor
+) = findDescriptor(
+    serviceUuid = descriptor.serviceUuid,
+    characteristicUuid = descriptor.characteristicUuid,
+    descriptorUuid = descriptor.descriptorUuid
+)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+private fun List<PlatformService>.findDescriptor(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    descriptorUuid: Uuid
+): PlatformDescriptor =
+    this.findCharacteristic(serviceUuid, characteristicUuid)
+        .descriptors
+        .first(descriptorUuid)

--- a/core/src/androidMain/kotlin/PlatformService.kt
+++ b/core/src/androidMain/kotlin/PlatformService.kt
@@ -27,38 +27,41 @@ internal fun BluetoothGattService.toPlatformService(): PlatformService {
     )
 }
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 internal fun List<PlatformService>.findCharacteristic(
     characteristic: Characteristic
-) = findCharacteristic(
-    serviceUuid = characteristic.serviceUuid,
-    characteristicUuid = characteristic.characteristicUuid
-)
+): PlatformCharacteristic =
+    findCharacteristic(
+        serviceUuid = characteristic.serviceUuid,
+        characteristicUuid = characteristic.characteristicUuid
+    )
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 private fun List<PlatformService>.findCharacteristic(
     serviceUuid: Uuid,
     characteristicUuid: Uuid
-): PlatformCharacteristic = this
-    .first(serviceUuid)
-    .characteristics
-    .first(characteristicUuid)
+): PlatformCharacteristic =
+    first(serviceUuid)
+        .characteristics
+        .first(characteristicUuid)
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 internal fun List<PlatformService>.findDescriptor(
     descriptor: Descriptor
-) = findDescriptor(
-    serviceUuid = descriptor.serviceUuid,
-    characteristicUuid = descriptor.characteristicUuid,
-    descriptorUuid = descriptor.descriptorUuid
-)
+): PlatformDescriptor =
+    findDescriptor(
+        serviceUuid = descriptor.serviceUuid,
+        characteristicUuid = descriptor.characteristicUuid,
+        descriptorUuid = descriptor.descriptorUuid
+    )
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 private fun List<PlatformService>.findDescriptor(
     serviceUuid: Uuid,
     characteristicUuid: Uuid,
     descriptorUuid: Uuid
 ): PlatformDescriptor =
-    this.findCharacteristic(serviceUuid, characteristicUuid)
-        .descriptors
-        .first(descriptorUuid)
+    findCharacteristic(
+        serviceUuid = serviceUuid,
+        characteristicUuid = characteristicUuid
+    ).descriptors.first(descriptorUuid)

--- a/core/src/commonMain/kotlin/Characteristic.kt
+++ b/core/src/commonMain/kotlin/Characteristic.kt
@@ -30,4 +30,4 @@ public data class DiscoveredCharacteristic internal constructor(
 internal fun <T : Characteristic> List<T>.first(
     characteristicUuid: Uuid
 ): T = firstOrNull { it.characteristicUuid == characteristicUuid }
-    ?: throw IOException("Characteristic $characteristicUuid not found")
+    ?: throw NoSuchElementException("Characteristic $characteristicUuid not found")

--- a/core/src/commonMain/kotlin/Characteristic.kt
+++ b/core/src/commonMain/kotlin/Characteristic.kt
@@ -26,3 +26,8 @@ public data class DiscoveredCharacteristic internal constructor(
     override val characteristicUuid: Uuid,
     public val descriptors: List<Descriptor>,
 ) : Characteristic
+
+internal fun <T : Characteristic> List<T>.first(
+    characteristicUuid: Uuid
+): T = firstOrNull { it.characteristicUuid == characteristicUuid }
+    ?: throw IOException("Characteristic $characteristicUuid not found")

--- a/core/src/commonMain/kotlin/Descriptor.kt
+++ b/core/src/commonMain/kotlin/Descriptor.kt
@@ -24,3 +24,12 @@ public data class LazyDescriptor(
     public override val characteristicUuid: Uuid,
     public override val descriptorUuid: Uuid,
 ) : Descriptor
+
+internal fun <T : Descriptor> List<T>.first(
+    descriptorUuid: Uuid
+): T = firstOrNull(descriptorUuid)
+    ?: throw IOException("Descriptor $descriptorUuid not found")
+
+internal fun <T : Descriptor> List<T>.firstOrNull(
+    descriptorUuid: Uuid
+): T? = firstOrNull { it.descriptorUuid == descriptorUuid }

--- a/core/src/commonMain/kotlin/Descriptor.kt
+++ b/core/src/commonMain/kotlin/Descriptor.kt
@@ -28,7 +28,7 @@ public data class LazyDescriptor(
 internal fun <T : Descriptor> List<T>.first(
     descriptorUuid: Uuid
 ): T = firstOrNull(descriptorUuid)
-    ?: throw IOException("Descriptor $descriptorUuid not found")
+    ?: throw NoSuchElementException("Descriptor $descriptorUuid not found")
 
 internal fun <T : Descriptor> List<T>.firstOrNull(
     descriptorUuid: Uuid

--- a/core/src/commonMain/kotlin/Service.kt
+++ b/core/src/commonMain/kotlin/Service.kt
@@ -10,3 +10,9 @@ public data class DiscoveredService internal constructor(
     override val serviceUuid: Uuid,
     public val characteristics: List<DiscoveredCharacteristic>,
 ) : Service
+
+/** @throws IOException if service is not found. */
+internal fun <T : Service> List<T>.first(
+    serviceUuid: Uuid
+): T = firstOrNull { it.serviceUuid == serviceUuid }
+    ?: throw IOException("Service $serviceUuid not found")

--- a/core/src/commonMain/kotlin/Service.kt
+++ b/core/src/commonMain/kotlin/Service.kt
@@ -15,4 +15,4 @@ public data class DiscoveredService internal constructor(
 internal fun <T : Service> List<T>.first(
     serviceUuid: Uuid
 ): T = firstOrNull { it.serviceUuid == serviceUuid }
-    ?: throw IOException("Service $serviceUuid not found")
+    ?: throw NoSuchElementException("Service $serviceUuid not found")

--- a/core/src/jsMain/kotlin/PlatformService.kt
+++ b/core/src/jsMain/kotlin/PlatformService.kt
@@ -31,38 +31,41 @@ internal suspend fun BluetoothRemoteGATTService.toPlatformService(): PlatformSer
     )
 }
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 internal fun List<PlatformService>.findCharacteristic(
     characteristic: Characteristic
-) = findCharacteristic(
-    serviceUuid = characteristic.serviceUuid,
-    characteristicUuid = characteristic.characteristicUuid
-)
+): PlatformCharacteristic =
+    findCharacteristic(
+        serviceUuid = characteristic.serviceUuid,
+        characteristicUuid = characteristic.characteristicUuid
+    )
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 private fun List<PlatformService>.findCharacteristic(
     serviceUuid: Uuid,
     characteristicUuid: Uuid
-): PlatformCharacteristic = this
-    .first(serviceUuid)
-    .characteristics
-    .first(characteristicUuid)
+): PlatformCharacteristic =
+    first(serviceUuid)
+        .characteristics
+        .first(characteristicUuid)
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 internal fun List<PlatformService>.findDescriptor(
     descriptor: Descriptor
-) = findDescriptor(
-    serviceUuid = descriptor.serviceUuid,
-    characteristicUuid = descriptor.characteristicUuid,
-    descriptorUuid = descriptor.descriptorUuid
-)
+): PlatformDescriptor =
+    findDescriptor(
+        serviceUuid = descriptor.serviceUuid,
+        characteristicUuid = descriptor.characteristicUuid,
+        descriptorUuid = descriptor.descriptorUuid
+    )
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 private fun List<PlatformService>.findDescriptor(
     serviceUuid: Uuid,
     characteristicUuid: Uuid,
     descriptorUuid: Uuid
 ): PlatformDescriptor =
-    this.findCharacteristic(serviceUuid, characteristicUuid)
-        .descriptors
-        .first(descriptorUuid)
+    findCharacteristic(
+        serviceUuid = serviceUuid,
+        characteristicUuid = characteristicUuid
+    ).descriptors.first(descriptorUuid)

--- a/core/src/jsMain/kotlin/PlatformService.kt
+++ b/core/src/jsMain/kotlin/PlatformService.kt
@@ -30,3 +30,39 @@ internal suspend fun BluetoothRemoteGATTService.toPlatformService(): PlatformSer
         bluetoothRemoteGATTService = this,
     )
 }
+
+/** @throws IOException if service or characteristic is not found. */
+internal fun List<PlatformService>.findCharacteristic(
+    characteristic: Characteristic
+) = findCharacteristic(
+    serviceUuid = characteristic.serviceUuid,
+    characteristicUuid = characteristic.characteristicUuid
+)
+
+/** @throws IOException if service or characteristic is not found. */
+private fun List<PlatformService>.findCharacteristic(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid
+): PlatformCharacteristic = this
+    .first(serviceUuid)
+    .characteristics
+    .first(characteristicUuid)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+internal fun List<PlatformService>.findDescriptor(
+    descriptor: Descriptor
+) = findDescriptor(
+    serviceUuid = descriptor.serviceUuid,
+    characteristicUuid = descriptor.characteristicUuid,
+    descriptorUuid = descriptor.descriptorUuid
+)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+private fun List<PlatformService>.findDescriptor(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    descriptorUuid: Uuid
+): PlatformDescriptor =
+    this.findCharacteristic(serviceUuid, characteristicUuid)
+        .descriptors
+        .first(descriptorUuid)

--- a/core/src/macosX64Main/kotlin/PlatformService.kt
+++ b/core/src/macosX64Main/kotlin/PlatformService.kt
@@ -28,3 +28,39 @@ internal fun CBService.toPlatformService(): PlatformService {
         cbService = this,
     )
 }
+
+/** @throws IOException if service or characteristic is not found. */
+internal fun List<PlatformService>.findCharacteristic(
+    characteristic: Characteristic
+) = findCharacteristic(
+    serviceUuid = characteristic.serviceUuid,
+    characteristicUuid = characteristic.characteristicUuid
+)
+
+/** @throws IOException if service or characteristic is not found. */
+private fun List<PlatformService>.findCharacteristic(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid
+): PlatformCharacteristic = this
+    .first(serviceUuid)
+    .characteristics
+    .first(characteristicUuid)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+internal fun List<PlatformService>.findDescriptor(
+    descriptor: Descriptor
+) = findDescriptor(
+    serviceUuid = descriptor.serviceUuid,
+    characteristicUuid = descriptor.characteristicUuid,
+    descriptorUuid = descriptor.descriptorUuid
+)
+
+/** @throws IOException if service, characteristic or descriptor is not found. */
+private fun List<PlatformService>.findDescriptor(
+    serviceUuid: Uuid,
+    characteristicUuid: Uuid,
+    descriptorUuid: Uuid
+): PlatformDescriptor =
+    this.findCharacteristic(serviceUuid, characteristicUuid)
+        .descriptors
+        .first(descriptorUuid)

--- a/core/src/macosX64Main/kotlin/PlatformService.kt
+++ b/core/src/macosX64Main/kotlin/PlatformService.kt
@@ -29,38 +29,41 @@ internal fun CBService.toPlatformService(): PlatformService {
     )
 }
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 internal fun List<PlatformService>.findCharacteristic(
     characteristic: Characteristic
-) = findCharacteristic(
-    serviceUuid = characteristic.serviceUuid,
-    characteristicUuid = characteristic.characteristicUuid
-)
+): PlatformCharacteristic =
+    findCharacteristic(
+        serviceUuid = characteristic.serviceUuid,
+        characteristicUuid = characteristic.characteristicUuid
+    )
 
-/** @throws IOException if service or characteristic is not found. */
+/** @throws NoSuchElementException if service or characteristic is not found. */
 private fun List<PlatformService>.findCharacteristic(
     serviceUuid: Uuid,
     characteristicUuid: Uuid
-): PlatformCharacteristic = this
-    .first(serviceUuid)
-    .characteristics
-    .first(characteristicUuid)
+): PlatformCharacteristic =
+    first(serviceUuid)
+        .characteristics
+        .first(characteristicUuid)
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 internal fun List<PlatformService>.findDescriptor(
     descriptor: Descriptor
-) = findDescriptor(
-    serviceUuid = descriptor.serviceUuid,
-    characteristicUuid = descriptor.characteristicUuid,
-    descriptorUuid = descriptor.descriptorUuid
-)
+): PlatformDescriptor =
+    findDescriptor(
+        serviceUuid = descriptor.serviceUuid,
+        characteristicUuid = descriptor.characteristicUuid,
+        descriptorUuid = descriptor.descriptorUuid
+    )
 
-/** @throws IOException if service, characteristic or descriptor is not found. */
+/** @throws NoSuchElementException if service, characteristic or descriptor is not found. */
 private fun List<PlatformService>.findDescriptor(
     serviceUuid: Uuid,
     characteristicUuid: Uuid,
     descriptorUuid: Uuid
 ): PlatformDescriptor =
-    this.findCharacteristic(serviceUuid, characteristicUuid)
-        .descriptors
-        .first(descriptorUuid)
+    findCharacteristic(
+        serviceUuid = serviceUuid,
+        characteristicUuid = characteristicUuid
+    ).descriptors.first(descriptorUuid)


### PR DESCRIPTION
When a service, characteristic or descriptor cannot be found, `NoSuchElementException` is now thrown with a `message` stating the UUID that could not be found.

On Apple platform, services are now cached on service discovery (which matches behavior of the other platform targets).

Closes #14
Closes #38