### PR TITLE
Fix regression w/ pulling in AtomicFU dependency

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -59,6 +59,10 @@ kotlin {
                 api(libs.kotlinx.coroutines.android)
                 implementation(libs.androidx.core)
                 implementation(libs.androidx.startup)
+
+                // Workaround for AtomicFU plugin not automatically adding JVM dependency for Android.
+                // https://github.com/Kotlin/kotlinx-atomicfu/issues/145
+                implementation(libs.atomicfu)
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 android-compile = "33"
 android-min = "21"
+atomicfu = "0.21.0"
 coroutines = "1.7.2"
 jvm-toolchain = "11"
 kotlin = "1.8.22"
@@ -9,16 +10,17 @@ tuulbox = "6.4.1"
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version = "1.10.1" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-tuulbox-logging = { module = "com.juul.tuulbox:logging", version.ref = "tuulbox" }
 tuulbox-collections = { module = "com.juul.tuulbox:collections", version.ref = "tuulbox" }
+tuulbox-logging = { module = "com.juul.tuulbox:logging", version.ref = "tuulbox" }
 uuid = { module = "com.benasher44:uuid", version = "0.7.1" }
 
 [plugins]
 android-library = { id = "com.android.library", version = "8.0.2" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.21.0" }
+atomicfu = { id = "kotlinx-atomicfu", version.ref = "atomicfu" }
 dokka = { id = "org.jetbrains.dokka", version = "1.8.20" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.15.0" }


### PR DESCRIPTION
In #511 AtomicFU was upgraded. In #511, I "cleaned up" the AtomicFU dependency, only to later learn that [AtomicFU plugin doesn't automatically add the dependency for Android source sets](https://github.com/Kotlin/kotlinx-atomicfu/issues/145).

Fixes #519 by explicitly adding the AtomicFU dependency for the Android source set.