### PR TITLE
Suppress native dependency warnings to quiet AtomicFU warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
+# Disable native dependency warnings to quiet AtomicFU warnings.
+# Setting can be removed after https://youtrack.jetbrains.com/issue/KT-32476 is fixed.
+kotlin.native.ignoreIncorrectDependencies=true
+
 # Publication configuration
 # https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties
 


### PR DESCRIPTION
Warnings about AtomicFU can be quite noisy (and unhelpful). Disabling until [KT-32476](https://youtrack.jetbrains.com/issue/KT-32476) is fixed.

<details>
<summary>Example noisy logs</summary>

```
A compileOnly dependency is used in the Kotlin/Native target 'iosX64':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
A compileOnly dependency is used in the Kotlin/Native target 'macosArm64':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
A compileOnly dependency is used in the Kotlin/Native target 'iosArm32':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
A compileOnly dependency is used in the Kotlin/Native target 'iosArm64':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
A compileOnly dependency is used in the Kotlin/Native target 'iosSimulatorArm64':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
A compileOnly dependency is used in the Kotlin/Native target 'macosX64':
Compilation: main

Dependencies:
org.jetbrains.kotlinx:atomicfu:0.20.1

Such dependencies are not applicable for Kotlin/Native, consider changing the dependency type to 'implementation' or 'api'.
To disable this warning, set the kotlin.native.ignoreIncorrectDependencies=true project property
```
</details>