### PR TITLE
Expose JavaScript peripheral advertisments

### DIFF
--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.job
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.DataView
 import kotlin.coroutines.CoroutineContext
 import org.w3c.dom.events.Event as JsEvent


### PR DESCRIPTION
Expose an `advertisements` property on `JsPeripheral` via the Web BLE `watchAdvertisements` method.

The code to do this was already there in order to provide the `rssi()` functionality. This change provides general access to the peripheral advertisements, and re-implements `rssi()` using the new property.

There are use cases where certain information is vended solely via the advertisements, so it can be necessary to obtain the advertisements from a connected peripheral in the case where the scanner was not used initially.