### PR TITLE
Fix "disposed" peripheral log message

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -186,7 +186,7 @@ internal class BluetoothDeviceAndroidPeripheral(
     private fun dispose(cause: Throwable?) {
         closeConnection()
         threading.close()
-        logger.info(cause) { message = "$this disposed" }
+        logger.info(cause) { message = "Disposed" }
     }
 
     private fun closeConnection() {


### PR DESCRIPTION
Accidentally used `this` reference which referred to the logger (not the `Peripheral`, as was intended).

The logger already prints out the peripheral identifier, so including the `Periheral.toString()` in the log message was unnecessary — so, removed `$this` entirely.