### PR TITLE
Throw `LocationManagerUnavailableException` when `LocationManager` is unavailable

### DIFF
--- a/core/src/androidMain/kotlin/Bluetooth.kt
+++ b/core/src/androidMain/kotlin/Bluetooth.kt
@@ -40,7 +40,7 @@ public actual enum class Reason {
 
 private val Context.locationManager: LocationManager
     get() = ContextCompat.getSystemService(this, LocationManager::class.java)
-        ?: error("LocationManager system service unavailable")
+        ?: throw LocationManagerUnavailableException("LocationManager system service unavailable")
 
 private val isLocationEnabled: Boolean
     get() = LocationManagerCompat.isLocationEnabled(applicationContext.locationManager)

--- a/exceptions/api/exceptions.api
+++ b/exceptions/api/exceptions.api
@@ -28,6 +28,12 @@ public final class com/juul/kable/GattStatusException : java/io/IOException {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/juul/kable/LocationManagerUnavailableException : com/juul/kable/BluetoothException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public class com/juul/kable/NotConnectedException : java/io/IOException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/exceptions/src/commonMain/kotlin/Exceptions.kt
+++ b/exceptions/src/commonMain/kotlin/Exceptions.kt
@@ -6,6 +6,11 @@ public open class BluetoothException(
     cause: Throwable? = null,
 ) : Exception(message, cause)
 
+public class LocationManagerUnavailableException(
+    message: String? = null,
+    cause: Throwable? = null,
+) : BluetoothException(message, cause)
+
 public class BluetoothDisabledException(
     message: String? = null,
     cause: Throwable? = null,


### PR DESCRIPTION
Was previously throwing an `IllegalStateException` but that doesn't match the other possible exceptions which inherit from `BluetoothException`.

After this change, the exception tree will look like:

- `Exception`
  - `BluetoothException`
    - `BluetoothDisabledException`
    - `LocationManagerUnavailableException`   _(only thrown on Android)_
    - `GattRequestRejectedException`          _(only thrown on Android)_
  - `IOException`
    - `ConnectionRejectedException`
    - `GattStatusException`                   _(only thrown on Android)_
    - `NotConnectedException`
      - `ConnectionLostException`
      - `NotReadyException`