### PR TITLE
Disable `GradleDependency` Android lint check

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -145,5 +145,7 @@ android {
         // we disable the "missing permission" lint check. Caution must be taken during later Android version bumps to
         // make sure we aren't missing any newly introduced permission requirements.
         disable += "MissingPermission"
+
+        disable += "GradleDependency"
     }
 }


### PR DESCRIPTION
Since we have `warningsAsErrors`, this warning lint check unnecessarily fails the build.