### PR TITLE
Add support for `autoConnect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ On Android targets, additional configuration options are available (all configur
 
 ```kotlin
 val peripheral = scope.peripheral(advertisement) {
+    autoConnectIf { true }
     onServicesDiscovered {
         requestMtu(...)
     }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -287,11 +287,13 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 }
 
 public final class com/juul/kable/PeripheralBuilder {
+	public final fun getAutoConnect ()Z
 	public final fun getPhy ()Lcom/juul/kable/Phy;
 	public final fun getTransport ()Lcom/juul/kable/Transport;
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
 	public final fun observationExceptionHandler (Lkotlin/jvm/functions/Function3;)V
 	public final fun onServicesDiscovered (Lkotlin/jvm/functions/Function2;)V
+	public final fun setAutoConnect (Z)V
 	public final fun setPhy (Lcom/juul/kable/Phy;)V
 	public final fun setTransport (Lcom/juul/kable/Transport;)V
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -287,13 +287,12 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 }
 
 public final class com/juul/kable/PeripheralBuilder {
-	public final fun getAutoConnect ()Z
+	public final fun autoConnectIf (Lkotlin/jvm/functions/Function0;)V
 	public final fun getPhy ()Lcom/juul/kable/Phy;
 	public final fun getTransport ()Lcom/juul/kable/Transport;
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
 	public final fun observationExceptionHandler (Lkotlin/jvm/functions/Function3;)V
 	public final fun onServicesDiscovered (Lkotlin/jvm/functions/Function2;)V
-	public final fun setAutoConnect (Z)V
 	public final fun setPhy (Lcom/juul/kable/Phy;)V
 	public final fun setTransport (Lcom/juul/kable/Transport;)V
 }

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -67,6 +67,7 @@ internal fun BluetoothDevice.threading(): Threading =
 internal fun BluetoothDevice.connect(
     scope: CoroutineScope,
     context: Context,
+    autoConnect: Boolean,
     transport: Transport,
     phy: Phy,
     state: MutableStateFlow<State>,
@@ -80,10 +81,10 @@ internal fun BluetoothDevice.connect(
     val bluetoothGatt = when {
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
             val handler = (threading as Threading.Handler).handler
-            connectGatt(context, false, callback, transport.intValue, phy.intValue, handler)
+            connectGatt(context, autoConnect, callback, transport.intValue, phy.intValue, handler)
         }
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> connectGatt(context, false, callback, transport.intValue)
-        else -> connectGatt(context, false, callback)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> connectGatt(context, autoConnect, callback, transport.intValue)
+        else -> connectGatt(context, autoConnect, callback)
     } ?: return null
 
     return Connection(scope, bluetoothGatt, threading.dispatcher, callback, logging)

--- a/core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -8,6 +8,8 @@ import android.bluetooth.BluetoothDevice.PHY_LE_CODED_MASK
 import android.bluetooth.BluetoothDevice.TRANSPORT_AUTO
 import android.bluetooth.BluetoothDevice.TRANSPORT_BREDR
 import android.bluetooth.BluetoothDevice.TRANSPORT_LE
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
 import android.content.Context
 import android.os.Build
 import android.os.Handler
@@ -83,11 +85,25 @@ internal fun BluetoothDevice.connect(
             val handler = (threading as Threading.Handler).handler
             connectGatt(context, autoConnect, callback, transport.intValue, phy.intValue, handler)
         }
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> connectGatt(context, autoConnect, callback, transport.intValue)
-        else -> connectGatt(context, autoConnect, callback)
+
+        Build.VERSION.SDK_INT <= Build.VERSION_CODES.M && autoConnect ->
+            connectGattWithReflection(context, true, callback, transport.intValue)
+                ?: connectGattCompat(context, true, callback, transport.intValue)
+
+        else -> connectGattCompat(context, autoConnect, callback, transport.intValue)
     } ?: return null
 
     return Connection(scope, bluetoothGatt, threading.dispatcher, callback, logging)
+}
+
+private fun BluetoothDevice.connectGattCompat(
+    context: Context,
+    autoConnect: Boolean,
+    callback: BluetoothGattCallback,
+    transport: Int,
+): BluetoothGatt = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> connectGatt(context, autoConnect, callback, transport)
+    else -> connectGatt(context, autoConnect, callback)
 }
 
 private val Transport.intValue: Int

