### PR TITLE
Add ability to set logging identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ peripherals are logging. The identifier (for the purposes of logging) can be set
 ```kotlin
 val peripheral = scope.peripheral(advertisement) {
     logging {
-        identifier = "Example 1"
+        identifier = "Example"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ val peripheral = scope.peripheral(advertisement) {
 
 _I/O data is only shown in logs when logging `level` is set to `Data`._
 
+When logging, the identity of the peripheral is prefixed on log messages to differentiate messages when multiple
+peripherals are logging. The identifier (for the purposes of logging) can be set via the `identifier` property:
+
+```kotlin
+val peripheral = scope.peripheral(advertisement) {
+    logging {
+        identifier = "Example 1"
+    }
+}
+```
+
+The default (when not specified, or set to `null`) is to use the platform specific peripheral identifier:
+
+- Android: Hardware (MAC) address (e.g. "00:11:22:AA:BB:CC")
+- Apple: The UUID associated with the peer
+- JavaScript: A `DOMString` that uniquely identifies a device
+
 #### Service Discovery
 
 All platforms support an `onServicesDiscovered` action (that is executed after service discovery but before observations

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -399,10 +399,12 @@ public final class com/juul/kable/logs/Logging {
 	public final fun getData ()Lcom/juul/kable/logs/Logging$DataProcessor;
 	public final fun getEngine ()Lcom/juul/kable/logs/LogEngine;
 	public final fun getFormat ()Lcom/juul/kable/logs/Logging$Format;
+	public final fun getIdentifier ()Ljava/lang/String;
 	public final fun getLevel ()Lcom/juul/kable/logs/Logging$Level;
 	public final fun setData (Lcom/juul/kable/logs/Logging$DataProcessor;)V
 	public final fun setEngine (Lcom/juul/kable/logs/LogEngine;)V
 	public final fun setFormat (Lcom/juul/kable/logs/Logging$Format;)V
+	public final fun setIdentifier (Ljava/lang/String;)V
 	public final fun setLevel (Lcom/juul/kable/logs/Logging$Level;)V
 }
 

--- a/core/src/androidMain/kotlin/Observers.kt
+++ b/core/src/androidMain/kotlin/Observers.kt
@@ -53,7 +53,7 @@ internal class Observers(
     logging: Logging,
 ) {
 
-    private val logger = Logger(logging, tag = "Kable/Observers")
+    private val logger = Logger(logging, tag = "Kable/Observers", peripheral.bluetoothDevice.address)
 
     val characteristicChanges = MutableSharedFlow<AndroidObservationEvent>()
     private val observations = Observations()

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -125,14 +125,14 @@ public enum class Priority { Low, Balanced, High }
 
 public class AndroidPeripheral internal constructor(
     parentCoroutineContext: CoroutineContext,
-    private val bluetoothDevice: BluetoothDevice,
+    internal val bluetoothDevice: BluetoothDevice,
     private val transport: Transport,
     private val phy: Phy,
     private val onServicesDiscovered: ServicesDiscoveredAction,
     private val logging: Logging,
 ) : Peripheral {
 
-    private val logger = Logger(logging, tag = "Kable/Peripheral", prefix = "$bluetoothDevice ")
+    private val logger = Logger(logging, tag = "Kable/Peripheral", identifier = bluetoothDevice.address)
 
     private val _state = MutableStateFlow<State>(State.Disconnected())
     public override val state: Flow<State> = _state.asStateFlow()

--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -26,7 +26,7 @@ public class AndroidScanner internal constructor(
     logging: Logging,
 ) : Scanner {
 
-    private val logger = Logger(logging, tag = "Kable/Scanner")
+    private val logger = Logger(logging, tag = "Kable/Scanner", identifier = "")
 
     private val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
         ?: error("Bluetooth not supported")

--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -26,7 +26,7 @@ public class AndroidScanner internal constructor(
     logging: Logging,
 ) : Scanner {
 
-    private val logger = Logger(logging, tag = "Kable/Scanner", identifier = "")
+    private val logger = Logger(logging, tag = "Kable/Scanner", identifier = null)
 
     private val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
         ?: error("Bluetooth not supported")

--- a/core/src/androidMain/kotlin/gatt/Callback.kt
+++ b/core/src/androidMain/kotlin/gatt/Callback.kt
@@ -58,7 +58,7 @@ internal class Callback(
     macAddress: String,
 ) : BluetoothGattCallback() {
 
-    private val logger = Logger(logging, tag = "Kable/Callback", prefix = "$macAddress ")
+    private val logger = Logger(logging, tag = "Kable/Callback", identifier = macAddress)
 
     private var disconnectedAction: DisconnectedAction? = null
     fun invokeOnDisconnected(action: DisconnectedAction) {

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -97,7 +97,7 @@ public class ApplePeripheral internal constructor(
 
     private val centralManager: CentralManager = CentralManager.Default
 
-    private val logger = Logger(logging, prefix = "${cbPeripheral.identifier} ")
+    private val logger = Logger(logging, identifier = cbPeripheral.identifier.UUIDString)
 
     private val _state = MutableStateFlow<State>(State.Disconnected())
     override val state: Flow<State> = _state.asStateFlow()
@@ -151,7 +151,9 @@ public class ApplePeripheral internal constructor(
         }.launchIn(scope)
 
         try {
-            val delegate = PeripheralDelegate(logging).freeze() // todo: Create in `connectPeripheral`.
+            // todo: Create in `connectPeripheral`.
+            val delegate = PeripheralDelegate(logging, cbPeripheral.identifier.UUIDString).freeze()
+
             val connection = centralManager.connectPeripheral(cbPeripheral, delegate).also {
                 _connection.value = it
             }

--- a/core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -30,7 +30,10 @@ import platform.darwin.NSObject
 import kotlin.native.concurrent.freeze
 
 // https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate
-internal class PeripheralDelegate(logging: Logging) : NSObject(), CBPeripheralDelegateProtocol {
+internal class PeripheralDelegate(
+    logging: Logging,
+    identifier: String
+) : NSObject(), CBPeripheralDelegateProtocol {
 
     sealed class Response {
 
@@ -100,7 +103,7 @@ internal class PeripheralDelegate(logging: Logging) : NSObject(), CBPeripheralDe
     private val _characteristicChanges = MutableSharedFlow<DidUpdateValueForCharacteristic>(extraBufferCapacity = 64)
     val characteristicChanges = _characteristicChanges.asSharedFlow()
 
-    private val logger = Logger(logging)
+    private val logger = Logger(logging, tag = "Kable/Delegate", identifier = identifier)
 
     /* Discovering Services */
 

--- a/core/src/commonMain/kotlin/logs/LogMessage.kt
+++ b/core/src/commonMain/kotlin/logs/LogMessage.kt
@@ -30,9 +30,9 @@ internal class LogMessage {
         detail(key, value.toString())
     }
 
-    fun build(logging: Logging, platformIdentifier: String): String = buildString {
+    fun build(logging: Logging, platformIdentifier: String?): String = buildString {
         val prefix = logging.identifier ?: platformIdentifier
-        if (prefix.isNotEmpty()) {
+        if (!prefix.isNullOrEmpty()) {
             append(prefix)
             append(' ')
         }

--- a/core/src/commonMain/kotlin/logs/LogMessage.kt
+++ b/core/src/commonMain/kotlin/logs/LogMessage.kt
@@ -30,8 +30,12 @@ internal class LogMessage {
         detail(key, value.toString())
     }
 
-    fun build(logging: Logging, prefix: String?): String = buildString {
-        if (prefix != null) append(prefix)
+    fun build(logging: Logging, platformIdentifier: String): String = buildString {
+        val prefix = logging.identifier ?: platformIdentifier
+        if (prefix.isNotEmpty()) {
+            append(prefix)
+            append(' ')
+        }
         append(message)
 
         when (logging.format) {

--- a/core/src/commonMain/kotlin/logs/Logger.kt
+++ b/core/src/commonMain/kotlin/logs/Logger.kt
@@ -6,14 +6,14 @@ import com.juul.kable.logs.Logging.Level.Events
 internal class Logger(
     private val logging: Logging,
     private val tag: String = "Kable",
-    private val prefix: String? = null,
+    private val identifier: String,
 ) {
 
     inline fun verbose(throwable: Throwable? = null, crossinline init: LogMessage.() -> Unit) {
         if (logging.level == Events || logging.level == Data) {
             val message = LogMessage()
             message.init()
-            logging.engine.verbose(throwable, tag, message.build(logging, prefix))
+            logging.engine.verbose(throwable, tag, message.build(logging, identifier))
         }
     }
 
@@ -21,7 +21,7 @@ internal class Logger(
         if (logging.level == Events || logging.level == Data) {
             val message = LogMessage()
             message.init()
-            logging.engine.debug(throwable, tag, message.build(logging, prefix))
+            logging.engine.debug(throwable, tag, message.build(logging, identifier))
         }
     }
 
@@ -29,25 +29,25 @@ internal class Logger(
         if (logging.level == Events || logging.level == Data) {
             val message = LogMessage()
             message.init()
-            logging.engine.info(throwable, tag, message.build(logging, prefix))
+            logging.engine.info(throwable, tag, message.build(logging, identifier))
         }
     }
 
     inline fun warn(throwable: Throwable? = null, crossinline init: LogMessage.() -> Unit) {
         val message = LogMessage()
         message.init()
-        logging.engine.warn(throwable, tag, message.build(logging, prefix))
+        logging.engine.warn(throwable, tag, message.build(logging, identifier))
     }
 
     inline fun error(throwable: Throwable? = null, crossinline init: LogMessage.() -> Unit) {
         val message = LogMessage()
         message.init()
-        logging.engine.error(throwable, tag, message.build(logging, prefix))
+        logging.engine.error(throwable, tag, message.build(logging, identifier))
     }
 
     inline fun assert(throwable: Throwable? = null, crossinline init: LogMessage.() -> Unit) {
         val message = LogMessage()
         message.init()
-        logging.engine.assert(throwable, tag, message.build(logging, prefix))
+        logging.engine.assert(throwable, tag, message.build(logging, identifier))
     }
 }

--- a/core/src/commonMain/kotlin/logs/Logger.kt
+++ b/core/src/commonMain/kotlin/logs/Logger.kt
@@ -6,7 +6,7 @@ import com.juul.kable.logs.Logging.Level.Events
 internal class Logger(
     private val logging: Logging,
     private val tag: String = "Kable",
-    private val identifier: String,
+    private val identifier: String?,
 ) {
 
     inline fun verbose(throwable: Throwable? = null, crossinline init: LogMessage.() -> Unit) {

--- a/core/src/commonMain/kotlin/logs/Logging.kt
+++ b/core/src/commonMain/kotlin/logs/Logging.kt
@@ -44,6 +44,15 @@ public class Logging {
         public fun process(data: ByteArray): String
     }
 
+    /**
+     * Identifier to use in log messages. When `null`, defaults to the platform's peripheral identifier:
+     *
+     * - Android: Hardware (MAC) address (e.g. "00:11:22:AA:BB:CC")
+     * - Apple: The UUID associated with the peer
+     * - JavaScript: A `DOMString` that uniquely identifies a device
+     */
+    public var identifier: String? = null
+
     public var engine: LogEngine = SystemLogEngine
     public var level: Level = Level.Warnings
     public var format: Format = Format.Multiline

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -68,7 +68,7 @@ public class JsPeripheral internal constructor(
 
     private val scope = CoroutineScope(parentCoroutineContext + job)
 
-    private val logger = Logger(logging, prefix = "${bluetoothDevice.id} ")
+    private val logger = Logger(logging, identifier = bluetoothDevice.id)
 
     private val ioLock = Mutex()
 


### PR DESCRIPTION
Example of setting logging `identifier` to "Example":

<details>
<summary>OS X</summary>

```
...
2021-09-09 02:22:48.788 sensortag.kexe[42195:875213] V/Kable: Example Configuring characteristic observations
2021-09-09 02:22:48.788 sensortag.kexe[42195:875213] I/Kable: Example Connected
2021-09-09 02:22:48.789 sensortag.kexe[42195:875213] D/Kable: Example CentralManager.notify
  service: f000aa80-0451-4000-b000-000000000000
  characteristic: f000aa81-0451-4000-b000-000000000000
