### PR TITLE
Swap dispatch_sync to dispatch_async in NativeDarwin QueueDispatcher

### DIFF
--- a/core/src/appleMain/kotlin/QueueDispatcher.kt
+++ b/core/src/appleMain/kotlin/QueueDispatcher.kt
@@ -2,9 +2,9 @@ package com.juul.kable
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Runnable
+import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
 import platform.darwin.dispatch_queue_t
-import platform.darwin.dispatch_sync
 import kotlin.coroutines.CoroutineContext
 
 internal class QueueDispatcher(
@@ -14,7 +14,7 @@ internal class QueueDispatcher(
     val dispatchQueue: dispatch_queue_t = dispatch_queue_create(label, attr = null)
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        dispatch_sync(dispatchQueue) {
+        dispatch_async(dispatchQueue) {
             block.run()
         }
     }


### PR DESCRIPTION
Resolves https://github.com/JuulLabs/kable/issues/308

`dispatch` being implemented with a synchronous call frequently caused deadlocks--which would lead to hangs or crashes for the NativeDarwin consumer. Changing to an asynchronous addition to the queue fixes this.