### PR TITLE
Remove dependency on `native-mt` version of Coroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ kotlin {
 
         val nativeMain by creating {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}-native-mt")) {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}-native-mt") {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ kotlin {
 
         val nativeMain by creating {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-${coroutinesVersion}-native-mt")) {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}-native-mt")) {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
                 implementation("com.juul.kable:core:${kableVersion}")
             }
         }

--- a/README.md
+++ b/README.md
@@ -282,8 +282,30 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("com.juul.kable:core:$version")
+                implementation("com.juul.kable:core:${kableVersion}")
             }
+        }
+
+        val nativeMain by creating {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-${coroutinesVersion}-native-mt")) {
+                    version {
+                        strictly("${coroutinesVersion}-native-mt")
+                    }
+                }
+            }
+        }
+
+        val macosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val iosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+        
+        val iosArm64Main by getting {
+            dependsOn(nativeMain)
         }
     }
 }
@@ -293,9 +315,9 @@ android {
 }
 ```
 
-_Note that Apple-based targets (e.g. `macosX64`) require [Coroutines with multithread support for Kotlin/Native] (more
-specifically: Coroutines library artifacts that are suffixed with `-native-mt`). Kable is configured to use `-native-mt`
-as a transitive dependency for Apple-based targets._
+_Note that for compatibility with Kable, Native targets (e.g. `macosX64`) require
+[Coroutines with multithread support for Kotlin/Native] (more specifically: Coroutines library artifacts that are
+suffixed with `-native-mt`)._
 
 #### Platform-specific
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,5 @@
 fun coroutines(
-    module: String,
+    module: String = "core",
     version: String = "1.5.0"
 ): String = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,14 +22,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(coroutines("core", version = "1.5.0-native-mt"))
+                api(coroutines())
                 api(uuid())
-            }
-        }
-
-        val jsMain by getting {
-            dependencies {
-                api(coroutines("core"))
             }
         }
 
@@ -43,21 +37,18 @@ kotlin {
 
         val macosX64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-macosx64"))
             }
         }
 
         val iosX64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-iosx64"))
             }
         }
 
         val iosArm64Main by getting {
             dependencies {
-                api(coroutines("core", version = "1.5.0-native-mt!!"))
                 implementation(stately("isolate-iosarm64"))
             }
         }


### PR DESCRIPTION
Closes #129.

This lifts restricting library consumers to a specific version of Coroutines, with the caveat that library consumers will have to properly configure their Native targets to pull in the `-native-mt` version of Coroutines library.

[`README`](https://github.com/JuulLabs/kable/tree/twyatt/coroutines#multiplatform) has been updated to demonstrate how library consumers can configure Gradle (as recommended [here](https://youtrack.jetbrains.com/issue/KT-43651#focus=Comments-27-4566811.0-0), [here](https://github.com/cashapp/sqldelight/issues/2380#issuecomment-836205507) and [here](https://stackoverflow.com/a/65002984)).