### PR TITLE
Support requesting connection priority on Android

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -20,6 +20,7 @@ public final class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral 
 	public fun observe (Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public fun read (Lcom/juul/kable/Characteristic;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun read (Lcom/juul/kable/Descriptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun requestConnectionPriority (Lcom/juul/kable/Priority;)Z
 	public final fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun rssi (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
@@ -200,6 +201,14 @@ public final class com/juul/kable/Phy : java/lang/Enum {
 	public static final field LeCoded Lcom/juul/kable/Phy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/Phy;
 	public static fun values ()[Lcom/juul/kable/Phy;
+}
+
+public final class com/juul/kable/Priority : java/lang/Enum {
+	public static final field Balanced Lcom/juul/kable/Priority;
+	public static final field High Lcom/juul/kable/Priority;
+	public static final field Low Lcom/juul/kable/Priority;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/Priority;
+	public static fun values ()[Lcom/juul/kable/Priority;
 }
 
 public final class com/juul/kable/ScanFailedException : java/lang/IllegalStateException {

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -103,6 +103,8 @@ public fun CoroutineScope.peripheral(
     return AndroidPeripheral(coroutineContext, bluetoothDevice, builder.transport, builder.phy, builder.onServicesDiscovered)
 }
 
+public enum class Priority { Low, Balanced, High }
+
 public class AndroidPeripheral internal constructor(
     parentCoroutineContext: CoroutineContext,
     private val bluetoothDevice: BluetoothDevice,
@@ -197,6 +199,9 @@ public class AndroidPeripheral internal constructor(
             dispose()
         }
     }
+
+    public fun requestConnectionPriority(priority: Priority): Boolean =
+        connection.bluetoothGatt.requestConnectionPriority(priority.intValue)
 
     public override suspend fun rssi(): Int = connection.execute<OnReadRemoteRssi> {
         readRemoteRssi()
@@ -339,6 +344,13 @@ private val WriteType.intValue: Int
     get() = when (this) {
         WithResponse -> WRITE_TYPE_DEFAULT
         WithoutResponse -> WRITE_TYPE_NO_RESPONSE
+    }
+
+private val Priority.intValue: Int
+    get() = when (this) {
+        Priority.Low -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+        Priority.Balanced -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+        Priority.High -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
     }
 
 private fun BluetoothGatt.setCharacteristicNotification(


### PR DESCRIPTION
Closes #36

Unlike nearly every other BLE request on Android, this one does **not** (or at least it isn't documented to) invoke a function on [`BluetoothGattCallback`](https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback) to indicate when the process is complete (and whether successful or not). It seems you just have to blindly hope it worked. 🤷 

Per [Android ble, requestConnectionPriority not working](https://stackoverflow.com/a/47491885), it is recommended that `requestConnectionPriority` not be called during service discovery. Since Kable's `connect` suspends until connected _and_ services are discovered, it should be safe to call `requestConnectionPriority` anytime after `connect` and not worry about the issue described in the StackOverflow post.