### PR TITLE
Throw GattStatusException for unsuccessful read operations

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -193,7 +193,7 @@ public class AndroidPeripheral internal constructor(
         val bluetoothGattCharacteristic = bluetoothGattCharacteristicFrom(characteristic)
         return connection.execute<OnCharacteristicRead> {
             readCharacteristic(bluetoothGattCharacteristic)
-        }.value
+        }.value!!
     }
 
     public override suspend fun write(
@@ -219,7 +219,7 @@ public class AndroidPeripheral internal constructor(
         val bluetoothGattDescriptor = bluetoothGattDescriptorFrom(descriptor)
         return connection.execute<OnDescriptorRead> {
             readDescriptor(bluetoothGattDescriptor)
-        }.value
+        }.value!!
     }
 
     public override fun observe(

--- a/core/src/androidMain/kotlin/gatt/Response.kt
+++ b/core/src/androidMain/kotlin/gatt/Response.kt
@@ -62,7 +62,7 @@ internal sealed class Response {
 
     data class OnCharacteristicRead(
         val characteristic: BluetoothGattCharacteristic,
-        val value: ByteArray,
+        val value: ByteArray?,
         override val status: GattStatus,
     ) : Response()
 
@@ -73,7 +73,7 @@ internal sealed class Response {
 
     data class OnDescriptorRead(
         val descriptor: BluetoothGattDescriptor,
-        val value: ByteArray,
+        val value: ByteArray?,
         override val status: GattStatus,
     ) : Response()
 


### PR DESCRIPTION
The data stream from the `Callback` had the `value` property marked non-`null`, causing a `NullPointerException` to be thrown for `read` operations that were unsuccessful (i.e. GATT status != `GATT_SUCCESS`).

`Connection.execute` already checks that the GATT `status` is `GATT_SUCCESS` and throws `GattStatusException` otherwise. Since we expect Android to always provide non-`null` `ByteArray`s for successful `read` operations, we cast (via `!!`) to non-`null` `ByteArray` to return).

Improves the exception reported in #88.