### PR TITLE
Fix Android's scanner behavior when bluetooth is off

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothAdapter.kt
+++ b/core/src/androidMain/kotlin/BluetoothAdapter.kt
@@ -21,3 +21,27 @@ internal fun getBluetoothAdapterOrNull(): BluetoothAdapter? =
 
 internal fun getBluetoothAdapter(): BluetoothAdapter =
     getBluetoothAdapterOrNull() ?: error("Bluetooth not supported")
+
+
+/**
+ * Explicitly check the adapter state before connecting in order to respect system settings.
+ * Android doesn't actually turn bluetooth off when the setting is disabled, so without this
+ * check we're able to reconnect the device illegally.
+ */
+internal fun checkBluetoothAdapterState(
+    expected: Int,
+) {
+    fun nameFor(value: Int) = when (value) {
+        BluetoothAdapter.STATE_OFF -> "Off"
+        BluetoothAdapter.STATE_ON -> "On"
+        BluetoothAdapter.STATE_TURNING_OFF -> "TurningOff"
+        BluetoothAdapter.STATE_TURNING_ON -> "TurningOn"
+        else -> "Unknown"
+    }
+    val actual = getBluetoothAdapter().state
+    if (expected != actual) {
+        val actualName = nameFor(actual)
+        val expectedName = nameFor(expected)
+        throw BluetoothDisabledException("Bluetooth adapter state is $actualName ($actual), but $expectedName ($expected) was required.")
+    }
+}

--- a/core/src/androidMain/kotlin/BluetoothAdapter.kt
+++ b/core/src/androidMain/kotlin/BluetoothAdapter.kt
@@ -22,7 +22,6 @@ internal fun getBluetoothAdapterOrNull(): BluetoothAdapter? =
 internal fun getBluetoothAdapter(): BluetoothAdapter =
     getBluetoothAdapterOrNull() ?: error("Bluetooth not supported")
 
-
 /**
  * Explicitly check the adapter state before connecting in order to respect system settings.
  * Android doesn't actually turn bluetooth off when the setting is disabled, so without this

--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -2,8 +2,6 @@ package com.juul.kable
 
 import android.bluetooth.BluetoothAdapter.STATE_OFF
 import android.bluetooth.BluetoothAdapter.STATE_ON
-import android.bluetooth.BluetoothAdapter.STATE_TURNING_OFF
-import android.bluetooth.BluetoothAdapter.STATE_TURNING_ON
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothDevice.DEVICE_TYPE_CLASSIC
 import android.bluetooth.BluetoothDevice.DEVICE_TYPE_DUAL

--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -403,29 +403,6 @@ private val PlatformCharacteristic.supportsNotify: Boolean
 private val PlatformCharacteristic.supportsIndicate: Boolean
     get() = properties and PROPERTY_INDICATE != 0
 
-/**
- * Explicitly check the adapter state before connecting in order to respect system settings.
- * Android doesn't actually turn bluetooth off when the setting is disabled, so without this
- * check we're able to reconnect the device illegally.
- */
-private fun checkBluetoothAdapterState(
-    expected: Int,
-) {
-    fun nameFor(value: Int) = when (value) {
-        STATE_OFF -> "Off"
-        STATE_ON -> "On"
-        STATE_TURNING_OFF -> "TurningOff"
-        STATE_TURNING_ON -> "TurningOn"
-        else -> "Unknown"
-    }
-    val actual = getBluetoothAdapter().state
-    if (expected != actual) {
-        val actualName = nameFor(actual)
-        val expectedName = nameFor(expected)
-        throw BluetoothDisabledException("Bluetooth adapter state is $actualName ($actual), but $expectedName ($expected) was required.")
-    }
-}
-
 private fun typeFrom(value: Int): Type = when (value) {
     DEVICE_TYPE_UNKNOWN -> Type.Unknown
     DEVICE_TYPE_CLASSIC -> Type.Classic

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -75,6 +75,8 @@ internal class BluetoothLeScannerAndroidScanner(
             }.build()
         }
 
+        checkBluetoothAdapterState(BluetoothAdapter.STATE_ON)
+
         logger.info {
             message = if (scanFilters.isEmpty()) {
                 "Starting scan without filters"

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -1,6 +1,7 @@
 package com.juul.kable
 
 import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter.STATE_ON
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
@@ -75,7 +76,7 @@ internal class BluetoothLeScannerAndroidScanner(
             }.build()
         }
 
-        checkBluetoothAdapterState(BluetoothAdapter.STATE_ON)
+        checkBluetoothAdapterState(STATE_ON)
 
         logger.info {
             message = if (scanFilters.isEmpty()) {

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -76,8 +76,6 @@ internal class BluetoothLeScannerAndroidScanner(
             }.build()
         }
 
-        checkBluetoothAdapterState(STATE_ON)
-
         logger.info {
             message = if (scanFilters.isEmpty()) {
                 "Starting scan without filters"
@@ -85,6 +83,7 @@ internal class BluetoothLeScannerAndroidScanner(
                 "Starting scan with ${scanFilters.size} filter(s)"
             }
         }
+        checkBluetoothAdapterState(STATE_ON)
         scanner.startScan(scanFilters, scanSettings, callback)
 
         awaitClose {


### PR DESCRIPTION
Pre this fix, `startScan` would fail internally on high/recent OS versions and the scanner callbacks would never be called.