### PR TITLE
Trigger CI workflow on `pull_request` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  pull_request:
   push:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   pull_request:
-  push:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"


### PR DESCRIPTION
Replaces `push` with `pull_request` CI trigger to allow workflow runs of PRs from forks.

> When you create a pull request from a forked repository to the base repository, GitHub sends the `pull_request` event to the base repository and no pull request events occur on the forked repository.

— [Pull request events for forked repositories](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories)