### PR TITLE
Bump dependency versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,13 +6,13 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.20" apply false
-    id("com.android.library") version "4.0.2" apply false
-    id("org.jmailen.kotlinter") version "3.2.0" apply false
-    id("com.vanniktech.maven.publish") version "0.13.0" apply false
-    id("org.jetbrains.dokka") version "1.4.10.2"
-    id("kotlinx-atomicfu") version "0.14.4" apply false
-    id("binary-compatibility-validator") version "0.3.0"
+    kotlin("multiplatform") version "1.5.0" apply false
+    id("com.android.library") version "4.1.3" apply false
+    id("org.jmailen.kotlinter") version "3.4.4" apply false
+    id("com.vanniktech.maven.publish") version "0.15.1" apply false
+    id("org.jetbrains.dokka") version "1.4.32"
+    id("kotlinx-atomicfu") version "0.16.1" apply false
+    id("binary-compatibility-validator") version "0.5.0"
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.5.0" apply false
+    kotlin("multiplatform") version "1.5.10" apply false
     id("com.android.library") version "4.1.3" apply false
     id("org.jmailen.kotlinter") version "3.4.4" apply false
     id("com.vanniktech.maven.publish") version "0.15.1" apply false

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,21 +1,21 @@
 fun coroutines(
     module: String,
-    version: String = "1.4.2"
+    version: String = "1.5.0"
 ): String = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 
 fun atomicfu(
     module: String,
-    version: String = "0.14.4"
+    version: String = "0.16.1"
 ) = "org.jetbrains.kotlinx:atomicfu-$module:$version"
 
 fun uuid(
     artifact: String = "uuid",
-    version: String = "0.2.2"
+    version: String = "0.3.0"
 ): String = "com.benasher44:$artifact:$version"
 
 fun stately(
     module: String,
-    version: String = "1.1.1-a1"
+    version: String = "1.1.7-a1"
 ): String = "co.touchlab:stately-$module:$version"
 
 object androidx {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(coroutines("core", version = "1.4.2-native-mt"))
+                api(coroutines("core", version = "1.5.0-native-mt"))
                 api(uuid())
             }
         }
@@ -43,21 +43,21 @@ kotlin {
 
         val macosX64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.4.2-native-mt!!"))
+                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-macosx64"))
             }
         }
 
         val iosX64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.4.2-native-mt!!"))
+                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-iosx64"))
             }
         }
 
         val iosArm64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.4.2-native-mt!!"))
+                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-iosarm64"))
             }
         }

--- a/core/src/appleMain/kotlin/Observers.kt
+++ b/core/src/appleMain/kotlin/Observers.kt
@@ -67,7 +67,7 @@ internal class Observers(
     }
 }
 
-private class ObservationCount : IsolateState<MutableMap<Characteristic, Int>>({ mutableMapOf() }) {
+private class ObservationCount : IsolateState<MutableMap<Characteristic, Int>>(producer = { mutableMapOf() }) {
 
     val keys: Set<Characteristic>
         get() = access { it.keys.toSet() }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Most notably:

- Kotlin 1.5.0
- Coroutines 1.5.0
- AGP 4.1.3