### PR TITLE
Reduce reliance on `CoroutineScope` within `Peripheral`

### DIFF
--- a/core/src/appleMain/kotlin/CentralManager.kt
+++ b/core/src/appleMain/kotlin/CentralManager.kt
@@ -2,6 +2,7 @@ package com.juul.kable
 
 import com.benasher44.uuid.Uuid
 import com.juul.kable.logs.Logging
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.withContext
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCharacteristic
@@ -49,13 +50,14 @@ public class CentralManager internal constructor() {
 
     internal suspend fun connectPeripheral(
         peripheral: CBPeripheralCoreBluetoothPeripheral,
+        characteristicChanges: MutableSharedFlow<ObservationEvent<NSData>>,
         logging: Logging,
         options: Map<Any?, *>? = null,
     ): Connection {
         val parentCoroutineContext = peripheral.connectionScope.coroutineContext
         val cbPeripheral = peripheral.cbPeripheral
         val identifier = cbPeripheral.identifier.UUIDString
-        val delegate = PeripheralDelegate(peripheral.canSendWriteWithoutResponse, logging, identifier)
+        val delegate = PeripheralDelegate(peripheral.canSendWriteWithoutResponse, characteristicChanges, logging, identifier)
         withContext(dispatcher) {
             cbPeripheral.delegate = delegate
             cbCentralManager.connectPeripheral(cbPeripheral, options)


### PR DESCRIPTION
In the spirit of #427, but for Apple platform.

_(small step in resolving #378)_