### PR TITLE
Fix Gradle example configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,19 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
                 implementation("com.juul.kable:core:${kableVersion}")
+            }
+        }
+
+        val androidMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
+            }
+        }
+
+        val jsMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
             }
         }
 


### PR DESCRIPTION
Oversight in the original example updated in #134.

Declaring Coroutines dependency in `common` caused Gradle to fail (when compiling Native targets) with:

<details>
<summary><code>./gradlew runDebugExecutableMacosX64</code></summary>

```
* What went wrong:
Execution failed for task ':app:compileKotlinMacosX64'.
> Could not resolve all files for configuration ':app:macosX64CompileKlibraries'.
   > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1.
     Required by:
         project :app
      > Cannot find a version of 'org.jetbrains.kotlinx:kotlinx-coroutines-core' that satisfies the version constraints:
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.5.0-native-mt}'
           Dependency path 'sensortag:app:unspecified' --> 'com.juul.kable:core:0.7.0-SNAPSHOT' --> 'com.juul.kable:core-macosx64:0.7.0-SNAPSHOT' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'

   > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.5.0-native-mt}.
     Required by:
         project :app
      > Cannot find a version of 'org.jetbrains.kotlinx:kotlinx-coroutines-core' that satisfies the version constraints:
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.5.0-native-mt}'
           Dependency path 'sensortag:app:unspecified' --> 'com.juul.kable:core:0.7.0-SNAPSHOT' --> 'com.juul.kable:core-macosx64:0.7.0-SNAPSHOT' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'

   > Could not resolve org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0.
     Required by:
         project :app > com.juul.kable:core:0.7.0-SNAPSHOT > com.juul.kable:core-macosx64:0.7.0-SNAPSHOT
      > Cannot find a version of 'org.jetbrains.kotlinx:kotlinx-coroutines-core' that satisfies the version constraints:
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
           Dependency path 'sensortag:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.5.0-native-mt}'
           Dependency path 'sensortag:app:unspecified' --> 'com.juul.kable:core:0.7.0-SNAPSHOT' --> 'com.juul.kable:core-macosx64:0.7.0-SNAPSHOT' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
```
</details>

Removing Coroutines dependency from `common` allows Gradle to transitively use the Coroutines defined by Kable for `common` and specific Coroutines versions can be defined per source set.