### PR TITLE
Expose `AndroidPeripheral.type`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -27,6 +27,7 @@ public final class com/juul/kable/AndroidAdvertisement$BondState : java/lang/Enu
 public abstract interface class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
 	public abstract fun getAddress ()Ljava/lang/String;
 	public abstract fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getType ()Lcom/juul/kable/AndroidPeripheral$Type;
 	public abstract fun requestConnectionPriority (Lcom/juul/kable/AndroidPeripheral$Priority;)Z
 	public abstract fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -37,6 +38,15 @@ public final class com/juul/kable/AndroidPeripheral$Priority : java/lang/Enum {
 	public static final field Low Lcom/juul/kable/AndroidPeripheral$Priority;
 	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/AndroidPeripheral$Priority;
 	public static fun values ()[Lcom/juul/kable/AndroidPeripheral$Priority;
+}
+
+public final class com/juul/kable/AndroidPeripheral$Type : java/lang/Enum {
+	public static final field Classic Lcom/juul/kable/AndroidPeripheral$Type;
+	public static final field DualMode Lcom/juul/kable/AndroidPeripheral$Type;
+	public static final field LowEnergy Lcom/juul/kable/AndroidPeripheral$Type;
+	public static final field Unknown Lcom/juul/kable/AndroidPeripheral$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/AndroidPeripheral$Type;
+	public static fun values ()[Lcom/juul/kable/AndroidPeripheral$Type;
 }
 
 public abstract interface class com/juul/kable/AndroidScanner : com/juul/kable/Scanner {

--- a/core/src/androidMain/kotlin/AndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/AndroidPeripheral.kt
@@ -1,5 +1,8 @@
 package com.juul.kable
 
+import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresPermission
 import kotlinx.coroutines.flow.StateFlow
 
 @Deprecated(
@@ -11,6 +14,46 @@ public typealias Priority = AndroidPeripheral.Priority
 public interface AndroidPeripheral : Peripheral {
 
     public enum class Priority { Low, Balanced, High }
+
+    public enum class Type {
+
+        /** https://developer.android.com/reference/android/bluetooth/BluetoothDevice#DEVICE_TYPE_CLASSIC */
+        Classic,
+
+        /**
+         * Low Energy - LE-only
+         * https://developer.android.com/reference/android/bluetooth/BluetoothDevice#DEVICE_TYPE_LE
+         */
+        LowEnergy,
+
+        /**
+         * Dual Mode - BR/EDR/LE
+         * https://developer.android.com/reference/android/bluetooth/BluetoothDevice#DEVICE_TYPE_DUAL
+         */
+        DualMode,
+
+        /** https://developer.android.com/reference/android/bluetooth/BluetoothDevice#DEVICE_TYPE_UNKNOWN */
+        Unknown,
+    }
+
+    /**
+     * Get the type of the peripheral.
+     *
+     * Per [Making Android BLE work — part 1: Clearing the cache](https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02#42d8),
+     * when [type] is [Unknown][Type.Unknown], a scan should be performed before [connect].
+     *
+     * For apps targeting [R][Build.VERSION_CODES.R] or lower, [type] requires the
+     * [BLUETOOTH][Manifest.permission.BLUETOOTH] permission which can be gained with a simple
+     * `<uses-permission>` manifest tag.
+     *
+     * For apps targeting [S][Build.VERSION_CODES.S] or or higher, [type] requires the
+     * [BLUETOOTH_CONNECT][Manifest.permission.BLUETOOTH_CONNECT] permission which can be gained
+     * with `Activity.requestPermissions(String[], int)`.
+     */
+    @get:RequiresPermission(
+        anyOf = ["android.permission.BLUETOOTH", "android.permission.BLUETOOTH_CONNECT"],
+    )
+    public val type: Type
 
     /**
      * Returns the hardware address of this [AndroidPeripheral].

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -6,6 +6,10 @@ import android.bluetooth.BluetoothAdapter.STATE_ON
 import android.bluetooth.BluetoothAdapter.STATE_TURNING_OFF
 import android.bluetooth.BluetoothAdapter.STATE_TURNING_ON
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothDevice.DEVICE_TYPE_CLASSIC
+import android.bluetooth.BluetoothDevice.DEVICE_TYPE_DUAL
+import android.bluetooth.BluetoothDevice.DEVICE_TYPE_LE
+import android.bluetooth.BluetoothDevice.DEVICE_TYPE_UNKNOWN
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic.PROPERTY_INDICATE
 import android.bluetooth.BluetoothGattCharacteristic.PROPERTY_NOTIFY
@@ -15,6 +19,7 @@ import android.bluetooth.BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
 import com.benasher44.uuid.uuidFrom
+import com.juul.kable.AndroidPeripheral.Type
 import com.juul.kable.WriteType.WithResponse
 import com.juul.kable.WriteType.WithoutResponse
 import com.juul.kable.external.CLIENT_CHARACTERISTIC_CONFIG_UUID
@@ -186,6 +191,9 @@ internal class BluetoothDeviceAndroidPeripheral(
         // Avoid trampling existing `Disconnected` state (and its properties) by only updating if not already `Disconnected`.
         _state.update { previous -> previous as? State.Disconnected ?: State.Disconnected() }
     }
+
+    override val type: Type
+        get() = typeFrom(bluetoothDevice.type)
 
     override val address: String = bluetoothDevice.address
 
@@ -463,4 +471,12 @@ public actual fun String.toIdentifier(): Identifier {
         "MAC Address has invalid format: $this"
     }
     return this
+}
+
+private fun typeFrom(value: Int): Type = when (value) {
+    DEVICE_TYPE_UNKNOWN -> Type.Unknown
+    DEVICE_TYPE_CLASSIC -> Type.Classic
+    DEVICE_TYPE_DUAL -> Type.DualMode
+    DEVICE_TYPE_LE -> Type.LowEnergy
+    else -> error("Unsupported device type: $value")
 }


### PR DESCRIPTION
Needed for checking the state of the Android BLE cache, when making the decision if scanning is needed before reconnecting to a peripheral.

From `AndroidPeripheral.type` KDoc:

> Per [Making Android BLE work — part 1: Clearing the cache](https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02#42d8), when `type` is `Unknown`, a scan should be performed before attempting to `connect`.