### PR TITLE
Propagate early characteristic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,28 @@ Failures related to notifications/indications are propagated via [`connect`] if 
 prior to a connection being established. If a connection is already established when an [`observe`] [`Flow`] is
 beginning to be collected, then notification/indication failures are propagated via the [`observe`] [`Flow`].
 
+In scenarios where an I/O operation needs to be performed upon subscribing to the [`observe`] [`Flow`], an `onSubscribe`
+action may be specified:
+
+```kotlin
+val observation = peripheral.observe(characteristic) {
+    // Perform desired I/O operations upon collecting from the `observe` Flow, for example:
+    peripheral.write(descriptor, "ping".toByteArray())
+}
+observation.collect { data ->
+    // Process data.
+}
+```
+
+In the above example, `"ping"` will be written to the `descriptor` when:
+
+- [Connection][`connect`] is established (while the returned [`Flow`] is active); and
+- _After_ the observation is spun up (i.e. after enabling notifications or indications)
+
+The `onSubscription` action is useful in situations where an initial operation is needed when starting an observation
+(such as writing a configuration to the peripheral and expecting the response to come back in the form of a
+characteristic change).
+
 ## Structured Concurrency
 
 Peripheral objects/connections are scoped to a [Coroutine scope]. When creating a [`Peripheral`], the

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -17,7 +17,7 @@ public final class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral 
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getServices ()Ljava/util/List;
 	public fun getState ()Lkotlinx/coroutines/flow/Flow;
