### PR TITLE
Throw `BluetoothDisabledException` instead of `IllegalStateException` on scan

### DIFF
--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -35,7 +35,7 @@ public class AndroidScanner internal constructor(
         ?: error("Bluetooth not supported")
 
     public override val advertisements: Flow<Advertisement> = callbackFlow {
-        val scanner = checkNotNull(bluetoothAdapter.bluetoothLeScanner) { "Bluetooth disabled." }
+        val scanner = bluetoothAdapter.bluetoothLeScanner ?: throw BluetoothDisabledException("Bluetooth disabled.")
 
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {

--- a/core/src/androidMain/kotlin/Scanner.kt
+++ b/core/src/androidMain/kotlin/Scanner.kt
@@ -35,7 +35,7 @@ public class AndroidScanner internal constructor(
         ?: error("Bluetooth not supported")
 
     public override val advertisements: Flow<Advertisement> = callbackFlow {
-        val scanner = bluetoothAdapter.bluetoothLeScanner ?: throw BluetoothDisabledException("Bluetooth disabled.")
+        val scanner = bluetoothAdapter.bluetoothLeScanner ?: throw BluetoothDisabledException()
 
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {


### PR DESCRIPTION
When the scanner returns null on Android, use BluetoothDisabledException to catch in app.