### PR TITLE
CA-2351: Enable iOS Backgrounding

### DIFF
--- a/core/src/appleMain/kotlin/CentralManager.kt
+++ b/core/src/appleMain/kotlin/CentralManager.kt
@@ -12,9 +12,11 @@ import platform.CoreBluetooth.CBDescriptor
 import platform.CoreBluetooth.CBPeripheral
 import platform.CoreBluetooth.CBService
 import platform.CoreBluetooth.CBUUID
+import platform.CoreBluetooth.CBCentralManagerOptionRestoreIdentifierKey
 import platform.Foundation.NSData
 
 private const val DISPATCH_QUEUE_LABEL = "central"
+private const val CBCENTRALMANAGER_RESTORATION_ID = "kable-central-manager" // add a unique id to it
 
 public class CentralManager internal constructor() {
 
@@ -24,7 +26,8 @@ public class CentralManager internal constructor() {
 
     private val dispatcher = QueueDispatcher(DISPATCH_QUEUE_LABEL)
     internal val delegate = CentralManagerDelegate()
-    private val cbCentralManager = CBCentralManager(delegate, dispatcher.dispatchQueue)
+    private val cbOptions = mutableMapOf<Any?, Any>(CBCentralManagerOptionRestoreIdentifierKey to CBCENTRALMANAGER_RESTORATION_ID).toMap()
+    private val cbCentralManager = CBCentralManager(delegate, dispatcher.dispatchQueue, cbOptions)
 
     internal suspend fun scanForPeripheralsWithServices(
         services: List<Uuid>?,

--- a/core/src/appleMain/kotlin/CentralManager.kt
+++ b/core/src/appleMain/kotlin/CentralManager.kt
@@ -6,13 +6,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.withContext
 import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBCentralManagerOptionRestoreIdentifierKey
 import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBCharacteristicWriteType
 import platform.CoreBluetooth.CBDescriptor
 import platform.CoreBluetooth.CBPeripheral
 import platform.CoreBluetooth.CBService
 import platform.CoreBluetooth.CBUUID
-import platform.CoreBluetooth.CBCentralManagerOptionRestoreIdentifierKey
 import platform.Foundation.NSData
 import platform.Foundation.NSUUID
 import platform.Foundation.NSUserDefaults

--- a/core/src/appleMain/kotlin/CentralManager.kt
+++ b/core/src/appleMain/kotlin/CentralManager.kt
@@ -33,16 +33,10 @@ public class CentralManager internal constructor() {
     // do not cross pollinate restored instances of CBCentralManager. The value will live for the
     // lifetime of the consuming app.
     private val consumerId: String
-        get() {
-            val id = userDefaults.stringForKey(CBCENTRALMANAGER_CONSUMER_ID_KEY)
-            return if (id != null) {
-                id
-            } else {
-                val id = NSUUID().UUIDString()
-                userDefaults.setObject(id, CBCENTRALMANAGER_CONSUMER_ID_KEY)
-                id
+        get() = userDefaults.stringForKey(CBCENTRALMANAGER_CONSUMER_ID_KEY)
+            ?: NSUUID().UUIDString().also {
+                userDefaults.setObject(it, CBCENTRALMANAGER_CONSUMER_ID_KEY)
             }
-        }
 
     private val dispatcher = QueueDispatcher(DISPATCH_QUEUE_LABEL)
     internal val delegate = CentralManagerDelegate()

--- a/core/src/appleMain/kotlin/CentralManagerDelegate.kt
+++ b/core/src/appleMain/kotlin/CentralManagerDelegate.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
+import platform.CoreBluetooth.CBCentralManagerRestoredStatePeripheralsKey
 import platform.CoreBluetooth.CBManagerState
 import platform.CoreBluetooth.CBManagerStateUnknown
 import platform.CoreBluetooth.CBPeripheral
@@ -73,6 +74,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         central: CBCentralManager,
         didConnectPeripheral: CBPeripheral,
     ) {
+        println("Batman: Connected!")
         _connectionState.emitBlocking(DidConnect(didConnectPeripheral.identifier))
     }
 
@@ -82,6 +84,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         didDisconnectPeripheral: CBPeripheral,
         error: NSError?,
     ) {
+        println("Batman: Disconnected!")
         _onDisconnected.emitBlocking(didDisconnectPeripheral.identifier) // Used to notify `Peripheral` of disconnect.
         _connectionState.emitBlocking(DidDisconnect(didDisconnectPeripheral.identifier, error))
     }
@@ -92,6 +95,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         didFailToConnectPeripheral: CBPeripheral,
         error: NSError?,
     ) {
+        println("Batman: Failed to connect!")
         _connectionState.emitBlocking(DidFailToConnect(didFailToConnectPeripheral.identifier, error))
     }
 
@@ -121,6 +125,10 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
     }
 
     // todo: func centralManager(CBCentralManager, willRestoreState: [String : Any])
+    override fun centralManager(central: CBCentralManager, willRestoreState: Map<Any?, *>) {
+//        val peripherals = willRestoreState[CBCentralManagerRestoredStatePeripheralsKey]
+        // NO OP
+    }
 
     /* Monitoring the Central Manager’s Authorization */
 

--- a/core/src/appleMain/kotlin/CentralManagerDelegate.kt
+++ b/core/src/appleMain/kotlin/CentralManagerDelegate.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
-import platform.CoreBluetooth.CBCentralManagerRestoredStatePeripheralsKey
 import platform.CoreBluetooth.CBManagerState
 import platform.CoreBluetooth.CBManagerStateUnknown
 import platform.CoreBluetooth.CBPeripheral
@@ -74,7 +73,6 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         central: CBCentralManager,
         didConnectPeripheral: CBPeripheral,
     ) {
-        println("Batman: Connected!")
         _connectionState.emitBlocking(DidConnect(didConnectPeripheral.identifier))
     }
 
