### PR TITLE
Fix bug with observe onSubscription not being called on JavaScript

### DIFF
--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -265,7 +265,7 @@ public class JsPeripheral internal constructor(
     public override fun observe(
         characteristic: Characteristic,
         onSubscription: OnSubscriptionAction,
-    ): Flow<ByteArray> = observeDataView(characteristic)
+    ): Flow<ByteArray> = observeDataView(characteristic, onSubscription)
         .map { it.buffer.toByteArray() }
 
     private var isDisconnectedListenerRegistered = false


### PR DESCRIPTION
Whoops! (oversight in JavaScript implementation of `observe` function — had forgotten to pass along the `onSubscription` parameter).