### PR TITLE
Specify Kable in `common` source set of example Gradle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,10 @@ kotlin {
 
         val macosX64Main by getting {
             dependencies {
+                // Need to specify the Coroutines artifact specific for the target platform (`-macosx64`):
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:${coroutinesVersion}-native-mt") {
                     version {
+                        // `strictly` needed to make sure Gradle uses `-native-mt` version.
                         strictly("${coroutinesVersion}-native-mt")
                     }
                 }
@@ -305,8 +307,10 @@ kotlin {
 
         val iosX64Main by getting {
             dependencies {
+                // Need to specify the Coroutines artifact specific for the target platform (`-iosx64`):
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:${coroutinesVersion}-native-mt") {
                     version {
+                        // `strictly` needed to make sure Gradle uses `-native-mt` version.
                         strictly("${coroutinesVersion}-native-mt")
                     }
                 }
@@ -315,8 +319,10 @@ kotlin {
 
         val iosArm64Main by getting {
             dependencies {
+                // Need to specify the Coroutines artifact specific for the target platform (`-iosarm64`):
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:${coroutinesVersion}-native-mt") {
                     version {
+                        // `strictly` needed to make sure Gradle uses `-native-mt` version.
                         strictly("${coroutinesVersion}-native-mt")
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ repositories {
 
 kotlin {
     android()
-    js().browser() // and/or js().node()
+    js().browser()
     macosX64()
     iosX64()
     iosArm64()

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ kotlin {
 
         val macosX64Main by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:${coroutinesVersion}-native-mt") {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:${coroutinesVersion}-native-mt") {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }
@@ -305,7 +305,7 @@ kotlin {
 
         val iosX64Main by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:${coroutinesVersion}-native-mt") {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:${coroutinesVersion}-native-mt") {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }
@@ -315,7 +315,7 @@ kotlin {
 
         val iosArm64Main by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:${coroutinesVersion}-native-mt") {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:${coroutinesVersion}-native-mt") {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }

--- a/README.md
+++ b/README.md
@@ -282,25 +282,14 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
                 implementation("com.juul.kable:core:${kableVersion}")
             }
         }
 
-        val androidMain by getting {
+        val macosX64Main by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
-            }
-        }
-
-        val jsMain by getting {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}")
-            }
-        }
-
-        val nativeMain by creating {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}-native-mt") {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:${coroutinesVersion}-native-mt") {
                     version {
                         strictly("${coroutinesVersion}-native-mt")
                     }
@@ -308,16 +297,24 @@ kotlin {
             }
         }
 
-        val macosX64Main by getting {
-            dependsOn(nativeMain)
+        val iosX64Main by getting {
+            dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:${coroutinesVersion}-native-mt") {
+                    version {
+                        strictly("${coroutinesVersion}-native-mt")
+                    }
+                }
+            }
         }
 
-        val iosX64Main by getting {
-            dependsOn(nativeMain)
-        }
-        
         val iosArm64Main by getting {
-            dependsOn(nativeMain)
+            dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:${coroutinesVersion}-native-mt") {
+                    version {
+                        strictly("${coroutinesVersion}-native-mt")
+                    }
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ kotlin {
             }
         }
 
+        val androidMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}")
+            }
+        }
+
         val macosX64Main by getting {
             dependencies {
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:${coroutinesVersion}-native-mt") {


### PR DESCRIPTION
Found a Gradle configuration that works for both application and library Gradle configurations.

Now using (tested) this configuration in https://github.com/JuulLabs/sensortag/pull/10.