### PR TITLE
Bluetooth availability - monitor location service changes

### DIFF
--- a/core/src/androidMain/kotlin/Bluetooth.kt
+++ b/core/src/androidMain/kotlin/Bluetooth.kt
@@ -87,4 +87,3 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
     ) { locationEnabled, bluetoothState ->
         if (locationEnabled) bluetoothState else Unavailable(reason = LocationServicesDisabled)
     }
-

--- a/core/src/androidMain/kotlin/Bluetooth.kt
+++ b/core/src/androidMain/kotlin/Bluetooth.kt
@@ -21,9 +21,9 @@ import com.juul.kable.Reason.Off
 import com.juul.kable.Reason.TurningOff
 import com.juul.kable.Reason.TurningOn
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED as BLUETOOTH_STATE_CHANGED
@@ -47,7 +47,7 @@ private fun isLocationEnabled(): Boolean {
 
 private val locationNotNeededStateFlow: Flow<Boolean> =
     when {
-        SDK_INT > R -> MutableStateFlow(true)
+        SDK_INT > R -> flow { emit(true) }
         else -> broadcastReceiverFlow(IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION))
             .map { intent ->
                 intent.getBooleanExtra(LocationManager.EXTRA_PROVIDER_ENABLED, false)

--- a/core/src/androidMain/kotlin/Bluetooth.kt
+++ b/core/src/androidMain/kotlin/Bluetooth.kt
@@ -50,8 +50,11 @@ private val locationEnabledFlow = when {
     SDK_INT > R -> flowOf(true)
     else -> broadcastReceiverFlow(IntentFilter(PROVIDERS_CHANGED_ACTION))
         .map { intent ->
-            if (SDK_INT == R) intent.getBooleanExtra(EXTRA_PROVIDER_ENABLED, false)
-            else isLocationEnabled
+            if (SDK_INT == R) {
+                intent.getBooleanExtra(EXTRA_PROVIDER_ENABLED, false)
+            } else {
+                isLocationEnabled
+            }
         }
         .onStart { emit(isLocationEnabled) }
         .distinctUntilChanged()
@@ -84,3 +87,4 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
     ) { locationEnabled, bluetoothState ->
         if (locationEnabled) bluetoothState else Unavailable(reason = LocationServicesDisabled)
     }
+


### PR DESCRIPTION
I want to mention two things in advance.

Starting with is the usage of distinctUntilChange(). The used location filter hits more than once when the location tracking is enabled/disabled. Since we are only interested in this change we only emit on enable/disable change.

The second thing is using a function instead of property for isLocationEnabled. Sometimes, also in this context, the usage of property does not work reliably. I also read about that somewhere but cannot remember when and where. 

