### PR TITLE
Drop `LEGACY` JavaScript compiler support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ POM_DEVELOPER_NAME=Travis Wyatt
 POM_DEVELOPER_URL=https://github.com/twyatt
 
 kotlin.js.webpack.major.version=5
-kotlin.js.compiler=both
+kotlin.js.compiler=ir
 
 # Disable BuildConfig generation for all Android modules
 android.defaults.buildfeatures.buildconfig=false


### PR DESCRIPTION
According to [KT-42289 comment](https://youtrack.jetbrains.com/issue/KT-42289/Make-the-new-JS-IR-backend-Stable#focus=Comments-27-6622643.0-0), Kotlin/JS IR backend is considered stable w/ 1.8.0, and legacy backend is now deprecated.

Closes #243