### PR TITLE
Handle peripheral initiated MTU changes

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -15,6 +15,7 @@ public final class com/juul/kable/Advertisement {
 public final class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
 	public fun connect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getServices ()Ljava/util/List;
 	public fun getState ()Lkotlinx/coroutines/flow/Flow;
 	public fun observe (Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -20,7 +20,6 @@ import com.juul.kable.gatt.Response.OnCharacteristicRead
 import com.juul.kable.gatt.Response.OnCharacteristicWrite
 import com.juul.kable.gatt.Response.OnDescriptorRead
 import com.juul.kable.gatt.Response.OnDescriptorWrite
-import com.juul.kable.gatt.Response.OnMtuChanged
 import com.juul.kable.gatt.Response.OnReadRemoteRssi
 import com.juul.kable.gatt.Response.OnServicesDiscovered
 import kotlinx.atomicfu.atomic
@@ -34,6 +33,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -132,6 +132,15 @@ public class AndroidPeripheral internal constructor(
     private val _state = MutableStateFlow<State>(State.Disconnected())
     public override val state: Flow<State> = _state.asStateFlow()
 
+    private val _mtu = MutableStateFlow<Int?>(null)
+
+    /**
+     * [StateFlow] of the most recently negotiated MTU. The MTU will change upon a successful request to change the MTU
+     * (via [requestMtu]), or if the peripheral initiates an MTU change. [StateFlow]'s `value` will be `null` until MTU
+     * is negotiated.
+     */
+    public val mtu: StateFlow<Int?> = _mtu.asStateFlow()
+
     private val observers = Observers(this)
 
     @Volatile
@@ -164,6 +173,7 @@ public class AndroidPeripheral internal constructor(
             transport,
             phy,
             _state,
+            _mtu,
             invokeOnClose = { connectJob.value = null }
         ) ?: throw ConnectionRejectedException()
 
@@ -227,12 +237,16 @@ public class AndroidPeripheral internal constructor(
             .map { it.toPlatformService() }
     }
 
-    /** @throws NotReadyException if invoked without an established [connection][Peripheral.connect]. */
-    public suspend fun requestMtu(mtu: Int) {
-        connection.execute<OnMtuChanged> {
-            this@execute.requestMtu(mtu)
-        }
-    }
+    /**
+     * Requests that the current connection's MTU be changed. Suspends until the MTU changes, or failure occurs. The
+     * negotiated MTU value is returned, which may not be [mtu] value requested if the remote peripheral negotiated an
+     * alternate MTU.
+     *
+     * @throws NotReadyException if invoked without an established [connection][Peripheral.connect].
+     * @throws GattRequestRejectedException if Android was unable to fulfill the MTU change request.
+     * @throws GattStatusException if MTU change request failed.
+     */
+    public suspend fun requestMtu(mtu: Int): Int = connection.requestMtu(mtu)
 
     public override suspend fun write(
         characteristic: Characteristic,

--- a/core/src/androidMain/kotlin/PeripheralBuilder.kt
+++ b/core/src/androidMain/kotlin/PeripheralBuilder.kt
@@ -67,7 +67,7 @@ public actual class ServicesDiscoveredPeripheral internal constructor(
 
     public suspend fun requestMtu(
         mtu: Int
-    ): Unit = peripheral.requestMtu(mtu)
+    ): Int = peripheral.requestMtu(mtu)
 }
 
 public actual class PeripheralBuilder internal actual constructor() {

--- a/core/src/androidMain/kotlin/gatt/Response.kt
+++ b/core/src/androidMain/kotlin/gatt/Response.kt
@@ -51,11 +51,6 @@ internal sealed class Response {
         override val status: GattStatus,
     ) : Response()
 
-    data class OnMtuChanged(
-        val mtu: Int,
-        override val status: GattStatus,
-    ) : Response()
-
     data class OnServicesDiscovered(
         override val status: GattStatus,
     ) : Response()
@@ -94,6 +89,11 @@ internal sealed class Response {
             "OnDescriptorWrite(descriptor=${descriptor.uuid}, status=$status)"
     }
 }
+
+internal data class OnMtuChanged(
+    val mtu: Int,
+    override val status: GattStatus,
+) : Response()
 
 /**
  * Represents the possible GATT statuses as defined in [BluetoothGatt]:


### PR DESCRIPTION
Fixes #86.

Prevents `OutOfOrderGattCallbackException` after peripheral initiated MTU by implementing a dedicated channel for MTU events.

Additionally, exposes `mtu: StateFlow<Int?>` on `AndroidPeripheral`.