### PR TITLE
Use `gradle/gradle-build-action@v2` to simplify CI scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   pull_request:
+  # Trigger on merges to `main` to allow `gradle/gradle-build-action` runs to write their caches.
+  # https://github.com/gradle/gradle-build-action#using-the-caches-read-only
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -13,36 +18,21 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: actions/cache@v3
+      - name: assemble
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-            ~/.android/build-cache
-            ~/.android/cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          arguments: assemble
 
-      - run: ./gradlew assemble
-      - run: ./gradlew check
+      - name: check
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
 
-      - run: |
-          set -o xtrace
-          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
-            ./gradlew \
-            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
-            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
-            publishToMavenLocal
-          else
-            ./gradlew \
-            -PRELEASE_SIGNING_ENABLED=false \
-            publishToMavenLocal
-          fi
+      - name: publishToMavenLocal
         if: github.repository_owner == 'JuulLabs'
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+            publishToMavenLocal

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,11 +9,18 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
-      - run: ./gradlew dokkaHtmlMultiModule
+
+      - name: dokkaHtmlMultiModule
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+          arguments: dokkaHtmlMultiModule
+
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/dokkaHtmlMultiModule

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,29 +15,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: actions/cache@v3
+      - name: check
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-            ~/.android/build-cache
-            ~/.android/cache
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-publish-
-            ${{ runner.os }}-
+          arguments: check
 
-      - run: ./gradlew check
-      - run: >-
-          ./gradlew
-          -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
-          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
-          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
-          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
-          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
-          publish
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
+      - name: publish
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PVERSION_NAME=${{ github.ref_name }}
+            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+            -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+            -PmavenCentralPassword=${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+            publish


### PR DESCRIPTION
Uses `gradle/gradle-build-action` for Gradle runs (to leverage built-in caching configuration).