### PR TITLE
Fix code owners for Apple source set

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 
 *                @JuulLabs/conx-app-reviewers @twyatt
-macosX64Main/    @davidtaylor-juul @Phoenix7351
+appleMain/       @davidtaylor-juul @Phoenix7351


### PR DESCRIPTION
#63 moved where the Apple target's sources were located, this PR simply updates the code owners to match the new location.