@@ -84,7 +82,6 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         didDisconnectPeripheral: CBPeripheral,
         error: NSError?,
     ) {
-        println("Batman: Disconnected!")
         _onDisconnected.emitBlocking(didDisconnectPeripheral.identifier) // Used to notify `Peripheral` of disconnect.
         _connectionState.emitBlocking(DidDisconnect(didDisconnectPeripheral.identifier, error))
     }
@@ -95,7 +92,6 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         didFailToConnectPeripheral: CBPeripheral,
         error: NSError?,
     ) {
-        println("Batman: Failed to connect!")
         _connectionState.emitBlocking(DidFailToConnect(didFailToConnectPeripheral.identifier, error))
     }
 
@@ -124,9 +120,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         _state.value = central.state
     }
 
-    // todo: func centralManager(CBCentralManager, willRestoreState: [String : Any])
     override fun centralManager(central: CBCentralManager, willRestoreState: Map<Any?, *>) {
-//        val peripherals = willRestoreState[CBCentralManagerRestoredStatePeripheralsKey]
         // NO OP
     }
 

--- a/core/src/appleMain/kotlin/QueueDispatcher.kt
+++ b/core/src/appleMain/kotlin/QueueDispatcher.kt
@@ -2,9 +2,9 @@ package com.juul.kable
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Runnable
+import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
 import platform.darwin.dispatch_queue_t
-import platform.darwin.dispatch_sync
 import kotlin.coroutines.CoroutineContext
 
 internal class QueueDispatcher(
@@ -14,7 +14,7 @@ internal class QueueDispatcher(
     val dispatchQueue: dispatch_queue_t = dispatch_queue_create(label, attr = null)
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        dispatch_sync(dispatchQueue) {
+        dispatch_async(dispatchQueue) {
             block.run()
         }
     }

--- a/core/src/appleMain/kotlin/ScannerBuilder.kt
+++ b/core/src/appleMain/kotlin/ScannerBuilder.kt
@@ -1,12 +1,10 @@
 package com.juul.kable
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuidFrom
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.LoggingBuilder
 import platform.CoreBluetooth.CBCentralManagerScanOptionAllowDuplicatesKey
 import platform.CoreBluetooth.CBCentralManagerScanOptionSolicitedServiceUUIDsKey
-import platform.CoreBluetooth.CBUUID
 import platform.Foundation.NSArray
 
 public actual class ScannerBuilder {
@@ -24,7 +22,7 @@ public actual class ScannerBuilder {
      * array. This corresponds to Core Bluetooth's [CBCentralManagerScanOptionSolicitedServiceUUIDsKey]
      * scanning option.
      */
-    public var solicitedServiceUuids: List<Uuid>? = null//listOf(uuidFrom("23584b66-2c3c-09f2-cf3f-bc60bda79d4b")) //null
+    public var solicitedServiceUuids: List<Uuid>? = null
 
     private var logging: Logging = Logging()
 
@@ -37,10 +35,8 @@ public actual class ScannerBuilder {
         allowDuplicateKeys?.also {
             options[CBCentralManagerScanOptionAllowDuplicatesKey] = it
         }
-        solicitedServiceUuids?.also {
-            val cbArray = it.map { it.toCBUUID() }
-//            val nsArray = NSArray()
-            options[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = cbArray as NSArray //.toTypedArray()
+        solicitedServiceUuids?.also { uuids ->
+            options[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = uuids.map { it.toCBUUID() } as NSArray
         }
 
         return CentralManagerCoreBluetoothScanner(

--- a/core/src/appleMain/kotlin/ScannerBuilder.kt
+++ b/core/src/appleMain/kotlin/ScannerBuilder.kt
@@ -1,10 +1,13 @@
 package com.juul.kable
 
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.LoggingBuilder
 import platform.CoreBluetooth.CBCentralManagerScanOptionAllowDuplicatesKey
 import platform.CoreBluetooth.CBCentralManagerScanOptionSolicitedServiceUUIDsKey
+import platform.CoreBluetooth.CBUUID
+import platform.Foundation.NSArray
 
 public actual class ScannerBuilder {
 
@@ -21,7 +24,7 @@ public actual class ScannerBuilder {
      * array. This corresponds to Core Bluetooth's [CBCentralManagerScanOptionSolicitedServiceUUIDsKey]
      * scanning option.
      */
-    public var solicitedServiceUuids: List<Uuid>? = null
+    public var solicitedServiceUuids: List<Uuid>? = null//listOf(uuidFrom("23584b66-2c3c-09f2-cf3f-bc60bda79d4b")) //null
 
     private var logging: Logging = Logging()
 
@@ -35,7 +38,9 @@ public actual class ScannerBuilder {
             options[CBCentralManagerScanOptionAllowDuplicatesKey] = it
         }
         solicitedServiceUuids?.also {
-            options[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = it.toTypedArray()
+            val cbArray = it.map { it.toCBUUID() }
+//            val nsArray = NSArray()
+            options[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = cbArray as NSArray //.toTypedArray()
         }
 
         return CentralManagerCoreBluetoothScanner(


### PR DESCRIPTION
This PR allows Apple consumers to take advantage of being woken up in the background to receive BLE events (i.e. device connect/disconnect). 

Also fixes a crash that would occur when the consumer used solicitedServiceUuids--which is needed by the OS to wake up the app.