### PR TITLE
Update Gradle example for platform specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,21 @@ as a transitive dependency for Apple-based targets._
 
 #### Platform-specific
 
+Gradle will pull in the appropriate platform artifact when the undecorated `core` artifact is specified:
+
 ```kotlin
 repositories {
     jcenter() // or mavenCentral()
 }
 
+dependencies {
+    implementation("com.juul.kable:core:$version")
+}
+```
+
+If a specific platform artifact is needed, then it can be defined as follows:
+
+```
 dependencies {
     implementation("com.juul.kable:core-$platform:$version")
 }


### PR DESCRIPTION
Per https://github.com/JuulLabs/kable/issues/70#issuecomment-787509116, the undecorated Maven artifact should be used even for platform specific configurations.

Rendered markdown [here](https://github.com/JuulLabs/kable/tree/twyatt/readme#platform-specific).