### PR TITLE
Fix typo in `descriptorOf` example in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For example, a peripheral might have the following structure:
 
 To access a characteristic or descriptor, use the [`charactisticOf`] or [`descriptorOf`] functions, respectively.
 
-In the above example, to access "Descriptor D2":
+In the above example, to access "Descriptor D3":
 
 ```kotlin
 val descriptor = descriptorOf(


### PR DESCRIPTION
Referenced "Descriptor D2" when D3 is the one that was supposed to be referenced in the example BLE hierarchy.