### PR TITLE
Monitor disconnected state after connected

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -114,10 +114,6 @@ internal class BluetoothDeviceAndroidPeripheral(
         logger.info { message = "Connecting" }
         _state.value = State.Connecting.Bluetooth
 
-        state.filterIsInstance<Disconnected>()
-            .onEach { connectAction.reset() }
-            .launchIn(scope)
-
         try {
             _connection = bluetoothDevice.connect(
                 scope,
@@ -144,6 +140,10 @@ internal class BluetoothDeviceAndroidPeripheral(
             logger.error(e) { message = "Failed to connect" }
             throw e
         }
+
+        state.filterIsInstance<Disconnected>()
+            .onEach { connectAction.reset() }
+            .launchIn(scope)
 
         logger.info { message = "Connected" }
         _state.value = State.Connected

--- a/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -146,13 +146,6 @@ internal class CBPeripheralCoreBluetoothPeripheral(
         logger.info { message = "Connecting" }
         _state.value = State.Connecting.Bluetooth
 
-        centralManager.delegate.onDisconnected.onEach { identifier ->
-            if (identifier == cbPeripheral.identifier) {
-                connectAction.reset()
-                logger.info { message = "Disconnected" }
-            }
-        }.launchIn(scope)
-
         try {
             _connection.value = centralManager.connectPeripheral(
                 scope,
@@ -177,6 +170,13 @@ internal class CBPeripheralCoreBluetoothPeripheral(
             }
             throw e
         }
+
+        centralManager.delegate.onDisconnected.onEach { identifier ->
+            if (identifier == cbPeripheral.identifier) {
+                connectAction.reset()
+                logger.info { message = "Disconnected" }
+            }
+        }.launchIn(scope)
 
         logger.info { message = "Connected" }
         _state.value = State.Connected


### PR DESCRIPTION
Unfortunately `SharedRepeatableAction` is proving a bit error prone in its usage. In this particular case, we'd spin up a coroutine to monitor for peripheral disconnection, unfortunately it was prone to race conditions, whereas the resetting of the `SharedRepeatableAction` would propagate cancellation if it saw the disconnect before the `connect` process could itself propagate a failure.

Moving to the end of the connection process allows for failures to always be properly propagated from the `connect` call and _then_ properly monitoring for disconnected state.