### PR TITLE
Add `Bluetooth.BaseUuid` utility for short UUIDs

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -61,6 +61,13 @@ public final class com/juul/kable/Bluetooth$Availability$Unavailable : com/juul/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/juul/kable/Bluetooth$BaseUuid {
+	public static final field INSTANCE Lcom/juul/kable/Bluetooth$BaseUuid;
+	public final fun plus (I)Ljava/util/UUID;
+	public final fun plus (J)Ljava/util/UUID;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/juul/kable/BluetoothDisabledException : com/juul/kable/BluetoothException {
 	public fun <init> ()V
 }

--- a/core/src/commonMain/kotlin/Bluetooth.kt
+++ b/core/src/commonMain/kotlin/Bluetooth.kt
@@ -1,10 +1,30 @@
 package com.juul.kable
 
+import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
 
 public expect enum class Reason
 
 public object Bluetooth {
+
+    /**
+     * Bluetooth Base UUID: `00000000-0000-1000-8000-00805F9B34FB`
+     *
+     * [Bluetooth Core Specification, Vol 3, Part B: 2.5.1 UUID](https://www.bluetooth.com/specifications/specs/?types=adopted&keyword=Core+Specification)
+     */
+    public object BaseUuid {
+
+        private const val mostSignificantBits = 4096L // 00000000-0000-1000
+        private const val leastSignificantBits = -9223371485494954757L // 8000-00805F9B34FB
+
+        public operator fun plus(shortUuid: Int): Uuid = plus(shortUuid.toLong())
+
+        /** @param shortUuid 32-bits (or less) short UUID (if larger than 32-bits, will be truncated to 32-bits). */
+        public operator fun plus(shortUuid: Long): Uuid =
+            Uuid(mostSignificantBits + (shortUuid and 0xFFFF_FFFF shl 32), leastSignificantBits)
+
+        override fun toString(): String = "00000000-0000-1000-8000-00805F9B34FB"
+    }
 
     public sealed class Availability {
 

--- a/core/src/commonTest/kotlin/BluetoothTests.kt
+++ b/core/src/commonTest/kotlin/BluetoothTests.kt
@@ -1,0 +1,47 @@
+package com.juul.kable
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BluetoothTests {
+
+    @Test
+    fun baseUuid_plusInt() {
+        assertEquals(
+            expected = "00002909-0000-1000-8000-00805F9B34FB",
+            actual = (Bluetooth.BaseUuid + 0x2909).toString().uppercase(),
+        )
+    }
+
+    @Test
+    fun baseUuid_plusIntOfFFFF() {
+        assertEquals(
+            expected = "0000FFFF-0000-1000-8000-00805F9B34FB",
+            actual = (Bluetooth.BaseUuid + 0xFFFF).toString().uppercase(),
+        )
+    }
+
+    @Test
+    fun baseUuid_plusMaxInt() {
+        assertEquals(
+            expected = "7FFFFFFF-0000-1000-8000-00805F9B34FB",
+            actual = (Bluetooth.BaseUuid + Int.MAX_VALUE).toString().uppercase(),
+        )
+    }
+
+    @Test
+    fun baseUuid_plusLongOfFFFFFFFF() {
+        assertEquals(
+            expected = "FFFFFFFF-0000-1000-8000-00805F9B34FB",
+            actual = (Bluetooth.BaseUuid + 0xFFFF_FFFF).toString().uppercase(),
+        )
+    }
+
+    @Test
+    fun baseUuid_greaterThan32bits_truncates() {
+        assertEquals(
+            expected = "FFFFFFFF-0000-1000-8000-00805F9B34FB",
+            actual = (Bluetooth.BaseUuid + 0x7FFFF_FFFF_FFFF_FFF).toString().uppercase(),
+        )
+    }
+}


### PR DESCRIPTION
Provides a convenience object for creating UUIDs from short UUIDs (i.e. 16-bit or 32-bit).

## Bluetooth Specification

The [Bluetooth Core Specification, Vol 3, Part B: 2.5.1 UUID](https://www.bluetooth.com/specifications/specs/?types=adopted&keyword=Core+Specification) states:

> To reduce the burden of storing and transferring 128-bit UUID values, a range of UUID values has been pre-allocated for assignment to often-used, registered purposes. The first UUID in this pre-allocated range is known as the Bluetooth_Base_UUID and has the value 00000000-0000-1000-8000- 00805F9B34FB. UUID values in the pre-allocated range have aliases that are represented as 16-bit or 32-bit values. These aliases are often called 16-bit and 32-bit UUIDs, but each actually represents a 128-bit UUID value.
>
> The full 128-bit value of a 16-bit or 32-bit UUID may be computed by a simple arithmetic operation.
>
> 128_bit_value = 16_bit_value * 2<sup>96</sup> + Bluetooth_Base_UUID
> 128_bit_value = 32_bit_value * 2<sup>96</sup> + Bluetooth_Base_UUID
>
> A 16-bit UUID may be converted to 32-bit UUID format by zero-extending the 16-bit value to 32-bits. An equivalent method is to add the 16-bit UUID value to a zero-valued 32-bit UUID.

## Example Usage

The first 7 entries of [Assigned Numbers: 3.4.1 Services by Name](https://www.bluetooth.com/specifications/assigned-numbers/) are listed as:

| **Service Name** | UUID |
|-|:-:|
| Alert Notification service | `0x1811` |
| Audio Input Control service | `0x1843` |
| Audio Stream Control service | `0x184E` |
| Authorization Control service | `0x183D` |
| Automation IO service | `0x1815` |
| Basic Audio Announcement service | `0x1851` |
| Battery service | `0x180F` |

These (for example) could be defined in code as:

```kotlin
val alertNotificationServiceUuid = Bluetooth.BaseUuid + 0x1811
val audioInputControlServiceUuid = Bluetooth.BaseUuid + 0x1843
val audioStreamControlServiceUuid = Bluetooth.BaseUuid + 0x184E
val authorizationControlServiceUuid = Bluetooth.BaseUuid + 0x183D
val automationIoServiceUuid = Bluetooth.BaseUuid + 0x1815
val basicAudioAnnouncementServiceUuid = Bluetooth.BaseUuid + 0x1851
val batteryServiceUuid = Bluetooth.BaseUuid + 0x180F
```