### PR TITLE
Remove redundant logging of peripheral identifier

### DIFF
--- a/core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -87,7 +87,7 @@ internal class PeripheralDelegate(
         didDiscoverServices: NSError?,
     ) {
         logger.debug {
-            message = "${peripheral.identifier} didDiscoverServices"
+            message = "didDiscoverServices"
             detail(didDiscoverServices)
         }
         _response.sendBlocking(DidDiscoverServices(peripheral.identifier, didDiscoverServices))
@@ -101,7 +101,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didDiscoverIncludedServicesForService"
+            message = "didDiscoverIncludedServicesForService"
             detail(didDiscoverIncludedServicesForService)
         }
         // todo
@@ -117,7 +117,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didDiscoverCharacteristicsForService"
+            message = "didDiscoverCharacteristicsForService"
             detail(didDiscoverCharacteristicsForService)
         }
         _response.sendBlocking(
@@ -137,7 +137,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didDiscoverDescriptorsForCharacteristic"
+            message = "didDiscoverDescriptorsForCharacteristic"
             detail(didDiscoverDescriptorsForCharacteristic)
         }
         // todo
@@ -153,7 +153,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didUpdateValueForCharacteristic"
+            message = "didUpdateValueForCharacteristic"
             detail(didUpdateValueForCharacteristic)
             detail(didUpdateValueForCharacteristic.value)
         }
@@ -179,7 +179,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didUpdateValueForDescriptor"
+            message = "didUpdateValueForDescriptor"
             detail(didUpdateValueForDescriptor)
         }
         _response.sendBlocking(
@@ -197,7 +197,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didWriteValueForCharacteristic"
+            message = "didWriteValueForCharacteristic"
             detail(didWriteValueForCharacteristic)
         }
         _response.sendBlocking(
@@ -217,7 +217,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didWriteValueForDescriptor"
+            message = "didWriteValueForDescriptor"
             detail(didWriteValueForDescriptor)
         }
         // todo
@@ -227,7 +227,7 @@ internal class PeripheralDelegate(
         peripheral: CBPeripheral,
     ) {
         logger.debug {
-            message = "${peripheral.identifier} peripheralIsReadyToSendWriteWithoutResponse"
+            message = "peripheralIsReadyToSendWriteWithoutResponse"
         }
         canSendWriteWithoutResponse.value = true
     }
@@ -242,7 +242,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didUpdateNotificationStateForCharacteristic"
+            message = "didUpdateNotificationStateForCharacteristic"
             detail(didUpdateNotificationStateForCharacteristic)
         }
         _response.sendBlocking(
@@ -262,7 +262,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didReadRSSI"
+            message = "didReadRSSI"
             detail("rssi", didReadRSSI.stringValue)
         }
         _response.sendBlocking(DidReadRssi(peripheral.identifier, didReadRSSI, error))
@@ -272,7 +272,7 @@ internal class PeripheralDelegate(
 
     override fun peripheralDidUpdateName(peripheral: CBPeripheral) {
         logger.debug {
-            message = "${peripheral.identifier} peripheralDidUpdateName"
+            message = "peripheralDidUpdateName"
         }
         // todo
     }
@@ -282,7 +282,7 @@ internal class PeripheralDelegate(
         didModifyServices: List<*>,
     ) {
         logger.debug {
-            message = "${peripheral.identifier} didModifyServices"
+            message = "didModifyServices"
         }
         // todo
     }
@@ -295,7 +295,7 @@ internal class PeripheralDelegate(
         error: NSError?,
     ) {
         logger.debug(error) {
-            message = "${peripheral.identifier} didOpenL2CAPChannel"
+            message = "didOpenL2CAPChannel"
         }
         // todo
     }


### PR DESCRIPTION
Example logs (from SensorTag sample app) shown with the redundant identifier (that this PR removes):

<img width="1695" alt="Screenshot 2023-06-13 at 10 43 04 AM" src="https://github.com/JuulLabs/kable/assets/98017/fb073d4b-6b29-40a2-bf9d-8af778b5af47">

_This occurs because `logger`s are already configured to log the `identifier`:_

https://github.com/JuulLabs/kable/blob/40973d5f50dd4346510f25dcd6296c62053c4cc6/core/src/appleMain/kotlin/PeripheralDelegate.kt#L81