### PR TITLE
Drop `iosArm32` target

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
     js().browser()
     iosX64()
     macosArm64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
     macosX64()
@@ -98,14 +97,6 @@ kotlin {
         }
 
         val iosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosArm32Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Test by getting {
             dependsOn(appleTest)
         }
 

--- a/exceptions/build.gradle.kts
+++ b/exceptions/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
     js().browser()
     iosX64()
     macosArm64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
     macosX64()
@@ -78,14 +77,6 @@ kotlin {
         }
 
         val iosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosArm32Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Test by getting {
             dependsOn(appleTest)
         }
 

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
     js().browser()
 
     iosX64()
-    iosArm32()
     iosArm64()
     macosX64()
     macosArm64()


### PR DESCRIPTION
![Screen Shot 2023-05-01 at 2 52 34 PM](https://user-images.githubusercontent.com/98017/235538225-0c46c6bd-4d36-4074-be78-5bbcfbcfde64.png)

https://kotlinlang.org/docs/native-target-support.html#deprecated-targets