### PR TITLE
Introduce platform specific `Peripheral` interfaces

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -15,22 +15,10 @@ public final class com/juul/kable/Advertisement {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
-	public fun connect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun getName ()Ljava/lang/String;
-	public fun getServices ()Ljava/util/List;
-	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun observe (Lcom/juul/kable/Characteristic;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
-	public fun read (Lcom/juul/kable/Characteristic;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun read (Lcom/juul/kable/Descriptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun requestConnectionPriority (Lcom/juul/kable/Priority;)Z
-	public final fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun rssi (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun toString ()Ljava/lang/String;
-	public fun write (Lcom/juul/kable/Characteristic;[BLcom/juul/kable/WriteType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun write (Lcom/juul/kable/Descriptor;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract interface class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
+	public abstract fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun requestConnectionPriority (Lcom/juul/kable/Priority;)Z
+	public abstract fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/juul/kable/AndroidScanner : com/juul/kable/Scanner {

--- a/core/src/androidMain/kotlin/AndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/AndroidPeripheral.kt
@@ -1,0 +1,26 @@
+package com.juul.kable
+
+import kotlinx.coroutines.flow.StateFlow
+
+public interface AndroidPeripheral : Peripheral {
+
+    public fun requestConnectionPriority(priority: Priority): Boolean
+
+    /**
+     * Requests that the current connection's MTU be changed. Suspends until the MTU changes, or failure occurs. The
+     * negotiated MTU value is returned, which may not be [mtu] value requested if the remote peripheral negotiated an
+     * alternate MTU.
+     *
+     * @throws NotReadyException if invoked without an established [connection][Peripheral.connect].
+     * @throws GattRequestRejectedException if Android was unable to fulfill the MTU change request.
+     * @throws GattStatusException if MTU change request failed.
+     */
+    public suspend fun requestMtu(mtu: Int): Int
+
+    /**
+     * [StateFlow] of the most recently negotiated MTU. The MTU will change upon a successful request to change the MTU
+     * (via [requestMtu]), or if the peripheral initiates an MTU change. [StateFlow]'s `value` will be `null` until MTU
+     * is negotiated.
+     */
+    public val mtu: StateFlow<Int?>
+}

--- a/core/src/androidMain/kotlin/Observations.kt
+++ b/core/src/androidMain/kotlin/Observations.kt
@@ -2,10 +2,10 @@ package com.juul.kable
 
 internal actual fun Peripheral.observationHandler(): Observation.Handler = object : Observation.Handler {
     override suspend fun startObservation(characteristic: Characteristic) {
-        (this@observationHandler as AndroidPeripheral).startObservation(characteristic)
+        (this@observationHandler as BluetoothDeviceAndroidPeripheral).startObservation(characteristic)
     }
 
     override suspend fun stopObservation(characteristic: Characteristic) {
-        (this@observationHandler as AndroidPeripheral).stopObservation(characteristic)
+        (this@observationHandler as BluetoothDeviceAndroidPeripheral).stopObservation(characteristic)
     }
 }

--- a/core/src/appleMain/kotlin/ApplePeripheral.kt
+++ b/core/src/appleMain/kotlin/ApplePeripheral.kt
@@ -1,0 +1,10 @@
+package com.juul.kable
+
+@Deprecated(
+    message = "Renamed to `CoreBluetoothPeripheral`.",
+    replaceWith = ReplaceWith(
+        expression = "CoreBluetoothPeripheral",
+        imports = ["com.juul.kable.CoreBluetoothPeripheral"],
+    ),
+)
+public typealias ApplePeripheral = CoreBluetoothPeripheral

--- a/core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
+++ b/core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
@@ -1,0 +1,25 @@
+package com.juul.kable
+
+import kotlinx.coroutines.flow.Flow
+import platform.Foundation.NSData
+import kotlin.coroutines.cancellation.CancellationException
+
+public interface CoreBluetoothPeripheral : Peripheral {
+
+    @Throws(CancellationException::class, IOException::class)
+    public suspend fun write(descriptor: Descriptor, data: NSData)
+
+    @Throws(CancellationException::class, IOException::class, NotReadyException::class)
+    public suspend fun write(characteristic: Characteristic, data: NSData, writeType: WriteType)
+
+    @Throws(CancellationException::class, IOException::class, NotReadyException::class)
+    public suspend fun readAsNSData(descriptor: Descriptor): NSData
+
+    public fun observeAsNSData(
+        characteristic: Characteristic,
+        onSubscription: OnSubscriptionAction = {},
+    ): Flow<NSData>
+
+    @Throws(CancellationException::class, IOException::class, NotReadyException::class)
+    public suspend fun readAsNSData(characteristic: Characteristic): NSData
+}

--- a/core/src/appleMain/kotlin/Identifier.kt
+++ b/core/src/appleMain/kotlin/Identifier.kt
@@ -6,6 +6,6 @@ import com.benasher44.uuid.uuidFrom
 public actual typealias Identifier = Uuid
 
 public actual val Peripheral.identifier: Identifier
-    get() = (this as ApplePeripheral).platformIdentifier.toUuid()
+    get() = (this as CBPeripheralCoreBluetoothPeripheral).platformIdentifier.toUuid()
 
 public actual fun String.toIdentifier(): Identifier = uuidFrom(this)

--- a/core/src/appleMain/kotlin/Observations.kt
+++ b/core/src/appleMain/kotlin/Observations.kt
@@ -2,10 +2,10 @@ package com.juul.kable
 
 internal actual fun Peripheral.observationHandler(): Observation.Handler = object : Observation.Handler {
     override suspend fun startObservation(characteristic: Characteristic) {
-        (this@observationHandler as ApplePeripheral).startNotifications(characteristic)
+        (this@observationHandler as CBPeripheralCoreBluetoothPeripheral).startNotifications(characteristic)
     }
 
     override suspend fun stopObservation(characteristic: Characteristic) {
-        (this@observationHandler as ApplePeripheral).stopNotifications(characteristic)
+        (this@observationHandler as CBPeripheralCoreBluetoothPeripheral).stopNotifications(characteristic)
     }
 }

--- a/core/src/jsMain/kotlin/Identifier.kt
+++ b/core/src/jsMain/kotlin/Identifier.kt
@@ -3,7 +3,7 @@ package com.juul.kable
 public actual typealias Identifier = String
 
 public actual val Peripheral.identifier: Identifier
-    get() = (this as JsPeripheral).platformIdentifier
+    get() = (this as BluetoothDeviceWebBluetoothPeripheral).platformIdentifier
 
 public actual fun String.toIdentifier(): Identifier {
     return this

--- a/core/src/jsMain/kotlin/JsPeripheral.kt
+++ b/core/src/jsMain/kotlin/JsPeripheral.kt
@@ -1,0 +1,10 @@
+package com.juul.kable
+
+@Deprecated(
+    message = "Renamed to `WebBluetoothPeripheral`.",
+    replaceWith = ReplaceWith(
+        expression = "WebBluetoothPeripheral",
+        imports = ["com.juul.kable.WebBluetoothPeripheral"],
+    ),
+)
+public typealias JsPeripheral = WebBluetoothPeripheral

--- a/core/src/jsMain/kotlin/Observations.kt
+++ b/core/src/jsMain/kotlin/Observations.kt
@@ -2,10 +2,10 @@ package com.juul.kable
 
 internal actual fun Peripheral.observationHandler(): Observation.Handler = object : Observation.Handler {
     override suspend fun startObservation(characteristic: Characteristic) {
-        (this@observationHandler as JsPeripheral).startObservation(characteristic)
+        (this@observationHandler as BluetoothDeviceWebBluetoothPeripheral).startObservation(characteristic)
     }
 
     override suspend fun stopObservation(characteristic: Characteristic) {
-        (this@observationHandler as JsPeripheral).stopObservation(characteristic)
+        (this@observationHandler as BluetoothDeviceWebBluetoothPeripheral).stopObservation(characteristic)
     }
 }

--- a/core/src/jsMain/kotlin/WebBluetoothPeripheral.kt
+++ b/core/src/jsMain/kotlin/WebBluetoothPeripheral.kt
@@ -1,0 +1,13 @@
+package com.juul.kable
+
+import kotlinx.coroutines.flow.Flow
+import org.khronos.webgl.DataView
+
+public interface WebBluetoothPeripheral : Peripheral {
+    public suspend fun readAsDataView(characteristic: Characteristic): DataView
+    public suspend fun readAsDataView(descriptor: Descriptor): DataView
+    public fun observeDataView(
+        characteristic: Characteristic,
+        onSubscription: OnSubscriptionAction = {},
+    ): Flow<DataView>
+}


### PR DESCRIPTION
No change in functionality, just changing how methods are exposed (via `interface` now rather than concrete classes).

Took the opportunity to rename JavaScript and Apple interfaces to names that more appropriately represent the framework they're built on top of.