### PR TITLE
Use major-only version for `github-pages-deploy-action`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./gradlew dokkaHtmlMultiModule
-      - uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/dokkaHtmlMultiModule


### PR DESCRIPTION
Noticed that this action has major-only version tags available, which reduces version bump churn.