### PR TITLE
Suppress Scanner advertisement delivery failures

### DIFF
--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -3,6 +3,7 @@ package com.juul.kable
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
+import android.util.Log
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.sendBlocking
@@ -25,13 +26,17 @@ public class AndroidScanner internal constructor() : Scanner {
 
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
-                sendBlocking(Advertisement(result))
+                runCatching {
+                    sendBlocking(Advertisement(result))
+                }.onFailure { cause -> Log.w(TAG, "Unable to deliver scan result.", cause) }
             }
 
             override fun onBatchScanResults(results: MutableList<ScanResult>) {
-                results.forEach {
-                    sendBlocking(Advertisement(it))
-                }
+                runCatching {
+                    results.forEach {
+                        sendBlocking(Advertisement(it))
+                    }
+                }.onFailure { cause -> Log.w(TAG, "Unable to deliver batch scan results.", cause) }
             }
 
             override fun onScanFailed(errorCode: Int) {

--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -28,7 +28,9 @@ public class AndroidScanner internal constructor() : Scanner {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
                 runCatching {
                     sendBlocking(Advertisement(result))
-                }.onFailure { cause -> Log.w(TAG, "Unable to deliver scan result.", cause) }
+                }.onFailure {
+                    Log.w(TAG, "Unable to deliver scan result due to failure in flow or premature closing.")
+                }
             }
 
             override fun onBatchScanResults(results: MutableList<ScanResult>) {
@@ -36,7 +38,9 @@ public class AndroidScanner internal constructor() : Scanner {
                     results.forEach {
                         sendBlocking(Advertisement(it))
                     }
-                }.onFailure { cause -> Log.w(TAG, "Unable to deliver batch scan results.", cause) }
+                }.onFailure {
+                    Log.w(TAG, "Unable to deliver batch scan results due to failure in flow or premature closing.")
+                }
             }
 
             override fun onScanFailed(errorCode: Int) {

--- a/core/src/jsMain/kotlin/Scanner.kt
+++ b/core/src/jsMain/kotlin/Scanner.kt
@@ -33,7 +33,9 @@ public class JsScanner internal constructor(
         val listener: (Event) -> Unit = {
             runCatching {
                 offer(Advertisement(it as BluetoothAdvertisingEvent))
-            }.onFailure { cause -> console.warn("Unable to deliver advertisement event due to $cause.") }
+            }.onFailure {
+                console.warn("Unable to deliver advertisement event due to failure in flow or premature closing.")
+            }
         }
         bluetooth.addEventListener(ADVERTISEMENT_RECEIVED_EVENT, listener)
 

--- a/core/src/jsMain/kotlin/Scanner.kt
+++ b/core/src/jsMain/kotlin/Scanner.kt
@@ -31,7 +31,9 @@ public class JsScanner internal constructor(
 
         val scan = bluetooth.requestLEScan(options.toDynamic()).await()
         val listener: (Event) -> Unit = {
-            offer(Advertisement(it as BluetoothAdvertisingEvent))
+            runCatching {
+                offer(Advertisement(it as BluetoothAdvertisingEvent))
+            }.onFailure { cause -> console.warn("Unable to deliver advertisement event due to $cause.") }
         }
         bluetooth.addEventListener(ADVERTISEMENT_RECEIVED_EVENT, listener)
 


### PR DESCRIPTION
When `callbackFlow`'s `Channel` is closed due to downstream `Flow` being cancelled then sending to the `Channel` can unexpectedly throw an exception. We suppress the exception, as it is assumed that `Flow` is shutting down anyways.

Closes #67 