### PR TITLE
Fix regression (crash) introduced in #335

### DIFF
--- a/core/src/androidMain/kotlin/Bluetooth.kt
+++ b/core/src/androidMain/kotlin/Bluetooth.kt
@@ -10,7 +10,8 @@ import android.bluetooth.BluetoothAdapter.STATE_TURNING_ON
 import android.content.Context
 import android.content.IntentFilter
 import android.location.LocationManager
-import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.R
 import androidx.core.content.ContextCompat
 import androidx.core.location.LocationManagerCompat
 import com.juul.kable.Bluetooth.Availability.Available
@@ -53,7 +54,7 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
             }
         }
         .onStart {
-            val availability = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && !isLocationEnabled) {
+            val availability = if (SDK_INT <= R && !isLocationEnabled) {
                 Unavailable(reason = LocationServicesDisabled)
             } else {
                 when (BluetoothAdapter.getDefaultAdapter()?.isEnabled) {

--- a/core/src/androidMain/kotlin/broadcastReceiverFlow.kt
+++ b/core/src/androidMain/kotlin/broadcastReceiverFlow.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -17,6 +18,6 @@ public fun broadcastReceiverFlow(
             if (intent != null) trySend(intent)
         }
     }
-    ContextCompat.registerReceiver(applicationContext, broadcastReceiver, intentFilter, 0)
+    ContextCompat.registerReceiver(applicationContext, broadcastReceiver, intentFilter, RECEIVER_NOT_EXPORTED)
     awaitClose { applicationContext.unregisterReceiver(broadcastReceiver) }
 }


### PR DESCRIPTION
`ContextCompat` requires that you specify if the receiver is exported or not. If you don't specify a flag (and use `0`) then it will crash. Fixed by specifying `RECEIVER_NOT_EXPORTED`.