### PR TITLE
Introduce `SharedRepeatableAction` for handling connect

### DIFF
--- a/core/src/appleMain/kotlin/Peripheral.kt
+++ b/core/src/appleMain/kotlin/Peripheral.kt
@@ -175,13 +175,13 @@ internal class CBPeripheralCoreBluetoothPeripheral(
 
     private fun onDisconnected() {
         logger.info { message = "Disconnected" }
-        connectAction.cancel()
+        connectAction.reset()
         _connection.value?.close()
         _connection.value = null
     }
 
     override suspend fun connect() {
-        connectAction.getOrAsync().await()
+        connectAction.await()
     }
 
     private suspend fun establishConnection(scope: CoroutineScope) {
@@ -238,7 +238,7 @@ internal class CBPeripheralCoreBluetoothPeripheral(
 
     override suspend fun disconnect() {
         try {
-            connectAction.cancelAndJoin()
+            connectAction.resetAndJoin()
         } finally {
             withContext(NonCancellable) {
                 centralManager.cancelPeripheralConnection(cbPeripheral)

--- a/core/src/commonMain/kotlin/SharedRepeatableAction.kt
+++ b/core/src/commonMain/kotlin/SharedRepeatableAction.kt
@@ -13,19 +13,19 @@ import kotlin.coroutines.CoroutineContext
 /**
  * A mechanism for launching and awaiting a shared action ([Deferred]) repeatedly.
  *
- * The action is started by calling [getOrAsync]. Subsequent calls to [getOrAsync] will return the
- * same (i.e. shared) action if it is still executing (not [completed][Deferred.isCompleted]).
+ * The [action] is started by calling [getOrAsync]. Subsequent calls to [getOrAsync] will return the
+ * same (i.e. shared) [action] until cancelled or failure occurs.
  *
- * The [action] is passed a [scope][CoroutineScope] that can be used to spawn coroutines that
+ * The [action] is passed a [scope][CoroutineScope] that can be used to spawn coroutines that can
  * outlive the [action]. [getOrAsync] will continue to return the same action until either
- * [cancelled][cancel], or [action] has finished executing **and** all coroutines spawned from the
- * [scope][CoroutineScope] provided to [action] have completed.
+ * [cancelled][cancel], or a failures occurs in either the [action] or any coroutines spawned from
+ * the [scope][CoroutineScope] provided to [action].
  *
  * An exception thrown from [action] will cancel any coroutines spawned from the
  * [scope][CoroutineScope] that was provided to the [action].
  *
  * Calling [cancel] or [cancelAndJoin] will cancel the [action] and any coroutines created from the
- * [scope][CoroutineScope] provided to the [action]. Subsequent calls to [getOrAsync] will then
+ * [scope][CoroutineScope] provided to the [action]. A subsequent call to [getOrAsync] will then
  * start the [action] again.
  */
 internal class SharedRepeatableAction<T>(
@@ -33,11 +33,10 @@ internal class SharedRepeatableAction<T>(
     private val action: suspend (scope: CoroutineScope) -> T,
 ) {
 
-    // Hold a reference to both jobs because `action.parent` (which is `root`) becomes `null` when
-    // `action` completes before `root`.
     private class Jobs<T>(
         val root: Job,
         val action: Deferred<T>,
+        var isCancelled: Boolean = false,
     )
 
     private var jobs: Jobs<T>? = null
@@ -46,27 +45,30 @@ internal class SharedRepeatableAction<T>(
     fun getOrAsync(): Deferred<T> = guard.withLock {
         // ktlint-disable indent
         (
-            jobs?.takeUnless { it.root.isCompleted }
-                ?: run {
-                    val rootJob = Job(coroutineContext.job)
-                    val rootScope = CoroutineScope(coroutineContext + rootJob)
-                    val actionJob = rootScope.async { action(rootScope) }.apply {
-                        invokeOnCompletion { cause ->
-                            if (cause != null) this@SharedRepeatableAction.cancel()
-                        }
+            jobs?.takeUnless { it.isCancelled } ?: run {
+                val rootJob = Job(coroutineContext.job)
+                val rootScope = CoroutineScope(coroutineContext + rootJob)
+                val actionJob = rootScope.async { action(rootScope) }.apply {
+                    invokeOnCompletion { cause ->
+                        if (cause != null) this@SharedRepeatableAction.cancel()
                     }
-                    Jobs(rootJob, actionJob)
-                }.also { jobs = it }
+                }
+                Jobs(rootJob, actionJob)
+            }.also { jobs = it }
         ).action
         // ktlint-enable indent
     }
 
     fun cancel() {
-        guard.withLock { jobs }?.root?.cancel()
+        guard.withLock {
+            jobs?.apply { isCancelled = true }
+        }?.root?.cancel()
     }
 
     suspend fun cancelAndJoin() {
-        guard.withLock { jobs }?.root?.cancelAndJoin()
+        guard.withLock {
+            jobs?.apply { isCancelled = true }
+        }?.root?.cancelAndJoin()
     }
 }
 

--- a/core/src/commonMain/kotlin/SharedRepeatableAction.kt
+++ b/core/src/commonMain/kotlin/SharedRepeatableAction.kt
@@ -1,0 +1,75 @@
+package com.juul.kable
+
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A mechanism for launching and awaiting a shared action ([Deferred]) repeatedly.
+ *
+ * The action is started by calling [getOrAsync]. Subsequent calls to [getOrAsync] will return the
+ * same (i.e. shared) action if it is still executing (not [completed][Deferred.isCompleted]).
+ *
+ * The [action] is passed a [scope][CoroutineScope] that can be used to spawn coroutines that
+ * outlive the [action]. [getOrAsync] will continue to return the same action until either
+ * [cancelled][cancel], or [action] has finished executing **and** all coroutines spawned from the
+ * [scope][CoroutineScope] provided to [action] have completed.
+ *
+ * An exception thrown from [action] will cancel any coroutines spawned from the
+ * [scope][CoroutineScope] that was provided to the [action].
+ *
+ * Calling [cancel] or [cancelAndJoin] will cancel the [action] and any coroutines created from the
+ * [scope][CoroutineScope] provided to the [action]. Subsequent calls to [getOrAsync] will then
+ * start the [action] again.
+ */
+internal class SharedRepeatableAction<T>(
+    private val coroutineContext: CoroutineContext,
+    private val action: suspend (scope: CoroutineScope) -> T,
+) {
+
+    // Hold a reference to both jobs because `action.parent` (which is `root`) becomes `null` when
+    // `action` completes before `root`.
+    private class Jobs<T>(
+        val root: Job,
+        val action: Deferred<T>,
+    )
+
+    private var jobs: Jobs<T>? = null
+    private val guard = reentrantLock()
+
+    fun getOrAsync(): Deferred<T> = guard.withLock {
+        // ktlint-disable indent
+        (
+            jobs?.takeUnless { it.root.isCompleted }
+                ?: run {
+                    val rootJob = Job(coroutineContext.job)
+                    val rootScope = CoroutineScope(coroutineContext + rootJob)
+                    val actionJob = rootScope.async { action(rootScope) }.apply {
+                        invokeOnCompletion { cause ->
+                            if (cause != null) this@SharedRepeatableAction.cancel()
+                        }
+                    }
+                    Jobs(rootJob, actionJob)
+                }.also { jobs = it }
+        ).action
+        // ktlint-enable indent
+    }
+
+    fun cancel() {
+        guard.withLock { jobs }?.root?.cancel()
+    }
+
+    suspend fun cancelAndJoin() {
+        guard.withLock { jobs }?.root?.cancelAndJoin()
+    }
+}
+
+internal fun <T> CoroutineScope.sharedRepeatableAction(
+    action: suspend (scope: CoroutineScope) -> T,
+) = SharedRepeatableAction(coroutineContext, action)

--- a/core/src/commonTest/kotlin/SharedRepeatableActionTests.kt
+++ b/core/src/commonTest/kotlin/SharedRepeatableActionTests.kt
@@ -1,0 +1,127 @@
+package com.juul.kable
+
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SharedRepeatableActionTests {
+
+    @Test
+    fun exceptionThrownFromAction_cancelsCoroutinesLaunchedFromScope() = runTest {
+        supervisorScope {
+            lateinit var innerJob: Job
+            val started = MutableStateFlow(false)
+            val asserted = MutableStateFlow(false)
+
+            val action = sharedRepeatableAction { scope ->
+                innerJob = scope.launch(start = UNDISPATCHED) {
+                    awaitCancellation()
+                }
+                started.value = true
+                asserted.first { it }
+                throw IllegalStateException()
+            }
+
+            val deferred = action.getOrAsync()
+            started.first { it }
+            assertFalse { innerJob.isCompleted }
+            asserted.value = true
+
+            assertFailsWith<IllegalStateException> {
+                deferred.await()
+            }
+            assertTrue { innerJob.isCompleted }
+        }
+    }
+
+    @Test
+    fun exceptionThrownFromCoroutineLaunchedFromScope_cancelsAction() = runTest {
+        supervisorScope {
+            val action = sharedRepeatableAction { scope ->
+                scope.launch {
+                    throw IllegalStateException()
+                }
+                awaitCancellation()
+            }
+
+            assertFailsWith<CancellationException> {
+                action.getOrAsync().await()
+            }
+        }
+    }
+
+    @Test
+    fun actionIsCancelled_canStartAgain() = runTest {
+        val innerRuns = Channel<Int>()
+        var innerCounter = 0
+        val actionRuns = Channel<Int>()
+        var actionCounter = 0
+
+        val action = sharedRepeatableAction { scope ->
+            scope.launch {
+                innerRuns.send(++innerCounter)
+                awaitCancellation()
+            }
+            actionRuns.send(++actionCounter)
+            awaitCancellation()
+        }.apply { getOrAsync() }
+
+        assertEquals(
+            expected = 1,
+            actual = innerRuns.receive(),
+        )
+        assertEquals(
+            expected = 1,
+            actual = actionRuns.receive(),
+        )
+
+        action.cancelAndJoin()
+        action.getOrAsync()
+
+        assertEquals(
+            expected = 2,
+            actual = innerRuns.receive(),
+        )
+        assertEquals(
+            expected = 2,
+            actual = actionRuns.receive(),
+        )
+
+        action.cancel()
+    }
+
+    @Test
+    fun multipleCallers_allGetResultOfAction() = runTest {
+        val action = sharedRepeatableAction { scope ->
+            scope.launch(start = UNDISPATCHED) {
+                awaitCancellation()
+            }
+            1
+        }
+
+        val results = (1..10).map {
+            async { action.getOrAsync().await() }
+        }.awaitAll()
+
+        assertEquals(
+            expected = List(10) { 1 },
+            actual = results,
+        )
+
+        action.cancel()
+    }
+}


### PR DESCRIPTION
Provides a mechanism for allowing an **action** to be performed, and concurrent threads to all watch for the result; while also allowing for the **action** to be cancelled and started over again. _Useful for handling the connect process._

Based on (evolution of) the [`SharedRepeatableTask`](https://github.com/JuulLabs/kable/blob/0.23.0/core/src/jsMain/kotlin/SharedRepeatableTask.kt) class with the primary differentiator: that `SharedRepeatableAction` provides a `CoroutineScope` to the `action` that allows for coroutines to be spawned that **outlive the `action`**.

`SharedRepeatableAction` is available in `common` code but will initially only be used in Apple (and I'll migrate the other platforms over later).

Closes #339.