### PR TITLE
Route observation re-wiring exceptions through `observe` Flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Bluetooth Low Energy provides the capability of subscribing to characteristic ch
 indications, whereas a characteristic change on a connected peripheral is "pushed" to the central via a characteristic
 notification and/or indication which carries the new value of the characteristic.
 
-Characteristic change notifications/indications can be observed/subscribed to via the [`observe`] function which returns a [`Flow`]
-of the new characteristic data.
+Characteristic change notifications/indications can be observed/subscribed to via the [`observe`] function which returns
+a [`Flow`] of the new characteristic data.
 
 ```kotlin
 val observation = peripheral.observe(characteristic)
@@ -204,9 +204,9 @@ established. Once a connection is established then characteristic changes will s
 connection drops, the [`Flow`] will remain active, and upon reconnecting it will resume streaming characteristic
 changes.
 
-Failures related to notifications/indications are propagated via [`connect`] if the [`observe`] [`Flow`] is collected
-prior to a connection being established. If a connection is already established when an [`observe`] [`Flow`] is
-beginning to be collected, then notification/indication failures are propagated via the [`observe`] [`Flow`].
+Failures related to notifications/indications are propagated via the [`observe`] [`Flow`], for example, if the
+associated characteristic is invalid or cannot be found, then a `NoSuchElementException` is propagated via the
+[`observe`] [`Flow`].
 
 In scenarios where an I/O operation needs to be performed upon subscribing to the [`observe`] [`Flow`], an `onSubscribe`
 action may be specified:

--- a/core/src/androidMain/kotlin/Connection.kt
+++ b/core/src/androidMain/kotlin/Connection.kt
@@ -2,6 +2,7 @@ package com.juul.kable
 
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGatt.GATT_SUCCESS
+import com.juul.kable.AndroidObservationEvent.CharacteristicChange
 import com.juul.kable.gatt.Callback
 import com.juul.kable.gatt.GattStatus
 import kotlinx.coroutines.CoroutineDispatcher
@@ -13,11 +14,6 @@ import kotlinx.coroutines.withContext
 public class OutOfOrderGattCallbackException internal constructor(
     message: String,
 ) : IllegalStateException(message)
-
-internal data class CharacteristicChange(
-    val characteristic: Characteristic,
-    val data: ByteArray,
-)
 
 private val GattSuccess = GattStatus(GATT_SUCCESS)
 

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -144,6 +144,12 @@ public class ApplePeripheral internal constructor(
                 .characteristicChanges
                 .takeWhile { it !== Closed }
                 .mapNotNull { it as? Data }
+                .map {
+                    AppleObservationEvent.CharacteristicChange(
+                        characteristic = it.cbCharacteristic.toLazyCharacteristic(),
+                        data = it.data
+                    )
+                }
                 .onEach(observers.characteristicChanges::emit)
                 .launchIn(scope, start = UNDISPATCHED)
 

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -110,11 +110,9 @@ public interface Peripheral {
      * [characteristic] properties, observe will be configured (CCCD will be written to) as **notification** and/or
      * **indication**.
      *
-     * Failures related to notifications are propagated via [connect] if the [observe] [Flow] is collected prior to a
-     * connection being established. If a connection is already established when an [observe] [Flow] collection begins,
-     * then notification failures are propagated via the returned [observe] [Flow].
-     *
-     * If the specified [characteristic] is invalid or cannot be found then a [NoSuchElementException] is propagated.
+     * Failures related to notifications are propagated via the returned [observe] [Flow], for example, if the specified
+     * [characteristic] is invalid or cannot be found then a [NoSuchElementException] is propagated via the returned
+     * [Flow].
      *
      * The optional [onSubscription] parameter is functionally identical to using the
      * [onSubscription][kotlinx.coroutines.flow.onSubscription] operator on the returned [Flow] except it has the

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -291,7 +291,7 @@ public class JsPeripheral internal constructor(
 
     private fun Characteristic.createListener(): ObservationListener = { event ->
         val target = event.target as BluetoothRemoteGATTCharacteristic
-        val characteristicChange = CharacteristicChange(this, target.value!!)
+        val characteristicChange = JsObservationEvent.CharacteristicChange(this, target.value!!)
 
         if (!observers.characteristicChanges.tryEmit(characteristicChange))
             console.error("Failed to emit $characteristicChange")


### PR DESCRIPTION
Closes #115

Prior to this change, failures related to observation (e.g. writing to the config descriptor for enabling notifications/indications) could either go through the corresponding `observe` `Flow` or the `connect` function depending on when the `observe` was called — this was confusing and error prone.

Now, all failures related to spinning up the `observe` `Flow` are routed through the corresponding `Flow`, regardless of when the `observe` `Flow` is created.