### PR TITLE
Bump Kotlin to 1.6.0 and use hierarchical project structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,12 +6,12 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.5.20" apply false
+    kotlin("multiplatform") version "1.6.0-RC2" apply false
     id("com.android.library") version "4.1.3" apply false
     id("org.jmailen.kotlinter") version "3.4.4" apply false
     id("com.vanniktech.maven.publish") version "0.15.1" apply false
     id("org.jetbrains.dokka") version "1.4.32"
-    id("kotlinx-atomicfu") version "0.16.1" apply false
+    id("kotlinx-atomicfu") version "0.16.3" apply false
     id("binary-compatibility-validator") version "0.5.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.6.0-RC2" apply false
+    kotlin("multiplatform") version "1.6.0" apply false
     id("com.android.library") version "4.1.3" apply false
     id("org.jmailen.kotlinter") version "3.4.4" apply false
     id("com.vanniktech.maven.publish") version "0.15.1" apply false

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,34 +1,34 @@
 fun coroutines(
     module: String = "core",
-    version: String = "1.5.1"
+    version: String = "1.5.2"
 ): String = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 
 fun atomicfu(
     module: String,
-    version: String = "0.16.1"
+    version: String = "0.16.3"
 ) = "org.jetbrains.kotlinx:atomicfu-$module:$version"
 
 fun uuid(
     artifact: String = "uuid",
-    version: String = "0.3.0"
+    version: String = "0.3.1"
 ): String = "com.benasher44:$artifact:$version"
 
 fun stately(
     module: String,
-    version: String = "1.1.7-a1"
+    version: String = "1.1.10-a1"
 ): String = "co.touchlab:stately-$module:$version"
 
 fun wrappers(
-    version: String = "1.0.1-pre.213-kotlin-1.5.10"
+    version: String = "1.0.1-pre.264-kotlin-1.5.31"
 ) = "org.jetbrains.kotlin-wrappers:kotlin-extensions:$version"
 
 object androidx {
     fun startup(
-        version: String = "1.0.0"
+        version: String = "1.1.0"
     ) = "androidx.startup:startup-runtime:$version"
 }
 
 fun tuulbox(
     module: String,
-    version: String = "4.3.0"
+    version: String = "4.8.0"
 ) = "com.juul.tuulbox:$module:$version"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,15 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
+/* ```
+ *   common
+ *   |-- js
+ *   |-- android
+ *   '-- apple
+ *       |-- ios
+ *       '-- macos
+ * ```
+ */
 kotlin {
     explicitApi()
 
@@ -61,39 +70,35 @@ kotlin {
             }
         }
 
-        val macosX64Main by getting {
+        val appleMain by creating {
+            dependsOn(commonMain)
             dependencies {
-                implementation(stately("isolate-macosx64"))
+                implementation(stately("isolate"))
             }
+        }
+
+        val appleTest by creating
+
+        val macosX64Main by getting {
+            dependsOn(appleMain)
         }
 
         val iosX64Main by getting {
-            dependencies {
-                implementation(stately("isolate-iosx64"))
-            }
+            dependsOn(appleMain)
         }
 
         val iosArm32Main by getting {
-            dependencies {
-                implementation(stately("isolate-iosarm32"))
-            }
+            dependsOn(appleMain)
         }
 
         val iosArm64Main by getting {
-            dependencies {
-                implementation(stately("isolate-iosarm64"))
-            }
+            dependsOn(appleMain)
         }
 
         all {
             languageSettings.enableLanguageFeature("InlineClasses")
         }
     }
-}
-
-atomicfu {
-    transformJvm = true
-    transformJs = false
 }
 
 android {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -83,16 +83,32 @@ kotlin {
             dependsOn(appleMain)
         }
 
+        val macosX64Test by getting {
+            dependsOn(appleTest)
+        }
+
         val iosX64Main by getting {
             dependsOn(appleMain)
+        }
+
+        val iosX64Test by getting {
+            dependsOn(appleTest)
         }
 
         val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 
+        val iosArm32Test by getting {
+            dependsOn(appleTest)
+        }
+
         val iosArm64Main by getting {
             dependsOn(appleMain)
+        }
+
+        val iosArm64Test by getting {
+            dependsOn(appleTest)
         }
 
         all {

--- a/core/src/appleMain/kotlin/Advertisement.kt
+++ b/core/src/appleMain/kotlin/Advertisement.kt
@@ -39,7 +39,7 @@ public actual data class Advertisement(
         manufacturerData?.takeIf { (it.code == companyIdentifierCode) }?.data
 
     public actual val manufacturerData: ManufacturerData?
-        get() = manufacturerDataAsNSData?.toByteArray()?.toManufacturerData()
+        get() = manufacturerDataAsNSData?.toManufacturerData()
 
     public fun manufacturerDataAsNSData(companyIdentifierCode: Int): NSData? =
         manufacturerData(companyIdentifierCode)?.toNSData()
@@ -50,6 +50,8 @@ public actual data class Advertisement(
     override fun toString(): String =
         "Advertisement(name=$name, cbPeripheral=$cbPeripheral, rssi=$rssi, txPower=$txPower)"
 }
+
+internal fun NSData.toManufacturerData(): ManufacturerData? = toByteArray().toManufacturerData()
 
 private fun ByteArray.toManufacturerData(): ManufacturerData? =
     takeIf { size >= 2 }?.getShortAt(0)?.let { code ->

--- a/core/src/appleTest/kotlin/AdvertisementTest.kt
+++ b/core/src/appleTest/kotlin/AdvertisementTest.kt
@@ -1,9 +1,8 @@
 package com.juul.kable.test
 
-import com.juul.kable.Advertisement
+import com.juul.kable.toManufacturerData
 import com.juul.kable.toNSData
-import platform.CoreBluetooth.CBAdvertisementDataManufacturerDataKey
-import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSData
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -15,47 +14,37 @@ import kotlin.test.assertTrue
 class AdvertisementTest {
     @Test
     fun manufacturerData_advertisementWithMoreThanTwoBytes_hasCodeAndData() {
-        val advertisement = fakeAdvertisement(
-            ubyteArrayOf(
-                0xc3u, 0x05u, // little-endian manufacturer id
-                0x042u, // data
-            )
-        )
-        val data = advertisement.manufacturerData
-        assertNotNull(data)
-        assertEquals(data.code, 0x05c3)
-        assertEquals(data.data.size, 1)
-        assertEquals(data.data[0], 0x042)
+        val data = ubyteArrayOf(
+            0xc3u, 0x05u, // little-endian manufacturer id
+            0x042u, // data
+        ).toNSData()
+        val manufacturerData = data.toManufacturerData()
+
+        assertNotNull(manufacturerData)
+        assertEquals(manufacturerData.code, 0x05c3)
+        assertEquals(manufacturerData.data.size, 1)
+        assertEquals(manufacturerData.data[0], 0x042)
     }
 
     @Test
     fun manufacturerData_advertisementWithTwoBytes_hasCodeAndEmptyData() {
-        val advertisement = fakeAdvertisement(
-            ubyteArrayOf(
-                0xc3u, 0x05u, // little-endian manufacturer id
-            )
-        )
-        val data = advertisement.manufacturerData
-        assertNotNull(data)
-        assertEquals(data.code, 0x05c3)
-        assertTrue(data.data.isEmpty())
+        val data = ubyteArrayOf(
+            0xc3u, 0x05u, // little-endian manufacturer id
+        ).toNSData()
+        val manufacturerData = data.toManufacturerData()
+
+        assertNotNull(manufacturerData)
+        assertEquals(manufacturerData.code, 0x05c3)
+        assertTrue(manufacturerData.data.isEmpty())
     }
 
     @Test
     fun manufacturerData_advertisementWithFewerThanTwoBytes_isNull() {
-        val advertisement = fakeAdvertisement(
-            ubyteArrayOf(0x01u)
-        )
-        val data = advertisement.manufacturerData
-        assertNull(data)
-    }
+        val data = ubyteArrayOf(0x01u).toNSData()
+        val manufacturerData = data.toManufacturerData()
 
-    private fun fakeAdvertisement(manufacturerBytes: UByteArray): Advertisement =
-        Advertisement(
-            rssi = 0,
-            data = mapOf(
-                CBAdvertisementDataManufacturerDataKey to manufacturerBytes.toByteArray().toNSData()
-            ),
-            cbPeripheral = CBPeripheral()
-        )
+        assertNull(manufacturerData)
+    }
 }
+
+private fun UByteArray.toNSData(): NSData = toByteArray().toNSData()

--- a/core/src/iosArm32Main
+++ b/core/src/iosArm32Main
@@ -1,1 +1,0 @@
-appleMain

--- a/core/src/iosArm32Test
+++ b/core/src/iosArm32Test
@@ -1,1 +1,0 @@
-appleTest

--- a/core/src/iosArm64Main
+++ b/core/src/iosArm64Main
@@ -1,1 +1,0 @@
-appleMain

--- a/core/src/iosArm64Test
+++ b/core/src/iosArm64Test
@@ -1,1 +1,0 @@
-appleTest

--- a/core/src/iosX64Main
+++ b/core/src/iosX64Main
@@ -1,1 +1,0 @@
-appleMain

--- a/core/src/iosX64Test
+++ b/core/src/iosX64Test
@@ -1,1 +1,0 @@
-appleTest

--- a/core/src/macosX64Main
+++ b/core/src/macosX64Main
@@ -1,1 +1,0 @@
-appleMain

--- a/core/src/macosX64Test
+++ b/core/src/macosX64Test
@@ -1,1 +1,0 @@
-appleTest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-# https://kotlinlang.org/docs/reference/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure
+# https://kotlinlang.org/docs/mpp-share-on-platforms.html
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 


### PR DESCRIPTION
Related to #52.

Configures project to leverage [hierarchical project structure](https://kotlinlang.org/docs/reference/mpp-share-on-platforms.html) for iOS targets (and share code with MacOS target):

```
common 
|-- js 
|-- android 
'-- apple 
    |-- ios 
    '-- macos 
```

Requires Mac OS X 11 to build due to bumping Kotlin to 1.6.x.
Took the opportunity to bump all dependencies.

Advertisement unit tests were reworked to no longer instantiate `CBPeripheral` objects, as it was causing tests to crash:

<details>
<summary>Crash</summary>

```
> Failed to execute all tests:
  :core:iosX64Test: Test running process exited unexpectedly.
  Current test: connectingObserves_isAtLeast_connected_is_false
  Process output:
   2021-11-18 20:50:19.305 test.kexe[5528:24463] *** Terminating app due to uncaught exception 'NSRangeException', reason: 'Cannot remove an observer <CBPeripheral 0x6000024fc580> for the key path "delegate" from <CBPeripheral 0x6000024fc580> because it is not registered as an observer.'
  *** First throw call stack:
  (
  	0   CoreFoundation                      0x00000001056d2bb4 __exceptionPreprocess + 242
  	1   libobjc.A.dylib                     0x0000000105147be7 objc_exception_throw + 48
  	2   Foundation                          0x0000000105f27062 -[NSObject(NSKeyValueObserverRegistration) _removeObserver:forProperty:] + 689
  	3   Foundation                          0x0000000105f274c2 -[NSObject(NSKeyValueObserverRegistration) removeObserver:forKeyPath:] + 129
  	4   CoreBluetooth                       0x00000001054ded69 -[CBPeripheral dealloc] + 41
  	5   libobjc.A.dylib                     0x00000001051459f7 _ZN11objc_object17sidetable_releaseEbb + 177
  	6   test.kexe                           0x000000010495f43a -[NSObject(NSObjectToKotlin) releaseAsAssociatedObject:] + 26
  	7   test.kexe                           0x0000000104b6f6c2 Kotlin_ObjCExport_detachAndReleaseAssociatedObject + 82
  	8   test.kexe                           0x0000000104b39ab6 _ZN9ObjHeader17destroyMetaObjectEPS_ + 118
  	9   test.kexe                           0x0000000104b6b9ea _ZN6kotlin13RunFinalizersEP9ObjHeader + 138
  	10  test.kexe                           0x0000000104b432af _ZN12_GLOBAL__N_113freeContainerEP15ContainerHeader + 2127
  	11  test.kexe                           0x0000000104b3e2b7 _ZN12_GLOBAL__N_111decrementRCEP15ContainerHeader + 247
  	12  test.kexe                           0x0000000104b3a4b0 _ZN12_GLOBAL__N_114garbageCollectEP11MemoryStateb + 1248
  	13  test.kexe                           0x0000000104b46ee9 AllocArrayInstanceStrict + 457
  	14  test.kexe                           0x0000000104967e38 kfun:kotlin.collections#copyOfUninitializedElements__at__kotlin.CharArray(kotlin.Int;kotlin.Int){}kotlin.CharArray + 488
  	15  test.kexe                           0x000000010496858f kfun:kotlin.collections#copyOfUninitializedElements__at__kotlin.CharArray(kotlin.Int){}kotlin.CharArray + 175
  	16  test.kexe                           0x00000001049666fd kfun:kotlin.collections#copyOf__at__kotlin.CharArray(kotlin.Int){}kotlin.CharArray + 173
  	17  test.kexe                           0x00000001049e43c3 kfun:kotlin.text.StringBuilder#ensureCapacity(kotlin.Int){} + 419
  	18  test.kexe                           0x00000001049e5403 kfun:kotlin.text.StringBuilder.ensureExtraCapacity#internal + 99
  	19  test.kexe                           0x00000001049e40f0 kfun:kotlin.text.StringBuilder#append(kotlin.String?){}kotlin.text.StringBuilder + 368
  	20  test.kexe                           0x00000001049e3f0a kfun:kotlin.text.StringBuilder#append(kotlin.String){}kotlin.text.StringBuilder + 202
  	21  test.kexe                           0x00000001049bad90 kfun:kotlin.native.internal.test.TeamCityLogger.finish#internal + 656
  	22  test.kexe                           0x00000001049bc21d kfun:kotlin.native.internal.test.TeamCityLogger#pass(kotlin.native.internal.test.TestCase;kotlin.Long){} + 109
  	23  test.kexe                           0x00000001049c6c5d kfun:kotlin.native.internal.test.TestRunner.run#internal + 5725
  	24  test.kexe                           0x00000001049c9439 kfun:kotlin.native.internal.test.TestRunner.runIteration#internal + 4633
  	25  test.kexe                           0x00000001049ca622 kfun:kotlin.native.internal.test.TestRunner#run(){}kotlin.Int + 1410
  	26  test.kexe                           0x00000001049ba198 kfun:kotlin.native.internal.test#testLauncherEntryPoint(kotlin.Array<kotlin.String>){}kotlin.Int + 312
  	27  test.kexe                           0x00000001049ba28c kfun:kotlin.native.internal.test#main(kotlin.Array<kotlin.String>){} + 60
  	28  test.kexe                           0x0000000104959799 Konan_start + 153
  	29  test.kexe                           0x000000010495fcce Init_and_run_start + 94
  	30  dyld                                0x0000000104ed1e1e start_sim + 10
  	31  ???                                 0x0000000000000001 0x0 + 1
  )
  libc++abi: terminating with uncaught exception of type NSException
  Child process terminated with signal 6: Abort trap
```
</details>