### PR TITLE
Added ability to create peripheral from Platform specific identifiers

### DIFF
--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -198,6 +198,9 @@ public class AndroidPeripheral internal constructor(
     public override val services: List<DiscoveredService>?
         get() = _discoveredServices?.toList()
 
+    override val id: String
+        get() = bluetoothDevice.address
+
     @Volatile
     private var _connection: Connection? = null
     private val connection: Connection

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -123,6 +123,24 @@ public fun CoroutineScope.peripheral(
     )
 }
 
+public fun CoroutineScope.peripheral(
+    macAddress: String,
+    builderAction: PeripheralBuilderAction = {},
+): Peripheral {
+    val builder = PeripheralBuilder()
+    builder.builderAction()
+    val bluetoothDevice = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(macAddress)
+    return AndroidPeripheral(
+        coroutineContext,
+        bluetoothDevice,
+        builder.transport,
+        builder.phy,
+        builder.observationExceptionHandler,
+        builder.onServicesDiscovered,
+        builder.logging,
+    )
+}
+
 public enum class Priority { Low, Balanced, High }
 
 public class AndroidPeripheral internal constructor(

--- a/core/src/appleMain/kotlin/CentralManager.kt
+++ b/core/src/appleMain/kotlin/CentralManager.kt
@@ -41,6 +41,11 @@ public class CentralManager internal constructor() {
         if (cbCentralManager.isScanning) cbCentralManager.stopScan()
     }
 
+    internal fun retrievePeripheral(withIdentifiers: Uuid) : CBPeripheral {
+        val peripheral = cbCentralManager.retrievePeripheralsWithIdentifiers(listOf(withIdentifiers))
+        return peripheral.firstOrNull() as CBPeripheral
+    }
+
     internal suspend fun connectPeripheral(
         cbPeripheral: CBPeripheral,
         delegate: PeripheralDelegate,

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -86,6 +86,39 @@ public actual fun CoroutineScope.peripheral(
     )
 }
 
+public fun CoroutineScope.peripheral(
+    uuid: Uuid,
+    builderAction: PeripheralBuilderAction
+): Peripheral {
+    val peripheral = CentralManager.Default.retrievePeripheral(uuid)
+    val builder = PeripheralBuilder()
+    builder.builderAction()
+    return ApplePeripheral(
+        coroutineContext,
+        peripheral,
+        builder.observationExceptionHandler,
+        builder.onServicesDiscovered,
+        builder.logging
+    )
+}
+
+public fun CoroutineScope.peripheral(
+    cbPeripheral: CBPeripheral,
+    builderAction: PeripheralBuilderAction
+): Peripheral {
+    val builder = PeripheralBuilder()
+    builder.builderAction()
+    return ApplePeripheral(
+        coroutineContext,
+        cbPeripheral,
+        builder.observationExceptionHandler,
+        builder.onServicesDiscovered,
+        builder.logging
+    )
+}
+
+
+
 @OptIn(ExperimentalStdlibApi::class) // for CancellationException in @Throws
 public class ApplePeripheral internal constructor(
     parentCoroutineContext: CoroutineContext,

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -166,6 +166,9 @@ public class ApplePeripheral internal constructor(
     public override val services: List<DiscoveredService>?
         get() = _discoveredServices.value?.toList()
 
+    public override val id: String
+        get() = cbPeripheral.identifier().UUIDString
+
     private val _connection = atomic<Connection?>(null)
     private val connection: Connection
         inline get() = _connection.value ?: throw NotReadyException(toString())

--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -86,7 +86,7 @@ public actual fun CoroutineScope.peripheral(
     )
 }
 
-public fun CoroutineScope.peripheral(
+public fun CoroutineScope.peripheralFromUUID(
     uuid: Uuid,
     builderAction: PeripheralBuilderAction
 ): Peripheral {

--- a/core/src/commonMain/kotlin/Peripheral.kt
+++ b/core/src/commonMain/kotlin/Peripheral.kt
@@ -91,6 +91,17 @@ public interface Peripheral {
      */
     public val services: List<DiscoveredService>?
 
+    /**
+     * The identifier of the remote device
+     *
+     * This identifier is the identifier returned by the operating system for the address of the device.
+     * The value of the identifier will differ between operating system implementations.  On iOS
+     * the identifier is a UUID.  On Android the identifier is a MAC address.  For security reasons
+     * the identifier is not a MAC address on iOS and may be a randomized MAC on Android.  The identifier
+     * may also change.
+     */
+    public val id: String
+
     /** @throws NotReadyException if invoked without an established [connection][connect]. */
     @Throws(CancellationException::class, IOException::class, NotReadyException::class)
     public suspend fun rssi(): Int

--- a/core/src/jsMain/kotlin/Peripheral.kt
+++ b/core/src/jsMain/kotlin/Peripheral.kt
@@ -88,6 +88,9 @@ public class JsPeripheral internal constructor(
     public override val services: List<DiscoveredService>?
         get() = _discoveredServices?.toList()
 
+    override val id: String
+        get() = bluetoothDevice.id
+
     private val observationListeners = mutableMapOf<Characteristic, ObservationListener>()
 
     private val supportsAdvertisements = js("BluetoothDevice.prototype.watchAdvertisements") != null


### PR DESCRIPTION
Added functionality for creating Peripherals from MAC address on Android, and UUID / CBPeripheral on iOS