### PR TITLE
Throw `GattRequestRejectedException` when `setCharacteristicNotification` fails

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -303,7 +303,7 @@ internal class BluetoothDeviceAndroidPeripheral(
         val platformCharacteristic = discoveredServices.obtain(characteristic, Notify or Indicate)
         connection
             .bluetoothGatt
-            .setCharacteristicNotification(platformCharacteristic, true)
+            .setCharacteristicNotificationOrThrow(platformCharacteristic, true)
         setConfigDescriptor(platformCharacteristic, enable = true)
     }
 
@@ -318,7 +318,7 @@ internal class BluetoothDeviceAndroidPeripheral(
         }
         connection
             .bluetoothGatt
-            .setCharacteristicNotification(platformCharacteristic, false)
+            .setCharacteristicNotificationOrThrow(platformCharacteristic, false)
     }
 
     private suspend fun setConfigDescriptor(


### PR DESCRIPTION
It was an oversight that `setCharacteristicNotificationOrThrow` was not being used — which meant that failures to `setCharacteristicNotification` would fail silently; this PR fixes that.