### PR TITLE
Add `macosArm64` target to `log-engine-tuulbox`

### DIFF
--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
     iosArm64()
     macosX64()
     macosArm64()
-    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -14,10 +14,13 @@ kotlin {
         publishAllLibraryVariants()
     }
     js().browser()
+
     iosX64()
     iosArm32()
     iosArm64()
     macosX64()
+    macosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {


### PR DESCRIPTION
Adding macosArm64 target for mac M1 usage.