[I/Unknown] Connected
[V/Unknown] Writing gyro period
[I/Unknown] movement → writePeriod → data = 255 (FF)
2021-09-09 02:22:48.790 sensortag.kexe[42195:875213] D/Kable: Example write
  service: f000aa80-0451-4000-b000-000000000000
  characteristic: f000aa83-0451-4000-b000-000000000000
  writeType: WithoutResponse
  data: FF
...
2021-09-09 02:22:49.147 sensortag.kexe[42195:875235] D/Kable/Delegate: Example 7BA26113-69FC-4087-90FE-6E02F9C46B20 didUpdateValueForCharacteristic
  service: F000AA80-0451-4000-B000-000000000000
  characteristic: F000AA81-0451-4000-B000-000000000000
  data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[I/Unknown] Vector3f(x=0.0, y=0.0, z=0.0)
2021-09-09 02:22:51.713 sensortag.kexe[42195:875236] D/Kable/Delegate: Example 7BA26113-69FC-4087-90FE-6E02F9C46B20 didUpdateValueForCharacteristic
  service: F000AA80-0451-4000-B000-000000000000
  characteristic: F000AA81-0451-4000-B000-000000000000
[I/Unknown] Vector3f(x=9.20105, y=249.99237, z=-29.083252)
  data: B6 04 FF 7F 1C F1 A0 07 84 FF A4 27 00 00 00 00 00 00
