### PR TITLE
Use `SharedRepeatableAction` for managing connect process

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -145,5 +145,7 @@ android {
         // we disable the "missing permission" lint check. Caution must be taken during later Android version bumps to
         // make sure we aren't missing any newly introduced permission requirements.
         disable += "MissingPermission"
+
+        disable += "GradleDependency"
     }
 }

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -75,10 +75,6 @@ internal fun BluetoothDevice.connect(
     logging: Logging,
     threading: Threading,
 ): Connection? {
-    // Explicitly set Connecting state so when Peripheral is suspending until Connected, it doesn't incorrectly see
-    // Disconnected before the connection request has kicked off the Connecting state (via Callback).
-    state.value = State.Connecting.Bluetooth
-
     val callback = Callback(state, mtu, onCharacteristicChanged, logging, address)
 
     val bluetoothGatt = when {

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -15,12 +15,12 @@ import android.os.HandlerThread
 import com.juul.kable.gatt.Callback
 import com.juul.kable.logs.Logging
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.newSingleThreadContext
-import kotlin.coroutines.CoroutineContext
 
 internal sealed class Threading {
 
@@ -65,7 +65,7 @@ internal fun BluetoothDevice.threading(): Threading =
  * @param phy is only used on API level >= 26.
  */
 internal fun BluetoothDevice.connect(
-    parentCoroutineContext: CoroutineContext,
+    scope: CoroutineScope,
     context: Context,
     transport: Transport,
     phy: Phy,
@@ -74,7 +74,6 @@ internal fun BluetoothDevice.connect(
     onCharacteristicChanged: MutableSharedFlow<ObservationEvent<ByteArray>>,
     logging: Logging,
     threading: Threading,
-    invokeOnClose: () -> Unit,
 ): Connection? {
     // Explicitly set Connecting state so when Peripheral is suspending until Connected, it doesn't incorrectly see
     // Disconnected before the connection request has kicked off the Connecting state (via Callback).
@@ -91,7 +90,7 @@ internal fun BluetoothDevice.connect(
         else -> connectGatt(context, false, callback)
     } ?: return null
 
-    return Connection(parentCoroutineContext, bluetoothGatt, threading.dispatcher, callback, logging, invokeOnClose)
+    return Connection(scope, bluetoothGatt, threading.dispatcher, callback, logging)
 }
 
 private val Transport.intValue: Int


### PR DESCRIPTION
Continuation of migration to `SharedRepeatableAction` for Android (see #488 for previous migration of Apple platform).