### PR TITLE
Have `connect` throw `CancellationException` when scope is cancelled

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -223,7 +223,6 @@ public class AndroidPeripheral internal constructor(
     }
 
     public override suspend fun connect() {
-        check(job.isNotCancelled) { "Cannot connect, scope is cancelled for $this" }
         checkBluetoothAdapterState(expected = STATE_ON)
         connectJob.updateAndGet { it ?: connectAsync() }!!.await()
     }

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -195,7 +195,6 @@ public class ApplePeripheral internal constructor(
     }
 
     public override suspend fun connect() {
-        check(job.isNotCancelled) { "Cannot connect, scope is cancelled for $this" }
         connectJob.updateAndGet { it ?: connectAsync() }!!.await()
     }
 

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -65,7 +65,7 @@ public interface Peripheral {
      * suspend until connected (or failure occurs). If already connected, then returns immediately.
      *
      * @throws ConnectionRejectedException when a connection request is rejected by the system (e.g. bluetooth hardware unavailable).
-     * @throws IllegalStateException if [Peripheral]'s Coroutine scope has been cancelled.
+     * @throws CancellationException if [Peripheral]'s Coroutine scope has been cancelled.
      */
     public suspend fun connect(): Unit
 

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -154,7 +154,6 @@ public class JsPeripheral internal constructor(
     }
 
     public override suspend fun connect() {
-        check(job.isNotCancelled) { "Cannot connect, scope is cancelled for $this" }
         val job = connectJob ?: connectAsync().also { connectJob = it }
         job.await()
     }


### PR DESCRIPTION
We were seeing the `IllegalStateException` when calling `connect` from a flow that was being collected from a child scope of the `Peripheral`'s parent scope.

Extremely simplified pseudo-code illustrating the problem:

```kotlin
val scope = CoroutineScope()
val child = scope.createChildScope()
val peripheral = scope.peripheral(..)

peripheral.state.onEach { state ->
    if (state is Disconnected) {
        // seeing crashes w/ `connect` throwing `IllegalStateException`
        peripheral.connect()
    }
}.launchIn(child)

scope.cancel()
```

The theory is that there is a potential race condition where the `scope` is being cancelled but the `peripheral`'s state was being updated (and `child` hadn't yet been cancelled).

By removing the explicit check for scope state (in `Peripheral.connect`) allows us to lean on `connect`'s internals which uses `Deferred.await`, which throws `JobCancellationException` if the `async`'s scope is cancelled.

With this PR change, in the above example code (when the race condition would've previously occurred) now `peripheral.connect` will throw `JobCancellationException` causing the flow collection of `peripheral.state` flow to cancel gracefully.