-	public fun observe (Lcom/juul/kable/Characteristic;)Lkotlinx/coroutines/flow/Flow;
+	public fun observe (Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public fun read (Lcom/juul/kable/Characteristic;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun read (Lcom/juul/kable/Descriptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -160,7 +160,7 @@ public abstract interface class com/juul/kable/Peripheral {
 	public abstract fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getServices ()Ljava/util/List;
 	public abstract fun getState ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun observe (Lcom/juul/kable/Characteristic;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun observe (Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun read (Lcom/juul/kable/Characteristic;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun read (Lcom/juul/kable/Descriptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun rssi (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -169,6 +169,7 @@ public abstract interface class com/juul/kable/Peripheral {
 }
 
 public final class com/juul/kable/Peripheral$DefaultImpls {
+	public static synthetic fun observe$default (Lcom/juul/kable/Peripheral;Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun write$default (Lcom/juul/kable/Peripheral;Lcom/juul/kable/Characteristic;[BLcom/juul/kable/WriteType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -41,12 +41,14 @@ internal class Observers(
     private val lock = Mutex()
 
     fun acquire(
-        characteristic: Characteristic
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction,
     ) = characteristicChanges
         .onSubscription {
             peripheral.suspendUntilReady()
             if (observers.incrementAndGet(characteristic) == 1) {
                 peripheral.startObservation(characteristic)
+                onObservationStarted()
             }
         }
         .filter {

--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -3,7 +3,6 @@ package com.juul.kable
 import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -281,10 +281,14 @@ public class AndroidPeripheral internal constructor(
 
     internal suspend fun stopObservation(characteristic: Characteristic) {
         val platformCharacteristic = platformServices.findCharacteristic(characteristic)
-        setConfigDescriptor(platformCharacteristic, enable = false)
-        connection
-            .bluetoothGatt
-            .setCharacteristicNotification(platformCharacteristic, false)
+
+        try {
+            setConfigDescriptor(platformCharacteristic, enable = false)
+        } finally {
+            connection
+                .bluetoothGatt
+                .setCharacteristicNotification(platformCharacteristic, false)
+        }
     }
 
     private suspend fun setConfigDescriptor(

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -268,7 +268,8 @@ public class AndroidPeripheral internal constructor(
 
     public override fun observe(
         characteristic: Characteristic,
-    ): Flow<ByteArray> = observers.acquire(characteristic)
+        onObservationStarted: ObservationStartedAction,
+    ): Flow<ByteArray> = observers.acquire(characteristic, onObservationStarted)
 
     internal suspend fun startObservation(characteristic: Characteristic) {
         val platformCharacteristic = platformServices.findCharacteristic(characteristic)

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -268,8 +268,8 @@ public class AndroidPeripheral internal constructor(
 
     public override fun observe(
         characteristic: Characteristic,
-        onObservationStarted: ObservationStartedAction,
-    ): Flow<ByteArray> = observers.acquire(characteristic, onObservationStarted)
+        onSubscription: OnSubscriptionAction,
+    ): Flow<ByteArray> = observers.acquire(characteristic, onSubscription)
 
     internal suspend fun startObservation(characteristic: Characteristic) {
         val platformCharacteristic = platformServices.findCharacteristic(characteristic)

--- a/core/src/appleMain/kotlin/Observers.kt
+++ b/core/src/appleMain/kotlin/Observers.kt
@@ -41,7 +41,8 @@ internal class Observers(
     private val observers = ObservationCount()
 
     fun acquire(
-        characteristic: Characteristic
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction,
     ): Flow<NSData> {
         val cbCharacteristicUuid = characteristic.characteristicUuid.toCBUUID()
         val cbServiceUuid = characteristic.serviceUuid.toCBUUID()
@@ -51,6 +52,7 @@ internal class Observers(
                 peripheral.suspendUntilReady()
                 if (observers.incrementAndGet(characteristic) == 1) {
                     peripheral.startNotifications(characteristic)
+                    onObservationStarted()
                 }
             }
             .filter {

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -114,9 +114,9 @@ public class ApplePeripheral internal constructor(
 
     private val connectJob = atomic<Deferred<Unit>?>(null)
 
-    private val _ready = MutableStateFlow(false)
+    private val ready = MutableStateFlow(false)
     internal suspend fun suspendUntilReady() {
-        combine(_ready, state) { ready, state -> ready && state == State.Connected }.first { it }
+        combine(ready, state) { ready, state -> ready && state == State.Connected }.first { it }
     }
 
     private fun onDisconnected() {
@@ -127,7 +127,7 @@ public class ApplePeripheral internal constructor(
     }
 
     private fun connectAsync() = scope.async(start = LAZY) {
-        _ready.value = false
+        ready.value = false
 
         centralManager.delegate.onDisconnected.onEach { identifier ->
             if (identifier == cbPeripheral.identifier) onDisconnected()
@@ -162,7 +162,7 @@ public class ApplePeripheral internal constructor(
             throw t
         }
 
-        _ready.value = true
+        ready.value = true
     }
 
     public override suspend fun connect() {

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -282,12 +282,14 @@ public class ApplePeripheral internal constructor(
     }
 
     public override fun observe(
-        characteristic: Characteristic
-    ): Flow<ByteArray> = observeAsNSData(characteristic).map { it.toByteArray() }
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction,
+    ): Flow<ByteArray> = observeAsNSData(characteristic, onObservationStarted).map { it.toByteArray() }
 
     public fun observeAsNSData(
-        characteristic: Characteristic
-    ): Flow<NSData> = observers.acquire(characteristic)
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction = {},
+    ): Flow<NSData> = observers.acquire(characteristic, onObservationStarted)
 
     internal suspend fun startNotifications(characteristic: Characteristic) {
         val cbCharacteristic = cbCharacteristicFrom(characteristic)

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -283,13 +283,13 @@ public class ApplePeripheral internal constructor(
 
     public override fun observe(
         characteristic: Characteristic,
-        onObservationStarted: ObservationStartedAction,
-    ): Flow<ByteArray> = observeAsNSData(characteristic, onObservationStarted).map { it.toByteArray() }
+        onSubscription: OnSubscriptionAction,
+    ): Flow<ByteArray> = observeAsNSData(characteristic, onSubscription).map { it.toByteArray() }
 
     public fun observeAsNSData(
         characteristic: Characteristic,
-        onObservationStarted: ObservationStartedAction = {},
-    ): Flow<NSData> = observers.acquire(characteristic, onObservationStarted)
+        onSubscription: OnSubscriptionAction = {},
+    ): Flow<NSData> = observers.acquire(characteristic, onSubscription)
 
     internal suspend fun startNotifications(characteristic: Characteristic) {
         val cbCharacteristic = cbCharacteristicFrom(characteristic)

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -10,6 +10,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmName
 
 internal typealias PeripheralBuilderAction = PeripheralBuilder.() -> Unit
+internal typealias ObservationStartedAction = suspend () -> Unit
 
 public expect fun CoroutineScope.peripheral(
     advertisement: Advertisement,
@@ -117,5 +118,6 @@ public interface Peripheral {
      */
     public fun observe(
         characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction = {},
     ): Flow<ByteArray>
 }

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -129,6 +129,10 @@ public interface Peripheral {
      * only invoke the [onSubscription] once per connection (for the specified [characteristic]) then you can either
      * use the [shareIn][kotlinx.coroutines.flow.shareIn] [Flow] operator on the returned [Flow], or call [observe]
      * again with the same [characteristic] and without specifying an [onSubscription] action.
+     *
+     * If multiple [observations][observe] are created for the same [characteristic] but with different [onSubscription]
+     * actions, then the [onSubscription] actions will be executed in the order in which the returned [Flow]s are
+     * subscribed to.
      */
     public fun observe(
         characteristic: Characteristic,

--- a/core/src/jsMain/kotlin/Observers.kt
+++ b/core/src/jsMain/kotlin/Observers.kt
@@ -34,7 +34,10 @@ internal class Observers(
     private val characteristicChanges =
         MutableSharedFlow<CharacteristicChange>(extraBufferCapacity = 64)
 
-    fun acquire(characteristic: Characteristic): Flow<DataView> {
+    fun acquire(
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction,
+    ): Flow<DataView> {
         lateinit var bluetoothRemoteGATTCharacteristic: BluetoothRemoteGATTCharacteristic
         lateinit var observation: Observation
 
@@ -58,6 +61,7 @@ internal class Observers(
                             startNotifications().await()
                         }
                     }
+                    onObservationStarted()
                 }
             }
             .onCompletion {

--- a/core/src/jsMain/kotlin/Observers.kt
+++ b/core/src/jsMain/kotlin/Observers.kt
@@ -1,129 +1,89 @@
 package com.juul.kable
 
-import com.juul.kable.external.BluetoothRemoteGATTCharacteristic
-import kotlinx.coroutines.await
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onSubscription
-import kotlinx.coroutines.sync.withLock
 import org.khronos.webgl.DataView
-import org.w3c.dom.events.Event
 
-private typealias ObservationListener = (Event) -> Unit
-
-private const val CHARACTERISTIC_VALUE_CHANGED = "characteristicvaluechanged"
-
-private data class CharacteristicChange(
+internal data class CharacteristicChange(
     val characteristic: Characteristic,
     val data: DataView,
-)
-
-private data class Observation(
-    var count: Int = 0,
-    val listener: ObservationListener,
-    val onSubscription: OnSubscriptionAction,
 )
 
 internal class Observers(
     private val peripheral: JsPeripheral
 ) {
 
-    private val observers = mutableMapOf<Characteristic, Observation>()
-    private val characteristicChanges =
-        MutableSharedFlow<CharacteristicChange>(extraBufferCapacity = 64)
+    val characteristicChanges = MutableSharedFlow<CharacteristicChange>(extraBufferCapacity = 64)
+    private val observations = Observations()
 
     fun acquire(
         characteristic: Characteristic,
         onSubscription: OnSubscriptionAction,
-    ): Flow<DataView> {
-        lateinit var bluetoothRemoteGATTCharacteristic: BluetoothRemoteGATTCharacteristic
-        lateinit var observation: Observation
-
-        return characteristicChanges
-            .onSubscription {
-                peripheral.suspendUntilReady()
-
-                bluetoothRemoteGATTCharacteristic =
-                    peripheral.bluetoothRemoteGATTCharacteristicFrom(characteristic)
-
-                observation = observers[characteristic] ?: run {
-                    Observation(
-                        listener = characteristic.createListener(),
-                        onSubscription = onSubscription,
-                    ).also {
-                        observers[characteristic] = it
-                    }
-                }
-
-                if (++observation.count == 1) {
-                    bluetoothRemoteGATTCharacteristic.apply {
-                        addEventListener(CHARACTERISTIC_VALUE_CHANGED, observation.listener)
-                        peripheral.ioLock.withLock {
-                            startNotifications().await()
-                        }
-                    }
-                }
-                onSubscription()
+    ): Flow<DataView> = characteristicChanges
+        .onSubscription {
+            peripheral.suspendUntilReady()
+            if (observations.add(characteristic, onSubscription) == 1) {
+                peripheral.startObservation(characteristic)
             }
-            .filter {
-                it.characteristic.characteristicUuid == characteristic.characteristicUuid
+            onSubscription()
+        }
+        .filter {
+            it.characteristic.characteristicUuid == characteristic.characteristicUuid
+        }
+        .map { it.data }
+        .onCompletion {
+            if (observations.remove(characteristic, onSubscription) < 1) {
+                peripheral.stopObservation(characteristic)
             }
-            .map { it.data }
-            .onCompletion {
-                if (--observation.count < 1) {
-                    bluetoothRemoteGATTCharacteristic.apply {
-                        /* Throws `DOMException` if connection is closed:
-                         *
-                         * DOMException: Failed to execute 'stopNotifications' on 'BluetoothRemoteGATTCharacteristic':
-                         * Characteristic with UUID [...] is no longer valid. Remember to retrieve the characteristic
-                         * again after reconnecting.
-                         *
-                         * Wrapped in `runCatching` to silently ignore failure, as notification will already be
-                         * invalidated due to the connection being closed.
-                         */
-                        runCatching {
-                            peripheral.ioLock.withLock {
-                                stopNotifications().await()
-                            }
-                        }
+        }
 
-                        removeEventListener(CHARACTERISTIC_VALUE_CHANGED, observation.listener)
-                    }
-                    observers.remove(characteristic)
-                }
-            }
+    suspend fun rewire() {
+        observations.entries.forEach { (characteristic, onSubscriptionActions) ->
+            peripheral.startObservation(characteristic)
+            onSubscriptionActions.forEach { it() }
+        }
     }
+}
 
-    suspend fun rewire(services: List<PlatformService>) {
-        if (observers.isEmpty()) return
+private class Observations {
 
-        observers.forEach { (characteristic, observation) ->
-            val platformCharacteristic =
-                services.first { it.serviceUuid == characteristic.serviceUuid }
-                    .characteristics.first { it.characteristicUuid == characteristic.characteristicUuid }
+    private val observations = mutableMapOf<Characteristic, MutableList<OnSubscriptionAction>>()
+    val entries get() = observations.entries
 
-            platformCharacteristic
-                .bluetoothRemoteGATTCharacteristic
-                .apply {
-                    peripheral.ioLock.withLock {
-                        startNotifications().await()
-                    }
-                    addEventListener(CHARACTERISTIC_VALUE_CHANGED, platformCharacteristic.createListener())
-                }
-
-            observation.onSubscription()
+    fun add(
+        characteristic: Characteristic,
+        onSubscription: OnSubscriptionAction,
+    ): Int {
+        val actions = observations[characteristic]
+        return if (actions == null) {
+            val newActions = mutableListOf(onSubscription)
+            observations[characteristic] = newActions
+            1
+        } else {
+            actions += onSubscription
+            actions.count()
         }
     }
 
-    fun clear() {
-        observers.clear()
-    }
-
-    private fun Characteristic.createListener(): ObservationListener = { event ->
-        val target = event.target as BluetoothRemoteGATTCharacteristic
-        characteristicChanges.tryEmit(CharacteristicChange(this, target.value!!))
+    fun remove(
+        characteristic: Characteristic,
+        onSubscription: OnSubscriptionAction,
+    ): Int {
+        val actions = observations[characteristic]
+        return when {
+            actions == null -> 0
+            actions.count() == 1 -> {
+                observations -= characteristic
+                0
+            }
+            else -> {
+                actions -= onSubscription
+                actions.count()
+            }
+        }
     }
 }

--- a/core/src/jsMain/kotlin/Observers.kt
+++ b/core/src/jsMain/kotlin/Observers.kt
@@ -2,9 +2,12 @@ package com.juul.kable
 
 import com.juul.kable.external.BluetoothRemoteGATTCharacteristic
 import kotlinx.coroutines.await
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.sync.withLock
 import org.khronos.webgl.DataView
 import org.w3c.dom.events.Event
@@ -28,69 +31,62 @@ internal class Observers(
 ) {
 
     private val observers = mutableMapOf<Characteristic, Observation>()
-    private val changes = MutableSharedFlow<CharacteristicChange>(extraBufferCapacity = 64)
+    private val characteristicChanges =
+        MutableSharedFlow<CharacteristicChange>(extraBufferCapacity = 64)
 
-    fun acquire(characteristic: Characteristic) = flow {
-        val bluetoothRemoteGATTCharacteristic =
-            peripheral.bluetoothRemoteGATTCharacteristicFrom(characteristic)
-        val observation = observers[characteristic] ?: run {
-            Observation(listener = characteristic.createListener()).also {
-                observers[characteristic] = it
-            }
-        }
+    fun acquire(characteristic: Characteristic): Flow<DataView> {
+        lateinit var bluetoothRemoteGATTCharacteristic: BluetoothRemoteGATTCharacteristic
+        lateinit var observation: Observation
 
-        if (++observation.count == 1) {
-            bluetoothRemoteGATTCharacteristic.apply {
-                addEventListener(CHARACTERISTIC_VALUE_CHANGED, observation.listener)
-                peripheral.ioLock.withLock {
-                    startNotifications().await()
-                }
-            }
-        }
+        return characteristicChanges
+            .onSubscription {
+                peripheral.suspendUntilReady()
 
-        try {
-            changes.collect {
-                if (it.characteristic.characteristicUuid == characteristic.characteristicUuid) {
-                    emit(it.data)
-                }
-            }
-        } catch (t: Throwable) {
-            // Unnecessary `catch` block as workaround for KT-37279 (needed until we switch to IR compiler).
-            // https://youtrack.jetbrains.com/issue/KT-37279
-            // Once KT-37279 is fixed, this `catch` should be replaced with `finally`.
-            // See previous logic (before workaround) in:
-            // https://github.com/JuulLabs/kable/blob/151e54d255bf5595c67023927084d083e6180706/core/src/jsMain/kotlin/Observers.kt#L48-L72
-            observation.teardown(bluetoothRemoteGATTCharacteristic, characteristic)
-            return@flow
-        }
-        observation.teardown(bluetoothRemoteGATTCharacteristic, characteristic)
-    }
+                bluetoothRemoteGATTCharacteristic =
+                    peripheral.bluetoothRemoteGATTCharacteristicFrom(characteristic)
 
-    private suspend fun Observation.teardown(
-        bluetoothRemoteGATTCharacteristic: BluetoothRemoteGATTCharacteristic,
-        characteristic: Characteristic
-    ) {
-        if (--count < 1) {
-            bluetoothRemoteGATTCharacteristic.apply {
-                /* Throws `DOMException` if connection is closed:
-                 *
-                 * DOMException: Failed to execute 'stopNotifications' on 'BluetoothRemoteGATTCharacteristic':
-                 * Characteristic with UUID [...] is no longer valid. Remember to retrieve the characteristic
-                 * again after reconnecting.
-                 *
-                 * Wrapped in `runCatching` to silently ignore failure, as notification will already be
-                 * invalidated due to the connection being closed.
-                 */
-                runCatching {
-                    peripheral.ioLock.withLock {
-                        stopNotifications().await()
+                observation = observers[characteristic] ?: run {
+                    Observation(listener = characteristic.createListener()).also {
+                        observers[characteristic] = it
                     }
                 }
 
-                removeEventListener(CHARACTERISTIC_VALUE_CHANGED, listener)
+                if (++observation.count == 1) {
+                    bluetoothRemoteGATTCharacteristic.apply {
+                        addEventListener(CHARACTERISTIC_VALUE_CHANGED, observation.listener)
+                        peripheral.ioLock.withLock {
+                            startNotifications().await()
+                        }
+                    }
+                }
             }
-            observers.remove(characteristic)
-        }
+            .onCompletion {
+                if (--observation.count < 1) {
+                    bluetoothRemoteGATTCharacteristic.apply {
+                        /* Throws `DOMException` if connection is closed:
+                         *
+                         * DOMException: Failed to execute 'stopNotifications' on 'BluetoothRemoteGATTCharacteristic':
+                         * Characteristic with UUID [...] is no longer valid. Remember to retrieve the characteristic
+                         * again after reconnecting.
+                         *
+                         * Wrapped in `runCatching` to silently ignore failure, as notification will already be
+                         * invalidated due to the connection being closed.
+                         */
+                        runCatching {
+                            peripheral.ioLock.withLock {
+                                stopNotifications().await()
+                            }
+                        }
+
+                        removeEventListener(CHARACTERISTIC_VALUE_CHANGED, observation.listener)
+                    }
+                    observers.remove(characteristic)
+                }
+            }
+            .filter {
+                it.characteristic.characteristicUuid == characteristic.characteristicUuid
+            }
+            .map { it.data }
     }
 
     fun invalidate() {
@@ -124,6 +120,6 @@ internal class Observers(
 
     private fun Characteristic.createListener(): ObservationListener = { event ->
         val target = event.target as BluetoothRemoteGATTCharacteristic
-        changes.tryEmit(CharacteristicChange(this, target.value!!))
+        characteristicChanges.tryEmit(CharacteristicChange(this, target.value!!))
     }
 }

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -227,19 +227,18 @@ public class JsPeripheral internal constructor(
 
     public fun observeDataView(
         characteristic: Characteristic,
-        onObservationStarted: ObservationStartedAction = {},
-    ): Flow<DataView> = observers.acquire(characteristic, onObservationStarted)
+        onSubscription: OnSubscriptionAction = {},
+    ): Flow<DataView> = observers.acquire(characteristic, onSubscription)
 
     public override fun observe(
         characteristic: Characteristic,
-        onObservationStarted: ObservationStartedAction,
+        onSubscription: OnSubscriptionAction,
     ): Flow<ByteArray> = observeDataView(characteristic)
         .map { it.buffer.toByteArray() }
 
     private var isDisconnectedListenerRegistered = false
     private val disconnectedListener: (JsEvent) -> Unit = { event ->
         console.dir(event)
-        observers.invalidate()
         _state.value = State.Disconnected()
         unregisterDisconnectedListener()
         connectJob = null

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -226,11 +226,13 @@ public class JsPeripheral internal constructor(
     private val observers = Observers(this)
 
     public fun observeDataView(
-        characteristic: Characteristic
-    ): Flow<DataView> = observers.acquire(characteristic)
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction = {},
+    ): Flow<DataView> = observers.acquire(characteristic, onObservationStarted)
 
     public override fun observe(
-        characteristic: Characteristic
+        characteristic: Characteristic,
+        onObservationStarted: ObservationStartedAction,
     ): Flow<ByteArray> = observeDataView(characteristic)
         .map { it.buffer.toByteArray() }
 


### PR DESCRIPTION
Closes #105
Closes #112

Also fixes JavaScript observations to wait until connection is ready. Only users of experimental advertisement support in Chrome would've seen this bug, as using `requestDevice` obtains devices in a connected state, i.e. already ready.