```
</details>

<details>
<summary>Android</summary>

```
2021-09-09 02:30:52.382 19943-19943/com.juul.sensortag V/Kable/Peripheral: Example discoverServices
2021-09-09 02:30:52.384 19943-20022/com.juul.sensortag D/BluetoothGatt: discoverServices() - device: 54:6C:0E:53:01:7D
2021-09-09 02:30:52.389 19943-19943/com.juul.sensortag I/System.out: [D/SensorViewModel$connect] connect
2021-09-09 02:30:52.827 19943-20002/com.juul.sensortag D/BluetoothGatt: onConnectionUpdated() - Device=54:6C:0E:53:01:7D interval=6 latency=0 timeout=500 status=0
2021-09-09 02:30:54.520 19943-20002/com.juul.sensortag D/BluetoothGatt: onSearchComplete() = Device=54:6C:0E:53:01:7D Status=0
2021-09-09 02:30:54.523 19943-20022/com.juul.sensortag D/Kable/Callback: Example onServicesDiscovered
    status: GATT_SUCCESS(0)
2021-09-09 02:30:54.535 19943-19943/com.juul.sensortag V/Kable/Peripheral: Example Configuring characteristic observations
2021-09-09 02:30:54.535 19943-19943/com.juul.sensortag I/Kable/Peripheral: Example Connected
2021-09-09 02:30:54.546 19943-20022/com.juul.sensortag D/BluetoothGatt: readRssi() - device: 54:6C:0E:53:01:7D
2021-09-09 02:30:54.549 19943-19943/com.juul.sensortag D/Kable/Peripheral: Example setCharacteristicNotification
    service: f000aa80-0451-4000-b000-000000000000
    characteristic: f000aa81-0451-4000-b000-000000000000
    value: true
