### PR TITLE
Add disconnect to Apple peripheral when CBCentralManager turns off

### DIFF
--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.job
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import platform.CoreBluetooth.CBCentralManagerStatePoweredOff
 import platform.CoreBluetooth.CBCharacteristicWriteType
 import platform.CoreBluetooth.CBCharacteristicWriteWithResponse
 import platform.CoreBluetooth.CBCharacteristicWriteWithoutResponse
@@ -125,6 +126,15 @@ public class ApplePeripheral internal constructor(
     internal val platformIdentifier = cbPeripheral.identifier
 
     init {
+        centralManager.delegate
+            .state
+            .filter { state -> state == CBCentralManagerStatePoweredOff }
+            .onEach {
+                disconnect()
+                _state.value = State.Disconnected()
+            }
+            .launchIn(scope)
+
         centralManager.delegate
             .connectionState
             .filter { event -> event.identifier == cbPeripheral.identifier }


### PR DESCRIPTION
This adds a disconnect to the peripheral when central manager turns off.  After IOS version 10 there is no didDisconnect callback issued when the Central manager is returned which makes it seem that the device can still be subscribed to.  This adds a disconnect to the peripheral and leaves it up to the client application to decide to reconnect or not. Refs issue #165 