### PR TITLE
Simplify CI by only running on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,7 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-11]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -49,7 +46,7 @@ jobs:
             -PRELEASE_SIGNING_ENABLED=false \
             publishToMavenLocal
           fi
-        if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}
+        if: github.repository_owner == 'JuulLabs'
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Running on Ubuntu didn't provide any value as MacOS can run all the checks that Ubuntu can (and the Apple-only checks as well).