### PR TITLE
Keep BLE threads alive until `Peripheral` is disposed

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -150,9 +150,12 @@ public class AndroidPeripheral internal constructor(
         invokeOnCompletion {
             applicationContext.unregisterReceiver(receiver)
             closeConnection()
+            threading.close()
         }
     }
     private val scope = CoroutineScope(parentCoroutineContext + job)
+
+    private val threading = bluetoothDevice.threading()
 
     private val _mtu = MutableStateFlow<Int?>(null)
 
@@ -189,6 +192,7 @@ public class AndroidPeripheral internal constructor(
             _state,
             _mtu,
             logging,
+            threading,
             invokeOnClose = { connectJob.value = null }
         ) ?: throw ConnectionRejectedException()
     }


### PR DESCRIPTION
Closes #194

This change will keep the dedicated threads created for BLE communication alive across connections.

By keeping the threads alive (and re-using the same threads across a `Peripheral`'s connections) means we avoid a race-condition that can occur when a connection drops (thus, shutting down the BLE thread) in the middle of an I/O operation.