2021-09-09 02:30:54.550 19943-19943/com.juul.sensortag D/BluetoothGatt: setCharacteristicNotification() - uuid: f000aa81-0451-4000-b000-000000000000 enable: true
2021-09-09 02:30:54.552 19943-19943/com.juul.sensortag V/Kable/Peripheral: Example Writing ENABLE_NOTIFICATION_VALUE to CCCD
    service: f000aa80-0451-4000-b000-000000000000
    characteristic: f000aa81-0451-4000-b000-000000000000
    descriptor: 00002902-0000-1000-8000-00805f9b34fb
2021-09-09 02:30:54.553 19943-19943/com.juul.sensortag D/Kable/Peripheral: Example write
    service: f000aa80-0451-4000-b000-000000000000
    characteristic: f000aa81-0451-4000-b000-000000000000
    descriptor: 00002902-0000-1000-8000-00805f9b34fb
    data: 01 00
2021-09-09 02:30:54.557 19943-20022/com.juul.sensortag D/Kable/Callback: Example onReadRemoteRssi
    rssi: -60
    status: GATT_SUCCESS(0)
2021-09-09 02:30:54.558 19943-19943/com.juul.sensortag I/System.out: [I/SensorTag] Enabling gyro
2021-09-09 02:30:54.558 19943-19943/com.juul.sensortag D/Kable/Peripheral: Example write
    service: f000aa80-0451-4000-b000-000000000000
    characteristic: f000aa82-0451-4000-b000-000000000000
    writeType: WithoutResponse
    data: 7F 00
2021-09-09 02:30:54.560 19943-19943/com.juul.sensortag I/System.out: [I/SensorTag] Enabling gyro
2021-09-09 02:30:54.560 19943-19943/com.juul.sensortag D/Kable/Peripheral: Example write
    service: f000aa80-0451-4000-b000-000000000000
    characteristic: f000aa82-0451-4000-b000-000000000000
    writeType: WithoutResponse
    data: 7F 00
```
</details>

<details>
<summary>JavaScript</summary>

![Screen Shot 2021-09-09 at 2 32 40 AM](https://user-images.githubusercontent.com/98017/132661497-0fef16f7-b254-40fd-b0e4-9938adbacbe6.png)
</details>