### PR TITLE
Configure release drafter for auto versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,11 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
-  - title: 'Android'
+  - title: '![Logo](https://user-images.githubusercontent.com/98017/186845159-6091676e-3923-4be6-b38f-36ee4a4a6507.png) Android'
     label: 'android'
-  - title: 'Apple'
+  - title: '![Logo](https://user-images.githubusercontent.com/98017/186844398-9e8a4bfc-b63d-48dc-b87c-d0d34645295b.png) Apple'
     label: 'apple'
-  - title: 'JavaScript'
+  - title: '![Logo](https://user-images.githubusercontent.com/98017/186845627-ad1c11bf-8727-4ff4-af14-d5ef214c8df2.png) JavaScript'
     label: 'javascript'
   - title: '🧰 Maintenance'
     labels:
@@ -12,7 +14,15 @@ categories:
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'
-template: |
-  ## 🚀 Changes
-  
-  $CHANGES
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Updated release drafts configuration:

- Created labels (`major`, `minor` and `patch`) for auto versioning
- Updated assets for platform sections

---

Assets to be used in release drafts:

| Platform | Image | License | Source |
|:-:|:-:|:-:|:-:|
| Apple | ![apple](https://user-images.githubusercontent.com/98017/186844398-9e8a4bfc-b63d-48dc-b87c-d0d34645295b.png) | [CC4](https://creativecommons.org/licenses/by-sa/4.0/deed.en) | [Wikimedia](https://commons.m.wikimedia.org/wiki/File:Mekuo.png) |
| Android | ![android](https://user-images.githubusercontent.com/98017/186845159-6091676e-3923-4be6-b38f-36ee4a4a6507.png) | [CC3](https://creativecommons.org/licenses/by/3.0/deed.en) | [Wikimedia](https://commons.wikimedia.org/wiki/File:Android_robot.png) |
| JavaScript | ![js](https://user-images.githubusercontent.com/98017/186845627-ad1c11bf-8727-4ff4-af14-d5ef214c8df2.png) | CC0 | [Free SVG](https://freesvg.org/js-logo) |

> FreeSVG.org offers free vector images in SVG format with Creative Commons 0 license (public domain). You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
It is absolutely not required, but if you like this website, any mention of or link back is highly appreciated.