### PR TITLE
Handle UUID aliases during service discovery

### DIFF
--- a/core/src/jsMain/kotlin/Bluetooth.kt
+++ b/core/src/jsMain/kotlin/Bluetooth.kt
@@ -8,8 +8,14 @@ import kotlinext.js.jsObject
 import kotlinx.coroutines.CoroutineScope
 import kotlin.js.Promise
 
+// Deliberately NOT cast `as Bluetooth` to avoid potential class name collisions.
+@Suppress("UnsafeCastFromDynamic")
 internal val bluetooth: Bluetooth
-    get() = checkNotNull(js("window.navigator.bluetooth") as? Bluetooth) { "Bluetooth unavailable" }
+    get() = checkNotNull(safeWebBluetooth) { "Bluetooth unavailable" }
+
+// In a node build environment (e.g. unit test) there is no window, guard for that to avoid build errors.
+private val safeWebBluetooth: dynamic =
+    js("typeof(window) !== 'undefined' && window.navigator.bluetooth")
 
 public fun CoroutineScope.requestPeripheral(
     options: Options,

--- a/core/src/jsMain/kotlin/UUID.kt
+++ b/core/src/jsMain/kotlin/UUID.kt
@@ -2,6 +2,10 @@ package com.juul.kable
 
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuidFrom
+import com.juul.kable.external.BluetoothUUID
+
+// Number of characters in a 16-bit UUID alias in string hex representation
+private const val UUID_ALIAS_STRING_LENGTH = 4
 
 /**
  * Per [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-uuid) Draft Community Group Report,
@@ -13,4 +17,10 @@ import com.benasher44.uuid.uuidFrom
  */
 internal typealias UUID = String
 
-internal fun UUID.toUuid(): Uuid = uuidFrom(this)
+internal fun UUID.toUuid(): Uuid =
+    uuidFrom(
+        when (length) {
+            UUID_ALIAS_STRING_LENGTH -> BluetoothUUID.canonicalUUID(toInt(16))
+            else -> this
+        }
+    )

--- a/core/src/jsMain/kotlin/external/BluetoothUUID.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothUUID.kt
@@ -1,0 +1,17 @@
+package com.juul.kable.external
+
+import com.juul.kable.UUID
+
+/**
+ * According to [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/#uuids):
+ *
+ * > Note: This standard provides the BluetoothUUID.canonicalUUID(alias) function to map
+ * > a 16- or 32-bit Bluetooth UUID alias to its 128-bit form.
+ *
+ * _See also: [Standardized UUIDs](https://webbluetoothcg.github.io/web-bluetooth/#standardized-uuids)_
+ */
+internal abstract external class BluetoothUUID {
+    internal companion object {
+        internal fun canonicalUUID(alias: dynamic): UUID
+    }
+}


### PR DESCRIPTION
Translate UUID aliases surfaced during discovery into their long-form via `BluetoothUUID.canonicalUUID` so they will be accepted by the `com.benasher44.uuid` library API. See https://webbluetoothcg.github.io/web-bluetooth/#standardized-uuids

Also tweaks the bridging of the `window.navigator.bluetooth` reference as the build environment this was discovered and tested in was tripping over it. (Let me know if that needs to be in a separate PR and I'll move it.)

Closes #206 