### PR TITLE
Fix `requestPeripheral` when using Kotlin/JS IR compiler

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,6 +18,10 @@ fun stately(
     version: String = "1.1.7-a1"
 ): String = "co.touchlab:stately-$module:$version"
 
+fun wrappers(
+    version: String = "1.0.1-pre.213-kotlin-1.5.10"
+) = "org.jetbrains.kotlin-wrappers:kotlin-extensions:$version"
+
 object androidx {
     fun startup(
         version: String = "1.0.0"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 kotlin {
     explicitApi()
 
-    js().browser()
     android {
         publishAllLibraryVariants()
     }
+    js().browser()
     iosX64()
     iosArm32()
     iosArm64()
@@ -25,6 +25,12 @@ kotlin {
             dependencies {
                 api(coroutines())
                 api(uuid())
+            }
+        }
+
+        val jsMain by getting {
+            dependencies {
+                implementation(wrappers())
             }
         }
 

--- a/core/src/jsMain/kotlin/Bluetooth.kt
+++ b/core/src/jsMain/kotlin/Bluetooth.kt
@@ -1,5 +1,8 @@
 package com.juul.kable
 
+import com.juul.kable.Options.Filter.Name
+import com.juul.kable.Options.Filter.NamePrefix
+import com.juul.kable.Options.Filter.Services
 import com.juul.kable.external.Bluetooth
 import kotlinext.js.jsObject
 import kotlinx.coroutines.CoroutineScope
@@ -15,6 +18,25 @@ public fun CoroutineScope.requestPeripheral(
     .requestDevice(options.toDynamic())
     .then { device -> peripheral(device, builderAction) }
 
+/**
+ * Converts [Options] to JavaScript friendly object.
+ *
+ * According to the `requestDevice`
+ * [example](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#example), the form of the
+ * JavaScript object should be similar to:
+ * ```
+ * let options = {
+ *   filters: [
+ *     {services: ['heart_rate']},
+ *     {services: [0x1802, 0x1803]},
+ *     {services: ['c48e6067-5295-48d3-8d5c-0395f61792b1']},
+ *     {name: 'ExampleName'},
+ *     {namePrefix: 'Prefix'}
+ *   ],
+ *   optionalServices: ['battery_service']
+ * }
+ * ```
+ */
 private fun Options.toDynamic(): dynamic = if (filters == null) {
     jsObject {
         this.acceptAllDevices = true
@@ -23,6 +45,13 @@ private fun Options.toDynamic(): dynamic = if (filters == null) {
 } else {
     jsObject {
         this.optionalServices = optionalServices
-        this.filters = filters
+        this.filters = filters.map { it.toDynamic() }.toTypedArray()
     }
 }
+
+private fun Options.Filter.toDynamic(): dynamic =
+    when (this) {
+        is Name -> jsObject { this.name = name }
+        is NamePrefix -> jsObject { this.namePrefix = namePrefix }
+        is Services -> jsObject { this.services = services }
+    }

--- a/core/src/jsMain/kotlin/Bluetooth.kt
+++ b/core/src/jsMain/kotlin/Bluetooth.kt
@@ -1,6 +1,7 @@
 package com.juul.kable
 
 import com.juul.kable.external.Bluetooth
+import kotlinext.js.jsObject
 import kotlinx.coroutines.CoroutineScope
 import kotlin.js.Promise
 
@@ -15,13 +16,13 @@ public fun CoroutineScope.requestPeripheral(
     .then { device -> peripheral(device, builderAction) }
 
 private fun Options.toDynamic(): dynamic = if (filters == null) {
-    object {
-        val acceptAllDevices = true
-        val optionalServices = this@toDynamic.optionalServices
+    jsObject {
+        this.acceptAllDevices = true
+        this.optionalServices = optionalServices
     }
 } else {
-    object {
-        val optionalServices = this@toDynamic.optionalServices
-        val filters = this@toDynamic.filters
+    jsObject {
+        this.optionalServices = optionalServices
+        this.filters = filters
     }
 }


### PR DESCRIPTION
Was seeing:

```
TypeError: Failed to execute 'requestDevice' on 'Bluetooth': Either 'filters' should be present or 'acceptAllDevices' should be true, but not both.
```

Suspected to be caused by an incompatibility with using an anonymous `object`. This PR instead uses `kotlin-wrappers` library provided `jsObject`.