### PR TITLE
Use JDK 17 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,10 +19,9 @@ plugins {
  */
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    android {
-        publishAllLibraryVariants()
-    }
+    android().publishAllLibraryVariants()
     js().browser()
     iosX64()
     macosArm64()
@@ -131,6 +130,13 @@ kotlin {
 }
 
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
 
@@ -145,12 +151,5 @@ android {
         // we disable the "missing permission" lint check. Caution must be taken during later Android version bumps to
         // make sure we aren't missing any newly introduced permission requirements.
         disable += "MissingPermission"
-    }
-
-    // Android Gradle plugin targets JVM 11 bytecode
-    // https://developer.android.com/studio/releases/gradle-plugin#7-4-0
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
     }
 }

--- a/exceptions/build.gradle.kts
+++ b/exceptions/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
  */
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 # Disable native dependency warnings to quiet AtomicFU warnings.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ android-compile = "33"
 android-min = "21"
 atomicfu = "0.20.2"
 coroutines = "1.6.4"
+jvm-toolchain = "11"
 kotlin = "1.8.21"
 tuulbox = "6.4.0"
 

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -9,10 +9,9 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    android {
-        publishAllLibraryVariants()
-    }
+    android().publishAllLibraryVariants()
     js().browser()
 
     iosX64()
@@ -32,6 +31,13 @@ kotlin {
 }
 
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
 
@@ -40,12 +46,5 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
-    }
-
-    // Android Gradle plugin targets JVM 11 bytecode
-    // https://developer.android.com/studio/releases/gradle-plugin#7-4-0
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
     }
 }


### PR DESCRIPTION
Newer versions of AGP require JDK 17:

```
An exception occurred applying plugin request [id: 'com.android.library', artifact: 'com.android.tools.build:gradle:null']
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.18-10/x64/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```