### PR TITLE
Workaround for CBATTErrorDomain Code=14 "Peer removed pairing information"

### DIFF
--- a/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -163,7 +163,7 @@ internal class CBPeripheralCoreBluetoothPeripheral(
 
             // fixme: Handle centralManager:didFailToConnectPeripheral:error:
             // https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/1518988-centralmanager
-            suspendUntil<State.Connecting.Services>()
+            suspendUntilOrThrow<State.Connecting.Services>()
             discoverServices()
             onServicesDiscovered(ServicesDiscoveredPeripheral(this@CBPeripheralCoreBluetoothPeripheral))
 


### PR DESCRIPTION
Please see this thread https://developer.apple.com/forums/thread/132488

When we receive CBATTErrorDomain with code 14 is necessary to remove pairing information manually in bluetooth console. The app must advise the user in a friendly way, which is not scope of kable.

With `suspendUntil<State.Connecting.Services>()` the app hangs. So, it is necessary replace by `suspendUntilOrThrow<State.Connecting.Services>().`

In the app we can catch the exception and advising the user correctly:

```
try {
   peripheral.connect()
 } catch (e: ConnectionLostException) {
   if (verifyPlatform() == VerifyPlatform.IOS) {
         val st = peripheral.state.first()
         if (st is State.Disconnected && (st.status as State.Disconnected.Status.Unknown).status == 14) {
             // advise the user correctly
         }
    }
}
```

Thanks

Closes #334