### PR TITLE
Allow for configuration of transport and PHY on Android

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -173,10 +173,21 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 }
 
 public final class com/juul/kable/PeripheralKt {
-	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;)Lcom/juul/kable/Peripheral;
+	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;Lcom/juul/kable/Transport;Lcom/juul/kable/Phy;)Lcom/juul/kable/Peripheral;
 	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;Lcom/juul/kable/WriteNotificationDescriptor;)Lcom/juul/kable/Peripheral;
 	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;)Lcom/juul/kable/Peripheral;
+	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;Lcom/juul/kable/Transport;Lcom/juul/kable/Phy;)Lcom/juul/kable/Peripheral;
 	public static final fun peripheral (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;Lcom/juul/kable/WriteNotificationDescriptor;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun peripheral$default (Lkotlinx/coroutines/CoroutineScope;Landroid/bluetooth/BluetoothDevice;Lcom/juul/kable/Transport;Lcom/juul/kable/Phy;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun peripheral$default (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;Lcom/juul/kable/Transport;Lcom/juul/kable/Phy;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
+}
+
+public final class com/juul/kable/Phy : java/lang/Enum {
+	public static final field Le1M Lcom/juul/kable/Phy;
+	public static final field Le2M Lcom/juul/kable/Phy;
+	public static final field LeCoded Lcom/juul/kable/Phy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/Phy;
+	public static fun values ()[Lcom/juul/kable/Phy;
 }
 
 public final class com/juul/kable/ScanFailedException : java/lang/IllegalStateException {
@@ -263,6 +274,14 @@ public final class com/juul/kable/State$Disconnected$Status$UnknownDevice : com/
 
 public final class com/juul/kable/State$Disconnecting : com/juul/kable/State {
 	public static final field INSTANCE Lcom/juul/kable/State$Disconnecting;
+}
+
+public final class com/juul/kable/Transport : java/lang/Enum {
+	public static final field Auto Lcom/juul/kable/Transport;
+	public static final field BreDr Lcom/juul/kable/Transport;
+	public static final field Le Lcom/juul/kable/Transport;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/Transport;
+	public static fun values ()[Lcom/juul/kable/Transport;
 }
 
 public final class com/juul/kable/WriteNotificationDescriptor : java/lang/Enum {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -278,7 +278,7 @@ public final class com/juul/kable/State$Disconnecting : com/juul/kable/State {
 
 public final class com/juul/kable/Transport : java/lang/Enum {
 	public static final field Auto Lcom/juul/kable/Transport;
-	public static final field BreDr Lcom/juul/kable/Transport;
+	public static final field BrEdr Lcom/juul/kable/Transport;
 	public static final field Le Lcom/juul/kable/Transport;
 	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/Transport;
 	public static fun values ()[Lcom/juul/kable/Transport;

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -108,7 +108,7 @@ private val Transport.intValue: Int
     @TargetApi(Build.VERSION_CODES.M)
     get() = when (this) {
         Transport.Auto -> TRANSPORT_AUTO
-        Transport.BreDr -> TRANSPORT_BREDR
+        Transport.BrEdr -> TRANSPORT_BREDR
         Transport.Le -> TRANSPORT_LE
     }
 

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -3,7 +3,11 @@ package com.juul.kable
 import android.annotation.TargetApi
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothDevice.PHY_LE_1M_MASK
+import android.bluetooth.BluetoothDevice.PHY_LE_2M_MASK
+import android.bluetooth.BluetoothDevice.PHY_LE_CODED_MASK
 import android.bluetooth.BluetoothDevice.TRANSPORT_AUTO
+import android.bluetooth.BluetoothDevice.TRANSPORT_BREDR
+import android.bluetooth.BluetoothDevice.TRANSPORT_LE
 import android.content.Context
 import android.os.Build
 import android.os.Handler
@@ -13,25 +17,39 @@ import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.newSingleThreadContext
 
+/**
+ * @param transport is only used on API level >= 23.
+ * @param phy is only used on API level >= 26.
+ */
 internal fun BluetoothDevice.connect(
     context: Context,
+    transport: Transport,
+    phy: Phy,
     state: MutableStateFlow<State>,
     invokeOnClose: () -> Unit,
 ): Connection? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        connectApi26(context, state, invokeOnClose)
+        connectApi26(context, transport, phy, state, invokeOnClose)
     } else {
-        connectApi21(context, state, invokeOnClose)
+        connectApi21(context, transport, state, invokeOnClose)
     }
 
+/**
+ * @param transport is only used on API level >= 23.
+ */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 private fun BluetoothDevice.connectApi21(
     context: Context,
+    transport: Transport,
     state: MutableStateFlow<State>,
     invokeOnClose: () -> Unit,
 ): Connection? {
     val callback = Callback(state)
-    val bluetoothGatt = connectGatt(context, false, callback) ?: return null
+    val bluetoothGatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        connectGatt(context, false, callback, transport.intValue)
+    } else {
+        connectGatt(context, false, callback)
+    } ?: return null
 
     // Explicitly set Connecting state so when Peripheral is suspending until Connected, it doesn't incorrectly see
     // Disconnected before the connection request has kicked off the Connecting state (via Callback).
@@ -52,6 +70,8 @@ private fun BluetoothDevice.connectApi21(
 @TargetApi(Build.VERSION_CODES.O)
 private fun BluetoothDevice.connectApi26(
     context: Context,
+    transport: Transport,
+    phy: Phy,
     state: MutableStateFlow<State>,
     invokeOnClose: () -> Unit,
 ): Connection? {
@@ -61,12 +81,9 @@ private fun BluetoothDevice.connectApi26(
         val dispatcher = handler.asCoroutineDispatcher()
         val callback = Callback(state)
 
-        // todo: Have `transport` and `phy` be configurable.
-        val transport = TRANSPORT_AUTO
-        val phy = PHY_LE_1M_MASK
-
         val bluetoothGatt =
-            connectGatt(context, false, callback, transport, phy, handler) ?: return null
+            connectGatt(context, false, callback, transport.intValue, phy.intValue, handler)
+                ?: return null
 
         // Explicitly set Connecting state so when Peripheral is suspending until Connected, it doesn't incorrectly see
         // Disconnected before the connection request has kicked off the Connecting state (via Callback).
@@ -86,6 +103,22 @@ private fun BluetoothDevice.connectApi26(
         throw t
     }
 }
+
+private val Transport.intValue: Int
+    @TargetApi(Build.VERSION_CODES.M)
+    get() = when (this) {
+        Transport.Auto -> TRANSPORT_AUTO
+        Transport.BreDr -> TRANSPORT_BREDR
+        Transport.Le -> TRANSPORT_LE
+    }
+
+private val Phy.intValue: Int
+    @TargetApi(Build.VERSION_CODES.O)
+    get() = when (this) {
+        Phy.Le1M -> PHY_LE_1M_MASK
+        Phy.Le2M -> PHY_LE_2M_MASK
+        Phy.LeCoded -> PHY_LE_CODED_MASK
+    }
 
 private val BluetoothDevice.threadName: String
     get() = "Gatt@$this"

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -49,7 +49,7 @@ public enum class Transport {
     Auto,
 
     /** Prefer BR/EDR transport for GATT connections to remote dual-mode devices. */
-    BreDr,
+    BrEdr,
 
     /** Prefer LE transport for GATT connections to remote dual-mode devices. */
     Le,

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -90,7 +90,7 @@ public actual fun CoroutineScope.peripheral(
  */
 public fun CoroutineScope.peripheral(
     advertisement: Advertisement,
-    transport: Transport = Transport.Auto,
+    transport: Transport = Transport.Le,
     phy: Phy = Phy.Le1M,
 ): Peripheral = peripheral(advertisement.bluetoothDevice, transport, phy)
 
@@ -100,7 +100,7 @@ public fun CoroutineScope.peripheral(
  */
 public fun CoroutineScope.peripheral(
     bluetoothDevice: BluetoothDevice,
-    transport: Transport = Transport.Auto,
+    transport: Transport = Transport.Le,
     phy: Phy = Phy.Le1M,
 ): Peripheral = AndroidPeripheral(coroutineContext, bluetoothDevice, transport, phy)
 
@@ -122,7 +122,7 @@ public fun CoroutineScope.peripheral(
 public fun CoroutineScope.peripheral(
     bluetoothDevice: BluetoothDevice,
     writeObserveDescriptor: WriteNotificationDescriptor,
-): Peripheral = AndroidPeripheral(coroutineContext, bluetoothDevice, Transport.Auto, Phy.Le1M)
+): Peripheral = AndroidPeripheral(coroutineContext, bluetoothDevice, Transport.Le, Phy.Le1M)
 
 public class AndroidPeripheral internal constructor(
     parentCoroutineContext: CoroutineContext,


### PR DESCRIPTION
Enables for configuration of transport and PHY of bluetooth connections (Android only).

For more details on the parameters and what they mean, the following links have very helpful information:

- [Bluetooth PHY – How it Works and How to Leverage it](https://punchthrough.com/crash-course-in-2m-bluetooth-low-energy-phy/)
- [Comparison of Bluetooth Basic Rate/Enhanced Data Rate (BR/EDR) vs. Bluetooth low energy (LE) transports](https://electronics.stackexchange.com/a/258897)

---

Closes #61