### PR TITLE
Update Android Gradle configuration and set target API to `30`

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -130,15 +130,16 @@ kotlin {
 }
 
 android {
-    compileSdkVersion(libs.versions.android.compile.get())
+    compileSdk = libs.versions.android.compile.get().toInt()
 
     defaultConfig {
-        minSdkVersion(libs.versions.android.min.get())
+        minSdk = libs.versions.android.min.get().toInt()
+        targetSdk = libs.versions.android.target.get().toInt()
     }
 
-    lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
+    lint {
+        abortOnError = true
+        warningsAsErrors = true
     }
 
     sourceSets {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
-android-compile = "android-30"
+android-compile = "30"
 android-min = "21"
+android-target = "30"
 atomicfu = "0.17.1"
 coroutines = "1.6.0"
 kotlin = "1.6.10"

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -30,15 +30,16 @@ kotlin {
 }
 
 android {
-    compileSdkVersion(libs.versions.android.compile.get())
+    compileSdk = libs.versions.android.compile.get().toInt()
 
     defaultConfig {
-        minSdkVersion(libs.versions.android.min.get())
+        minSdk = libs.versions.android.min.get().toInt()
+        targetSdk = libs.versions.android.target.get().toInt()
     }
 
-    lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
+    lint {
+        abortOnError = true
+        warningsAsErrors = true
     }
 
     sourceSets {


### PR DESCRIPTION
Replaced deprecated Android Gradle configurations with the corresponding newer version of the directives.
Set target API to `30`, as the default target API defaults to minimum API (see https://github.com/JuulLabs/sensortag/pull/90 for more details).