### PR TITLE
Only attempt to stop observation if previously observed

### DIFF
--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -76,7 +76,7 @@ internal class Observers(
             }
         }
         .onCompletion {
-            if (observations.remove(characteristic, onSubscription) < 1) {
+            if (observations.remove(characteristic, onSubscription) == 0) {
                 try {
                     peripheral.stopObservation(characteristic)
                 } catch (e: NotReadyException) {
@@ -135,7 +135,7 @@ private class Observations {
     ): Int = lock.withLock {
         val actions = observations[characteristic]
         when {
-            actions == null -> 0
+            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
             actions.count() == 1 -> {
                 observations -= characteristic
                 0

--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -135,7 +135,7 @@ private class Observations {
     ): Int = lock.withLock {
         val actions = observations[characteristic]
         when {
-            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
+            actions == null -> -1 // No previous observation existed for characteristic.
             actions.count() == 1 -> {
                 observations -= characteristic
                 0

--- a/core/src/appleMain/kotlin/Observers.kt
+++ b/core/src/appleMain/kotlin/Observers.kt
@@ -139,7 +139,7 @@ private class Observations : IsolateState<MutableMap<Characteristic, MutableList
     ): Int = access {
         val actions = it[characteristic]
         when {
-            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
+            actions == null -> -1 // No previous observation existed for characteristic.
             actions.count() == 1 -> {
                 it -= characteristic
                 0

--- a/core/src/appleMain/kotlin/Observers.kt
+++ b/core/src/appleMain/kotlin/Observers.kt
@@ -78,7 +78,7 @@ internal class Observers(
                 }
             }
             .onCompletion {
-                if (observations.remove(characteristic, onSubscription) < 1) {
+                if (observations.remove(characteristic, onSubscription) == 0) {
                     try {
                         peripheral.stopNotifications(characteristic)
                     } catch (e: NotReadyException) {
@@ -139,7 +139,7 @@ private class Observations : IsolateState<MutableMap<Characteristic, MutableList
     ): Int = access {
         val actions = it[characteristic]
         when {
-            actions == null -> 0
+            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
             actions.count() == 1 -> {
                 it -= characteristic
                 0

--- a/core/src/jsMain/kotlin/Observers.kt
+++ b/core/src/jsMain/kotlin/Observers.kt
@@ -98,7 +98,7 @@ private class Observations {
     ): Int {
         val actions = observations[characteristic]
         return when {
-            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
+            actions == null -> -1 // No previous observation existed for characteristic.
             actions.count() == 1 -> {
                 observations -= characteristic
                 0

--- a/core/src/jsMain/kotlin/Observers.kt
+++ b/core/src/jsMain/kotlin/Observers.kt
@@ -53,7 +53,7 @@ internal class Observers(
             }
         }
         .onCompletion {
-            if (observations.remove(characteristic, onSubscription) < 1) {
+            if (observations.remove(characteristic, onSubscription) == 0) {
                 peripheral.stopObservation(characteristic)
             }
         }
@@ -98,7 +98,7 @@ private class Observations {
     ): Int {
         val actions = observations[characteristic]
         return when {
-            actions == null -> 0
+            actions == null -> -1 // -1 signifies that no previous observation existed for characteristic.
             actions.count() == 1 -> {
                 observations -= characteristic
                 0


### PR DESCRIPTION
Fixes #142.

When `observe` is called, internally it waits until connection is ready before initiating indicate/notify with the peripheral. At which time we increment a counter (of number of subscribers). When performing the reverse operation, we spin down the observation (i.e. inform the OS to disable indicate/notify of characteristic) when the last consumer of an `observe` unsubscribes. If a connection had never been established then upon the last consumer unsubscribing, we'd erroneously attempt to stop the indicate/notify of the characteristic.

By returning `-1` to indicate no previous indicate/notify for that observation has been performed, then we can skip the inverse process (of spinning the observe down).

The crash was due to the fact that we perform characteristic lookups to spin up/down the observations, and if a connection had never been established, then there would be no cached characteristics to search.