### PR TITLE
Remove default publication version name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,13 @@ jobs:
           if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
             ./gradlew \
             --no-parallel \
-            -PVERSION_NAME="unspecified" \
             -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
             -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
             publishToMavenLocal
           else
             ./gradlew \
             --no-parallel \
-            -PVERSION_NAME="unspecified-SNAPSHOT" \
+            -PRELEASE_SIGNING_ENABLED=false
             publishToMavenLocal
           fi
         if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError 
 # https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties
 
 GROUP=com.juul.kable
-VERSION_NAME=main-SNAPSHOT
 
 POM_NAME=Kable
 POM_DESCRIPTION=Kotlin Asynchronous Bluetooth Low Energy


### PR DESCRIPTION
Using `main-SNAPSHOT` as a default version name makes sense for library users who install to Maven local from the `main` branch; but for other branches it is just confusing. Better to remove the default entirely and let Maven plugin decide default version name (`unspecified` is used when not set).