### PR TITLE
Throw exception when Android's `BluetoothAdapter` is not `On`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -32,7 +32,11 @@ public final class com/juul/kable/AndroidScanner : com/juul/kable/Scanner {
 	public fun getAdvertisements ()Lkotlinx/coroutines/flow/Flow;
 }
 
-public class com/juul/kable/BluetoothLeException : java/lang/Exception {
+public final class com/juul/kable/BluetoothDisabledException : com/juul/kable/BluetoothException {
+	public fun <init> ()V
+}
+
+public class com/juul/kable/BluetoothException : java/lang/Exception {
 	public fun <init> ()V
 }
 
@@ -97,7 +101,7 @@ public final class com/juul/kable/DiscoveredService : com/juul/kable/Service {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/kable/GattRequestRejectedException : com/juul/kable/BluetoothLeException {
+public final class com/juul/kable/GattRequestRejectedException : com/juul/kable/BluetoothException {
 	public fun <init> ()V
 }
 

--- a/core/src/androidMain/kotlin/Exceptions.kt
+++ b/core/src/androidMain/kotlin/Exceptions.kt
@@ -1,3 +1,5 @@
+@file:JvmName("AndroidExceptionsKt") // Removes conflict with commonMain Exceptions.kt
+
 package com.juul.kable
 
 import android.bluetooth.BluetoothDevice

--- a/core/src/androidMain/kotlin/Exceptions.kt
+++ b/core/src/androidMain/kotlin/Exceptions.kt
@@ -18,4 +18,4 @@ public actual typealias IOException = java.io.IOException
 public class GattRequestRejectedException internal constructor(
     message: String? = null,
     cause: Throwable? = null,
-) : BluetoothLeException(message, cause)
+) : BluetoothException(message, cause)

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -201,21 +201,7 @@ public class AndroidPeripheral internal constructor(
 
     public override suspend fun connect() {
         check(job.isNotCancelled) { "Cannot connect, scope is cancelled for $this" }
-
-        // Explicitly check the adapter state before connecting in order to respect system settings.
-        // Android doesn't actually turn bluetooth off when the setting is disabled, so without this
-        // check we're able to reconnect the device illegally.
-        val adapterState = BluetoothAdapter.getDefaultAdapter().state
-        if (adapterState != STATE_ON) {
-            val stateName = when (adapterState) {
-                STATE_OFF -> "Off"
-                STATE_TURNING_OFF -> "TurningOff"
-                STATE_TURNING_ON -> "TurningOn"
-                else -> "Unknown"
-            }
-            throw BluetoothDisabledException("Cannot connect to device while bluetooth adapter state is $stateName.")
-        }
-
+        checkBluetoothAdapterState(expected = STATE_ON)
         connectJob.updateAndGet { it ?: connectAsync() }!!.await()
     }
 
@@ -396,3 +382,26 @@ private val PlatformCharacteristic.supportsNotify: Boolean
 
 private val PlatformCharacteristic.supportsIndicate: Boolean
     get() = bluetoothGattCharacteristic.properties and PROPERTY_INDICATE != 0
+
+/**
+ * Explicitly check the adapter state before connecting in order to respect system settings.
+ * Android doesn't actually turn bluetooth off when the setting is disabled, so without this
+ * check we're able to reconnect the device illegally.
+ */
+private fun checkBluetoothAdapterState(
+    expected: Int,
+) {
+    fun nameFor(value: Int) = when (value) {
+        STATE_OFF -> "Off"
+        STATE_ON -> "On"
+        STATE_TURNING_OFF -> "TurningOff"
+        STATE_TURNING_ON -> "TurningOn"
+        else -> "Unknown"
+    }
+    val actual = BluetoothAdapter.getDefaultAdapter().state
+    if (expected != actual) {
+        val actualName = nameFor(actual)
+        val expectedName = nameFor(expected)
+        throw BluetoothDisabledException("Bluetooth adapter state is $actualName ($actual), but $expectedName ($expected) was required.")
+    }
+}

--- a/core/src/commonMain/kotlin/Exceptions.kt
+++ b/core/src/commonMain/kotlin/Exceptions.kt
@@ -1,10 +1,18 @@
 package com.juul.kable
 
-/** Failure occurred with the underlying Bluetooth Low Energy system. */
-public open class BluetoothLeException internal constructor(
+/** Failure occurred with the underlying Bluetooth system. */
+public open class BluetoothException internal constructor(
     message: String? = null,
     cause: Throwable? = null,
 ) : Exception(message, cause)
+
+@Deprecated("Class has been renamed.", ReplaceWith("BluetoothException", "com.juul.kable.BluetoothException"))
+public typealias BluetoothLeException = BluetoothException
+
+public class BluetoothDisabledException internal constructor(
+    message: String? = null,
+    cause: Throwable? = null,
+) : BluetoothException(message, cause)
 
 public expect open class IOException internal constructor(
     message: String? = null,


### PR DESCRIPTION
Fixes #136.