### PR TITLE
Properly propagate observation cancellations

### DIFF
--- a/core/src/commonMain/kotlin/Observers.kt
+++ b/core/src/commonMain/kotlin/Observers.kt
@@ -67,6 +67,8 @@ internal class Observers<T>(
             .onSubscription {
                 try {
                     observation.onSubscription(onSubscription)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     exceptionHandler(ObservationExceptionPeripheral(peripheral), e)
                 }
@@ -80,6 +82,8 @@ internal class Observers<T>(
             .onCompletion {
                 try {
                     observation.onCompletion(onSubscription)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     exceptionHandler(ObservationExceptionPeripheral(peripheral), e)
                 }


### PR DESCRIPTION
Cancellations of observations should not be captured/handled by the observation exception handler.