### PR TITLE
Only sign local Maven publication on merges to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,8 @@ jobs:
           arguments: check
 
       - name: publishToMavenLocal
-        if: github.repository_owner == 'JuulLabs'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+            -PRELEASE_SIGNING_ENABLED=false
             publishToMavenLocal

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,0 +1,25 @@
+name: Validate Maven Signing
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  signing:
+    if: github.repository_owner == 'JuulLabs'
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: publishToMavenLocal
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+            publishToMavenLocal


### PR DESCRIPTION
Performs publication signing for local Maven publication only for commits on `main`. This should allow external contributions to run local Maven publications w/o signing and once merged to `main` will validate that publication signing is configured properly.

Closes #529