### PR TITLE
Only sign `publishToMavenLocal` under `JuulLabs` organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,22 @@ jobs:
       - run: ./gradlew assemble
       - run: ./gradlew check
 
-      - if: runner.os == 'macOS'
-        run: >
-          ./gradlew
-          --no-parallel
-          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
-          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
-          publishToMavenLocal
+      - run: |
+          set -o xtrace
+          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified" \
+            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
+            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
+            publishToMavenLocal
+          else
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified-SNAPSHOT" \
+            publishToMavenLocal
+          fi
+        if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Will allow `publishToMavenLocal` to run on PRs from forks (but without signing) — only performing the signed `publishToMavenLocal` if `SIGNING_KEY` is available (i.e. PRs from organization members).