### PR TITLE
Bump Android compile/target API to 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,33 @@ cancellation is provided to prevent connection leaks._
 
 ## Setup
 
+### Android
+
+Kable declares common bluetooth permissions but doesn't declare that bluetooth hardware is required. If your app
+requires bluetooth (and won't function without it), then the following should be added to your app's
+`AndroidManifest.xml`:
+
+```xml
+<manifest ..>
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="true"/>
+</manifest>
+```
+
+Kable declares the `BLUETOOTH_SCAN` permission with the assumption that your app will not derive physical location from
+scan results. If this is not true (and your app will derive physical location), then the following should be added to
+your app's `AndroidManifest.xml`:
+
+```xml
+<manifest ..>
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:node="remove"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+</manifest>
+```
+
 ### Gradle
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/core)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -140,6 +140,12 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+
+        // Calls to many functions on `BluetoothDevice`, `BluetoothGatt`, etc require `BLUETOOTH_CONNECT` permission,
+        // which has been specified in the `AndroidManifest.xml`; rather than needing to annotate a number of classes,
+        // we disable the "missing permission" lint check. Caution must be taken during later Android version bumps to
+        // make sure we aren't missing any newly introduced permission requirements.
+        disable += "MissingPermission"
     }
 
     sourceSets {

--- a/core/src/androidMain/AndroidManifest.xml
+++ b/core/src/androidMain/AndroidManifest.xml
@@ -5,9 +5,43 @@
     xmlns:tools="http://schemas.android.com/tools"
     >
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- Necessary to perform any Bluetooth classic or BLE communication, such as requesting a
+    connection, accepting a connection, and transferring data. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30"
+        />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30"
+        />
+
+    <!-- Not needed for apps targeting Android 9 (API 28) or lower, but there is no `minSdkVersion` attribute. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30"
+        />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30"
+        />
+
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s"
+        />
+
+    <!-- Required to call `BluetoothDevice.getName()`, `BluetoothDevice.getBondState()`, `BluetoothGatt.disconnect()`, etc. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <!-- "If you say the feature is required for your app, then the Google Play store will hide your
+    app from users on devices lacking those features. For this reason, you should only set the
+    required attribute to `true` if your app can't work without the feature."
+    — https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#features
+
+    Marked as `false` as Kable shouldn't make this decision for the consuming app. -->
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false"/>
 
     <application>
         <provider

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-android-compile = "30"
+android-compile = "31"
 android-min = "21"
-android-target = "30"
+android-target = "31"
 atomicfu = "0.18.5"
 coroutines = "1.6.4"
 kotlin = "1.7.20"


### PR DESCRIPTION
[Behavior changes: Apps targeting Android 12](https://developer.android.com/about/versions/12/behavior-changes-12) covers the changes for this target API change. The [Connectivity](https://developer.android.com/about/versions/12/behavior-changes-12#connectivity) section is most relevant for Kable, which covers the various bluetooth permission changes.