### PR TITLE
Handle bluetooth adapter state changes

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothStateBroadcastReceiver.kt
+++ b/core/src/androidMain/kotlin/BluetoothStateBroadcastReceiver.kt
@@ -1,0 +1,24 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+
+private val bluetoothStateIntentFilter: IntentFilter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+
+private inline fun bluetoothStateBroadcastReceiver(
+    crossinline action: (state: Int) -> Unit,
+): BroadcastReceiver = object : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+        action.invoke(state)
+    }
+}
+
+internal inline fun registerBluetoothStateBroadcastReceiver(
+    context: Context = applicationContext,
+    crossinline action: (state: Int) -> Unit,
+): BroadcastReceiver = bluetoothStateBroadcastReceiver(action)
+    .also { context.registerReceiver(it, bluetoothStateIntentFilter) }

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -1,6 +1,5 @@
 package com.juul.kable
 
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothAdapter.STATE_OFF
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
@@ -12,10 +11,6 @@ import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.util.Log
 import com.benasher44.uuid.uuidFrom
 import com.juul.kable.WriteType.WithResponse

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -57,7 +57,7 @@ public class JsPeripheral internal constructor(
 ) : Peripheral {
 
     private val job = SupervisorJob(parentCoroutineContext.job).apply {
-        invokeOnCompletion { dispose() }
+        invokeOnCompletion { closeConnection() }
     }
 
     private val scope = CoroutineScope(parentCoroutineContext + job)
@@ -143,7 +143,7 @@ public class JsPeripheral internal constructor(
         ready.value = true
     }
 
-    private fun dispose() {
+    private fun closeConnection() {
         observationListeners.clear()
         disconnectGatt()
         unregisterDisconnectedListener()


### PR DESCRIPTION
Uses a `BroadcastReceiver` to detect when bluetooth has been turned off at the OS level. As an aside, hopefully this addresses #102.

Also changes the name of the private `dispose` function, because I was getting it confused with `Disposable.dispose`, which has very different semantics.