--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -54,7 +54,7 @@ private const val DISCOVER_SERVICES_RETRIES = 5
 internal class BluetoothDeviceAndroidPeripheral(
     parentCoroutineContext: CoroutineContext,
     private val bluetoothDevice: BluetoothDevice,
-    private val autoConnect: Boolean,
+    private val autoConnectPredicate: () -> Boolean,
     private val transport: Transport,
     private val phy: Phy,
     observationExceptionHandler: ObservationExceptionHandler,
@@ -122,7 +122,7 @@ internal class BluetoothDeviceAndroidPeripheral(
             _connection = bluetoothDevice.connect(
                 scope,
                 applicationContext,
-                autoConnect,
+                autoConnectPredicate(),
                 transport,
                 phy,
                 _state,

--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -54,6 +54,7 @@ private const val DISCOVER_SERVICES_RETRIES = 5
 internal class BluetoothDeviceAndroidPeripheral(
     parentCoroutineContext: CoroutineContext,
     private val bluetoothDevice: BluetoothDevice,
+    private val autoConnect: Boolean,
     private val transport: Transport,
     private val phy: Phy,
     observationExceptionHandler: ObservationExceptionHandler,
@@ -121,6 +122,7 @@ internal class BluetoothDeviceAndroidPeripheral(
             _connection = bluetoothDevice.connect(
                 scope,
                 applicationContext,
+                autoConnect,
                 transport,
                 phy,
                 _state,

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -30,6 +30,7 @@ public fun CoroutineScope.peripheral(
     return BluetoothDeviceAndroidPeripheral(
         coroutineContext,
         bluetoothDevice,
+        builder.autoConnect,
         builder.transport,
         builder.phy,
         builder.observationExceptionHandler,

--- a/core/src/androidMain/kotlin/Peripheral.kt
+++ b/core/src/androidMain/kotlin/Peripheral.kt
@@ -30,7 +30,7 @@ public fun CoroutineScope.peripheral(
     return BluetoothDeviceAndroidPeripheral(
         coroutineContext,
         bluetoothDevice,
-        builder.autoConnect,
+        builder.autoConnectPredicate,
         builder.transport,
         builder.phy,
         builder.observationExceptionHandler,

--- a/core/src/androidMain/kotlin/PeripheralBuilder.kt
+++ b/core/src/androidMain/kotlin/PeripheralBuilder.kt
@@ -95,10 +95,10 @@ public actual class PeripheralBuilder internal actual constructor() {
     internal var autoConnectPredicate: () -> Boolean = { false }
 
     /**
-     * Whether to directly connect to the remote device ([predicate] returns `false` — connection
-     * attempts timeout after ~30 seconds) or to automatically connect as soon as the remote device
-     * becomes available ([predicate] returns `true` — [connection][Peripheral.connect] attempts
-     * will wait indefinitely unless wrapped in a `withTimeout`).
+     * Whether to automatically connect as soon as the remote device becomes available ([predicate]
+     * returns `true` — [connection][Peripheral.connect] attempts will wait indefinitely unless
+     * wrapped in a `withTimeout`), or to directly connect to the remote device ([predicate] returns
+     * `false` — connection attempts timeout after ~30 seconds).
      *
      * [predicate] is called once per connection attempt, not per call to
      * [connect][Peripheral.connect].

--- a/core/src/androidMain/kotlin/PeripheralBuilder.kt
+++ b/core/src/androidMain/kotlin/PeripheralBuilder.kt
@@ -92,13 +92,20 @@ public actual class PeripheralBuilder internal actual constructor() {
         observationExceptionHandler = handler
     }
 
+    internal var autoConnectPredicate: () -> Boolean = { false }
+
     /**
-     * Whether to directly connect to the remote device (`false` — connection attempts timeout after
-     * ~30 seconds) or to automatically connect as soon as the remote device becomes available
-     * (`true` — [connection][Peripheral.connect] attempts will wait indefinitely unless wrapped in
-     * a `withTimeout`).
+     * Whether to directly connect to the remote device ([predicate] returns `false` — connection
+     * attempts timeout after ~30 seconds) or to automatically connect as soon as the remote device
+     * becomes available ([predicate] returns `true` — [connection][Peripheral.connect] attempts
+     * will wait indefinitely unless wrapped in a `withTimeout`).
+     *
+     * [predicate] is called once per connection attempt, not per call to
+     * [connect][Peripheral.connect].
      */
-    public var autoConnect: Boolean = true
+    public fun autoConnectIf(predicate: () -> Boolean) {
+        autoConnectPredicate = predicate
+    }
 
     /** Preferred transport for GATT connections to remote dual-mode devices. */
     public var transport: Transport = Transport.Le

--- a/core/src/androidMain/kotlin/PeripheralBuilder.kt
+++ b/core/src/androidMain/kotlin/PeripheralBuilder.kt
@@ -92,6 +92,14 @@ public actual class PeripheralBuilder internal actual constructor() {
         observationExceptionHandler = handler
     }
 
+    /**
+     * Whether to directly connect to the remote device (`false` — connection attempts timeout after
+     * ~30 seconds) or to automatically connect as soon as the remote device becomes available
+     * (`true` — [connection][Peripheral.connect] attempts will wait indefinitely unless wrapped in
+     * a `withTimeout`).
+     */
+    public var autoConnect: Boolean = true
+
     /** Preferred transport for GATT connections to remote dual-mode devices. */
     public var transport: Transport = Transport.Le
 

--- a/core/src/androidMain/kotlin/Reflection.kt
+++ b/core/src/androidMain/kotlin/Reflection.kt
@@ -1,0 +1,74 @@
+@file:SuppressLint("PrivateApi")
+
+package com.juul.kable
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.content.Context
+
+/**
+ * Workaround for
+ * [Race condition in BluetoothGatt when using BluetoothDevice#connectGatt()](https://issuetracker.google.com/issues/36995652).
+ *
+ * Kotlin adaptation of RxAndroidBle's
+ * [`BleConnectionCompat.java`](https://github.com/dariuszseweryn/RxAndroidBle/blob/60b99f28766c208179055e96db894c66ac090ad9/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/BleConnectionCompat.java).
+ */
+internal fun BluetoothDevice.connectGattWithReflection(
+    context: Context,
+    autoConnect: Boolean,
+    callback: BluetoothGattCallback,
+    transport: Int,
+): BluetoothGatt? {
+    return try {
+        val bluetoothAdapter = getBluetoothAdapterOrNull() ?: return null
+        val iBluetoothManager = bluetoothAdapter.invoke("getBluetoothManager") ?: return null
+        val iBluetoothGatt = iBluetoothManager.invoke("getBluetoothGatt") ?: return null
+
+        val bluetoothGatt = BluetoothGatt(context, iBluetoothGatt, this, transport)
+            .apply { setAutoConnect(autoConnect) }
+        val successful = bluetoothGatt.connect(autoConnect, callback)
+        bluetoothGatt.takeIf { successful }
+    } catch (e: ReflectiveOperationException) {
+        null
+    } catch (e: IllegalArgumentException) {
+        null
+    }
+}
+
+private fun Any.invoke(method: String): Any? =
+    javaClass.getDeclaredMethod(method).apply { isAccessible = true }.invoke(this)
+
+private fun BluetoothGatt(
+    context: Context,
+    iBluetoothGatt: Any,
+    bluetoothDevice: BluetoothDevice,
+    transport: Int,
+): BluetoothGatt = BluetoothGatt::class.java.declaredConstructors[0]
+    .apply { isAccessible = true }
+    .run {
+        when (val parameters = parameterTypes.size) {
+            3 -> newInstance(context, iBluetoothGatt, bluetoothDevice)
+            4 -> newInstance(context, iBluetoothGatt, bluetoothDevice, transport)
+            else -> error("Unsupported BluetoothGatt constructor with $parameters parameters")
+        } as BluetoothGatt
+    }
+
+private fun BluetoothGatt.setAutoConnect(value: Boolean) {
+    javaClass.getDeclaredField("mAutoConnect").apply {
+        isAccessible = true
+        setBoolean(this@setAutoConnect, value)
+    }
+}
+
+private fun BluetoothGatt.connect(
+    autoConnect: Boolean,
+    callback: BluetoothGattCallback,
+): Boolean = javaClass
+    .getDeclaredMethod("connect", java.lang.Boolean::class.java, BluetoothGattCallback::class.java)
+    .run {
+        isAccessible = true
+        invoke(this@connect, autoConnect, callback) as Boolean
+    }
+    .also { successful -> if (!successful) close() }


### PR DESCRIPTION
[Martijn van Welie](https://medium.com/@martijn.van.welie) wrote a great article, [Making Android BLE work — part 2](https://medium.com/@martijn.van.welie/making-android-ble-work-part-2-47a3cdaade07), which includes a very informative section on [`autoConnect = true`](https://medium.com/@martijn.van.welie/making-android-ble-work-part-2-47a3cdaade07#7fcf).

~~Making `autoConnect = true` the default, as it is generally easier to manage and will match how Kable behaves on Apple platforms.~~

**UPDATE:** Default now matches the previous behavior, library consumers will need to opt-in to auto-connect.

Library consumers will be able to opt-in to the new behavior via:

```kotlin
val peripheral = scope.peripheral(..) {
    autoConnectIf { true }
}
peripheral.connect()
```

Auto-connect is a lambda predicate to allow consumers to dynamically decide if a connection should be auto-connect. This is useful in situations where initial connection is desired to be `autoConnect = false` (for faster connection) but having subsequent connections be `autoConnect = true` (for battery conservation).

Closes #410