### PR TITLE
Fix `IOException` to not drop `cause`

### DIFF
--- a/exceptions/src/appleMain/kotlin/Exceptions.kt
+++ b/exceptions/src/appleMain/kotlin/Exceptions.kt
@@ -5,7 +5,7 @@ package com.juul.kable
 public actual open class IOException actual constructor(
     message: String?,
     cause: Throwable?,
-) : Exception(message) {
+) : Exception(message, cause) {
     public actual constructor() : this(null, null)
     public actual constructor(message: String?) : this(message, null)
     public actual constructor(cause: Throwable?) : this(null, cause)

--- a/exceptions/src/jsMain/kotlin/Exceptions.kt
+++ b/exceptions/src/jsMain/kotlin/Exceptions.kt
@@ -5,7 +5,7 @@ package com.juul.kable
 public actual open class IOException actual constructor(
     message: String?,
     cause: Throwable?,
-) : Exception(message) {
+) : Exception(message, cause) {
     public actual constructor() : this(null, null)
     public actual constructor(message: String?) : this(message, null)
     public actual constructor(cause: Throwable?) : this(null, cause)


### PR DESCRIPTION
When a `cause` was provided to `IOException` it was not passed on through to the super `Exception` constructor (essentially dropping the `cause` entirely). This fixes this issue and no longer drops the `cause`.