### PR TITLE
Bump CI dependencies and use in-memory ascii-armored key for signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,42 +2,46 @@ name: CI
 on:
   push:
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15]
     runs-on: ${{ matrix.os }}
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Assemble
-        run: ./gradlew $GRADLE_ARGS assemble
+      - run: ./gradlew assemble
+      - run: ./gradlew check
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
+      - if: runner.os == 'macOS'
+        run: >
+          ./gradlew
+          --no-parallel
+          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
+          publishToMavenLocal
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,18 +6,11 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-16.04
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Dokka
-        run: ./gradlew dokkaHtmlMultiModule
-
-      - name: Deploy to Github Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - uses: actions/checkout@v2
+      - run: ./gradlew dokkaHtmlMultiModule
+      - uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/dokkaHtmlMultiModule
+          branch: gh-pages
+          folder: build/dokkaHtmlMultiModule

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,54 +1,46 @@
 name: Publish
 on:
   release:
-    types: [published]
+    types:
+      - published
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
 jobs:
   publish:
     runs-on: macos-10.15
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-publish-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
-
-      - name: Keyring
-        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
-
-      - name: Publish
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: >-
+      - run: ./gradlew check
+      - run: >-
           ./gradlew
-          $GRADLE_ARGS
           --no-parallel
-          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
-          uploadArchives
+          -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
+          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  update_release_draft:
+  update-release-draft:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,42 +4,41 @@ on:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   snapshot:
     runs-on: macos-10.15
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-snapshot-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
+      - run: ./gradlew check
+      - run: >
+          ./gradlew
+          --no-parallel
+          -PVERSION_NAME=main-SNAPSHOT
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
 
-      - name: Snapshot
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew $GRADLE_ARGS --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
Using built in GPG mechanisms ([supported by Gradle](https://docs.gradle.org/current/userguide/signing_plugin.html#using_in_memory_ascii_armored_openpgp_subkeys)) for storing keys as plain text (as GitHub secret), rather than the previously used method of base64'ing the binary key ring.