### PR TITLE
Fix leak/bug in `bluetoothState` flow

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothState.kt
+++ b/core/src/androidMain/kotlin/BluetoothState.kt
@@ -8,15 +8,15 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.shareIn
 
 private val intentFilter = IntentFilter(ACTION_STATE_CHANGED)
 
-@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 internal val bluetoothState = callbackFlow {
     val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -25,7 +25,7 @@ internal val bluetoothState = callbackFlow {
         }
     }
     applicationContext.registerReceiver(receiver, intentFilter)
-    invokeOnClose {
+    awaitClose {
         applicationContext.unregisterReceiver(receiver)
     }
 }.shareIn(GlobalScope, started = WhileSubscribed(replayExpirationMillis = 0))


### PR DESCRIPTION
Current implementation incorrectly calls `invokeOnClose` when it should be using `awaitClose`.

As a result, when `bluetoothState` subscriber count drops to zero, the following failure will occur:

```
Exception in thread "DefaultDispatcher-worker-1" java.lang.IllegalStateException: 'awaitClose { yourCallbackOrListener.cancel() }' should be used in the end of callbackFlow block.
Otherwise, a callback/listener may leak in case of external cancellation.
See callbackFlow API documentation for the details.
        at kotlinx.coroutines.flow.CallbackFlowBuilder.collectTo(Builders.kt:343)
        at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend(ChannelFlow.kt:60)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
        Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@701e72, Dispatchers.Default]
```