### PR TITLE
Simplify service filter creation in common code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Scan results can be filtered by manufacturer data using the same ID, data, and d
 ```kotlin
 val scanner = Scanner {
     filters = listOf(
-        Filter.ManufacturerData(manufacturerID = 1, data = byteArrayOf(), dataMask = byteArrayOf())
+        Filter.ManufacturerData(id = 1, data = byteArrayOf(), dataMask = byteArrayOf())
     )
 }
 ``` 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -258,6 +258,7 @@ public final class com/juul/kable/ScannerKt {
 	public static final fun Scanner (Ljava/util/List;)Lcom/juul/kable/Scanner;
 	public static final fun Scanner (Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Scanner;
 	public static synthetic fun Scanner$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Scanner;
+	public static final fun scannerWithFilters (Ljava/util/List;)Lcom/juul/kable/Scanner;
 }
 
 public abstract interface class com/juul/kable/Service {

--- a/core/src/androidMain/kotlin/Filter.kt
+++ b/core/src/androidMain/kotlin/Filter.kt
@@ -20,7 +20,7 @@ public actual sealed class Filter {
         public val dataMask: ByteArray?
     ) : Filter()
 
-    public actual class Service(
+    public actual class Service actual constructor(
         public actual val uuid: Uuid
     ) : Filter()
 }

--- a/core/src/appleMain/kotlin/Filter.kt
+++ b/core/src/appleMain/kotlin/Filter.kt
@@ -4,7 +4,7 @@ import com.benasher44.uuid.Uuid
 
 public actual sealed class Filter {
 
-    public actual class Service(
+    public actual class Service actual constructor(
         public actual val uuid: Uuid
     ) : Filter()
 }

--- a/core/src/commonMain/kotlin/Filter.kt
+++ b/core/src/commonMain/kotlin/Filter.kt
@@ -4,7 +4,7 @@ import com.benasher44.uuid.Uuid
 
 public expect sealed class Filter {
 
-    public class Service : Filter {
+    public class Service constructor(uuid: Uuid) : Filter {
         public val uuid: Uuid
     }
 }

--- a/core/src/commonMain/kotlin/Scanner.kt
+++ b/core/src/commonMain/kotlin/Scanner.kt
@@ -1,6 +1,8 @@
 package com.juul.kable
 
+import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmName
 
 public interface Scanner {
     public val advertisements: Flow<Advertisement>
@@ -8,10 +10,18 @@ public interface Scanner {
 
 @Deprecated(
     message = "Replaced with ScannerBuilder DSL",
-    replaceWith = ReplaceWith("Scanner { this.services = services }"),
+    replaceWith = ReplaceWith("Scanner { filters = services?.map { Filter.Service(it) } }"),
 )
+public fun Scanner(services: List<Uuid>?): Scanner =
+    Scanner { filters = services?.map { Filter.Service(it) } }
+
+@Deprecated(
+    message = "Replaced with ScannerBuilder DSL",
+    replaceWith = ReplaceWith("Scanner { this.filters = filters }"),
+)
+@JvmName("scannerWithFilters")
 public fun Scanner(filters: List<Filter>?): Scanner =
-    ScannerBuilder().apply { this.filters = filters }.build()
+    Scanner { this.filters = filters }
 
 public fun Scanner(
     builderAction: ScannerBuilder.() -> Unit = {},

--- a/core/src/jsMain/kotlin/Filter.kt
+++ b/core/src/jsMain/kotlin/Filter.kt
@@ -4,7 +4,7 @@ import com.benasher44.uuid.Uuid
 
 public actual sealed class Filter {
 
-    public actual class Service(
+    public actual class Service actual constructor(
         public actual val uuid: Uuid
     ) : Filter()
 }


### PR DESCRIPTION
#191 helped to commonize the scanner settings implementation, but as reported in https://github.com/JuulLabs/kable/pull/209#issuecomment-998975092, the updates in #191 don't provide a simple migration for the legacy API. The ability to construct common filters was also difficult from common code.

This PR aims to simplify filter creation (when using from common code) and provide deprecated functions for the legacy API.

Closes #230