### PR TITLE
Add Apple Silicon support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ allprojects {
     }
 }
 
-// Workaround for https://youtrack.jetbrains.com/issue/KT-49109 that allows building on Apple Silicon.
+// Workaround for https://youtrack.jetbrains.com/issue/KT-49109 that allows building on Apple Silicon
 // This should no longer be needed with Kotlin version 1.6.20
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,3 +35,7 @@ allprojects {
         }
     }
 }
+
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ allprojects {
     }
 }
 
-// Workaround for https://youtrack.jetbrains.com/issue/KT-49109 that allows building on Apple Silicon
+// Workaround for https://youtrack.jetbrains.com/issue/KT-49109 that allows building on Apple Silicon.
 // This should no longer be needed with Kotlin version 1.6.20
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,8 @@ allprojects {
     }
 }
 
+// Workaround for https://youtrack.jetbrains.com/issue/KT-49109 that allows building on Apple Silicon
+// This should no longer be needed with Kotlin version 1.6.20
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     iosX64()
     iosArm32()
     iosArm64()
+    iosSimulatorArm64()
     macosX64()
 
     sourceSets {
@@ -103,6 +104,13 @@ kotlin {
         }
 
         val iosArm64Test by getting {
+            dependsOn(appleTest)
+        }
+
+        val iosSimulatorArm64Main by getting {
+            dependsOn(appleMain)
+        }
+        val iosSimulatorArm64Test by getting {
             dependsOn(appleTest)
         }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
     }
     js().browser()
     iosX64()
+    macosArm64()
     iosArm32()
     iosArm64()
     iosSimulatorArm64()
@@ -80,6 +81,14 @@ kotlin {
         }
 
         val macosX64Test by getting {
+            dependsOn(appleTest)
+        }
+
+        val macosArm64Main by getting {
+            dependsOn(appleMain)
+        }
+
+        val macosArm64Test by getting {
             dependsOn(appleTest)
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ android-min = "21"
 atomicfu = "0.17.1"
 coroutines = "1.6.0"
 kotlin = "1.6.10"
-tuulbox = "6.0.1"
+tuulbox = "6.1.0"
 
 [libraries]
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }


### PR DESCRIPTION
Since Kotlin 1.5.30 added support for Apple Silicon it's now possible to build KMM projects on M1 without Rosetta. However it does require that all dependencies also support it explicitly.

This change should add Apple Silicon support for Kable as well. Unfortunately I haven't been able to test it locally since I'm not sure how to get the whole build working locally.