### PR TITLE
Make Android connection failures more robust

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.5.10" apply false
+    kotlin("multiplatform") version "1.5.20" apply false
     id("com.android.library") version "4.1.3" apply false
     id("org.jmailen.kotlinter") version "3.4.4" apply false
     id("com.vanniktech.maven.publish") version "0.15.1" apply false

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 fun coroutines(
     module: String = "core",
-    version: String = "1.5.2"
+    version: String = "1.5.1"
 ): String = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 
 fun atomicfu(

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 fun coroutines(
     module: String = "core",
-    version: String = "1.5.0"
+    version: String = "1.5.2"
 ): String = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 
 fun atomicfu(

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -193,14 +193,14 @@ public class AndroidPeripheral internal constructor(
 
     /** Creates a connect [Job] that completes when connection is established, or failure occurs. */
     private fun connectAsync() = scope.async(start = LAZY) {
-        val connection = establishConnection().also { _connection = it }
-
-        connection
-            .characteristicChanges
-            .onEach(observers.characteristicChanges::emit)
-            .launchIn(scope, start = UNDISPATCHED)
-
         try {
+            val connection = establishConnection().also { _connection = it }
+
+            connection
+                .characteristicChanges
+                .onEach(observers.characteristicChanges::emit)
+                .launchIn(scope, start = UNDISPATCHED)
+
             suspendUntilOrThrow<State.Connecting.Services>()
             discoverServices()
             onServicesDiscovered(ServicesDiscoveredPeripheral(this@AndroidPeripheral))
@@ -208,7 +208,7 @@ public class AndroidPeripheral internal constructor(
             logger.verbose { message = "Configuring characteristic observations" }
             observers.rewire()
         } catch (t: Throwable) {
-            closeConnection()
+            disconnect()
             logger.error(t) { message = "Failed to connect" }
             throw t
         }

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -42,8 +42,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onEach
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.update
+import kotlin.coroutines.CoroutineContext
 
 private val clientCharacteristicConfigUuid = uuidFrom(CLIENT_CHARACTERISTIC_CONFIG_UUID)
 

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -221,6 +221,7 @@ public class AndroidPeripheral internal constructor(
     private fun closeConnection() {
         _connection?.close()
         _connection = null
+        // Avoid trampling existing `Disconnected` state (and its properties) by only updating if not already `Disconnected`.
         _state.update { previous -> previous as? State.Disconnected ?: State.Disconnected() }
     }
 

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -208,7 +208,7 @@ public class AndroidPeripheral internal constructor(
             logger.verbose { message = "Configuring characteristic observations" }
             observers.rewire()
         } catch (t: Throwable) {
-            disconnect()
+            closeConnection()
             logger.error(t) { message = "Failed to connect" }
             throw t
         }
@@ -219,6 +219,9 @@ public class AndroidPeripheral internal constructor(
 
     private fun closeConnection() {
         _connection?.close()
+        if (_state.value !is State.Disconnected) {
+            _state.value = State.Disconnected()
+        }
         _connection = null
     }
 

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.flow.update
 
 private val clientCharacteristicConfigUuid = uuidFrom(CLIENT_CHARACTERISTIC_CONFIG_UUID)
 
@@ -219,10 +220,8 @@ public class AndroidPeripheral internal constructor(
 
     private fun closeConnection() {
         _connection?.close()
-        if (_state.value !is State.Disconnected) {
-            _state.value = State.Disconnected()
-        }
         _connection = null
+        _state.update { previous -> previous as? State.Disconnected ?: State.Disconnected() }
     }
 
     public override suspend fun connect() {


### PR DESCRIPTION
Fixes two separate issues, but they're close enough I think it's okay to couple them.

1. `establishConnection` can throw. Before this PR that exception wouldn't make it to the `logger`, now it will.
2. In the `catch` block of `connectAsync` call `disconnect` instead of `closeConnection`. This should guarantee that we've reached the `Disconnected` state before we actually throw the exception into the connection attempt.