### PR TITLE
Only write indicate or notify to CCCD on Android

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -300,11 +300,11 @@ public class AndroidPeripheral internal constructor(
             val bluetoothGattDescriptor = configDescriptor.bluetoothGattDescriptor
 
             if (enable) {
-                if (characteristic.supportsNotify)
-                    write(bluetoothGattDescriptor, ENABLE_NOTIFICATION_VALUE)
-
-                if (characteristic.supportsIndicate)
-                    write(bluetoothGattDescriptor, ENABLE_INDICATION_VALUE)
+                when {
+                    characteristic.supportsNotify -> write(bluetoothGattDescriptor, ENABLE_NOTIFICATION_VALUE)
+                    characteristic.supportsIndicate -> write(bluetoothGattDescriptor, ENABLE_INDICATION_VALUE)
+                    else -> Log.w(TAG, "Characteristic ${characteristic.characteristicUuid} supports neither notification nor indication")
+                }
             } else {
                 if (characteristic.supportsNotify || characteristic.supportsIndicate)
                     write(bluetoothGattDescriptor, DISABLE_NOTIFICATION_VALUE)

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -107,8 +107,9 @@ public interface Peripheral {
      * active, once reconnected characteristic changes will begin emitting again.
      *
      * If characteristic has a Client Characteristic Configuration descriptor (CCCD), then based on bits in the
-     * [characteristic] properties, observe will be configured (CCCD will be written to) as **notification** and/or
-     * **indication**.
+     * [characteristic] properties, observe will be configured (CCCD will be written to) as **notification** or
+     * **indication** (if [characteristic] supports both notifications and indications, then only **notification** is
+     * used).
      *
      * Failures related to notifications are propagated via [connect] if the [observe] [Flow] is collected prior to a
      * connection being established. If a connection is already established when an [observe] [Flow] collection begins,


### PR DESCRIPTION
Closes #99

Some peripherals have characteristics that support either notification or indication, when we're observing such a characteristic, we should write to the Client Characteristic Configuration descriptor (CCCD) either to enable notifications **or** indications, **not** both.

We default to only **notifications** if characteristic supports both. This is consistent with the documented behavior of [Core Bluetooth].

[Core Bluetooth]: https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518949-setnotifyvalue