### PR TITLE
Return device name from the scan record when available on Android

### DIFF
--- a/core/src/androidMain/kotlin/Advertisement.kt
+++ b/core/src/androidMain/kotlin/Advertisement.kt
@@ -22,7 +22,7 @@ public actual class Advertisement(
         get() = scanResult.device
 
     public actual val name: String?
-        get() = bluetoothDevice.name
+        get() = scanResult.scanRecord?.deviceName ?: bluetoothDevice.name
 
     public val address: String
         get() = bluetoothDevice.address


### PR DESCRIPTION
TLDR: Check and return device name from the advertisement scan record if available. If not return device name as before.

[As I wrote in the discussions](https://github.com/JuulLabs/kable/discussions/400) I had some issues with iBeacon devices. I noticed that on Apple devices I got more advertisements having names than the Android results. I start digging a bit and investigating and stumble upon this:
https://stackoverflow.com/questions/26290640/android-bluetoothdevice-getname-return-null and more especially:

> Advertisement data is how a client BTLE endpoint discovers a service device. A client can request a scan response and get more data. The device name is optional in this data. However, the BTLE spec requires that all Bluetooth Low Energy endpoints support the Generic Access service which is required to support the Device Name characteristic.
> ...
> Fortunately, most BTLE devices I have worked with do provide their name in the advertisement or scan response.
>
> Another possibility is that the device may place the name in the scan response part of the advertisement....

And

> On Marshmallow, utilize `ScanRecord.getDeviceName()` to retrieve the local name embedded in the scan record.
>
> `BluetoothDevice.getName()` is unreliable if the local name is included in a scan response, rather than in the immediate advertising packet.