### PR TITLE
Drop Kotlin/JS extensions and use internal `jso` instead

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -48,12 +48,6 @@ kotlin {
             }
         }
 
-        val jsMain by getting {
-            dependencies {
-                implementation(libs.kotlin.extensions)
-            }
-        }
-
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))

--- a/core/src/jsMain/kotlin/Bluetooth.kt
+++ b/core/src/jsMain/kotlin/Bluetooth.kt
@@ -4,7 +4,6 @@ import com.juul.kable.Options.Filter.Name
 import com.juul.kable.Options.Filter.NamePrefix
 import com.juul.kable.Options.Filter.Services
 import com.juul.kable.external.Bluetooth
-import kotlinext.js.jso
 import kotlinx.coroutines.CoroutineScope
 import kotlin.js.Promise
 

--- a/core/src/jsMain/kotlin/jso.kt
+++ b/core/src/jsMain/kotlin/jso.kt
@@ -1,0 +1,9 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.juul.kable
+
+// Copied from:
+// https://github.com/JetBrains/kotlin-wrappers/blob/91b2c1568ec6f779af5ec10d89b5e2cbdfe785ff/kotlin-extensions/src/main/kotlin/kotlinx/js/jso.kt
+
+internal inline fun <T : Any> jso(): T = js("({})")
+internal inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,12 @@ android-compile = "android-30"
 android-min = "21"
 atomicfu = "0.17.1"
 coroutines = "1.6.0"
-extensions = "1.0.1-pre.299-kotlin-1.6.10"
 kotlin = "1.6.10"
 tuulbox = "5.1.0"
 
 [libraries]
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-jvm", version.ref = "atomicfu" }
-kotlin-extensions = { module = "org.jetbrains.kotlin-wrappers:kotlin-extensions", version.ref = "extensions" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
Removes [Kotlin/JS extension] dependency in favor of using internal `jso` functions.
The [Kotlin/JS extension] library is upgraded frequently and has had breaking API changes, which would occasionally cause build failures for library consumers who also pulled in mismatched versions of [Kotlin/JS extension].

[Kotlin/JS extension]: https://github.com/JetBrains/kotlin-wrappers/tree/master/kotlin-extensions