### PR TITLE
Remove jcenter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // or mavenCentral()
+    mavenCentral()
 }
 
 kotlin {
@@ -243,7 +243,7 @@ as a transitive dependency for Apple-based targets._
 
 ```kotlin
 repositories {
-    jcenter() // or mavenCentral()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Due to Bintray (`jcenter()`) being [sunset], removing it from the
configuration example in README.

[sunset]: https://www.reddit.com/r/java/comments/lbstco/bintray_including_jcenter_will_be_sunset_on_may/