### PR TITLE
Android ScanSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The [`Scanner`] may be configured via the following DSL (shown are defaults, whe
 ```kotlin
 val scanner = Scanner {
     services = null
+    scanSettings = ScanSettings.Builder().build() // Android only, see details below
     logging {
         engine = SystemLogEngine
         level = Warnings
@@ -52,7 +53,32 @@ val advertisement = Scanner()
     .first { it.name?.startsWith("Example") }
 ```
 
-_**JavaScript:** Scanning for nearby peripherals is supported, but only available on Chrome 79+ with "Experimental Web
+### Android
+Android's BLE API offers some additional settings to customize your scan with. If you need these,
+Kable exposes them in the [`Scanner`] DSL when it's used in an Android source set (instead of the
+common source set). Just set the `scanSettings` value to whatever
+`android.bluetooth.le.ScanSettings` you need:
+
+```kotlin
+val scanner = Scanner {
+    services = null
+    // Only available for Android
+    scanSettings = ScanSettings.Builder()
+        .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+        .build()
+    logging {
+        engine = SystemLogEngine
+        level = Warnings
+        format = Multiline
+    }
+}
+```
+
+_Since these settings (or similar ones) don't exist on other platforms (e.g. iOS), the 
+`scanSettings` are only available when calling the DSL from an Android source set._
+
+### JavaScript
+_Scanning for nearby peripherals is supported, but only available on Chrome 79+ with "Experimental Web
 Platform features" enabled via:_ `chrome://flags/#enable-experimental-web-platform-features`
 
 ## Peripheral

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -227,8 +227,10 @@ public abstract interface class com/juul/kable/Scanner {
 
 public final class com/juul/kable/ScannerBuilder {
 	public fun <init> ()V
+	public final fun getScanSettings ()Landroid/bluetooth/le/ScanSettings;
 	public final fun getServices ()Ljava/util/List;
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
+	public final fun setScanSettings (Landroid/bluetooth/le/ScanSettings;)V
 	public final fun setServices (Ljava/util/List;)V
 }
 

--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -22,6 +22,7 @@ public class ScanFailedException internal constructor(
 
 public class AndroidScanner internal constructor(
     private val filterServices: List<Uuid>?,
+    private val scanSettings: ScanSettings,
     logging: Logging,
 ) : Scanner {
 
@@ -62,7 +63,7 @@ public class AndroidScanner internal constructor(
                 ?.toList()
         bluetoothAdapter.bluetoothLeScanner.startScan(
             scanFilter,
-            ScanSettings.Builder().build(),
+            scanSettings,
             callback,
         )
 

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -1,11 +1,13 @@
 package com.juul.kable
 
+import android.bluetooth.le.ScanSettings
 import com.benasher44.uuid.Uuid
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.LoggingBuilder
 
 public actual class ScannerBuilder {
     public actual var services: List<Uuid>? = null
+    public var scanSettings: ScanSettings = ScanSettings.Builder().build()
     private var logging: Logging = Logging()
 
     public actual fun logging(init: LoggingBuilder) {
@@ -14,6 +16,7 @@ public actual class ScannerBuilder {
 
     internal actual fun build(): Scanner = AndroidScanner(
         filterServices = services,
+        scanSettings = scanSettings,
         logging = logging,
     )
 }


### PR DESCRIPTION
Per [this discussion](https://github.com/JuulLabs/kable/discussions/158), this PR enables users to create a `Scanner` with Android-specific `ScanSettings` if the current default ones don't suffice. It simply adds a non-`actual` `var scanSettings` to the builder that's available when calling from an Android source set only. It defaults to the existing default. This means that users who don't care about customizing this can still invoke the DSL from a common source set, but those who want more control can invoke from an Android source set and get the control they need.