### PR TITLE
Use default hierarchy template

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,115 +8,43 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-/* ```
- *   common
- *   |-- js
- *   |-- android
- *   '-- apple
- *       |-- ios
- *       '-- macos
- * ```
- */
 kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     androidTarget().publishAllLibraryVariants()
-    js().browser()
-    iosX64()
-    macosArm64()
     iosArm64()
     iosSimulatorArm64()
+    iosX64()
+    js().browser()
+    macosArm64()
     macosX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(project(":exceptions"))
-                api(libs.kotlinx.coroutines.core)
-                api(libs.uuid)
-                implementation(libs.tuulbox.collections)
-            }
+        commonMain.dependencies {
+            api(project(":exceptions"))
+            api(libs.kotlinx.coroutines.core)
+            api(libs.uuid)
+            implementation(libs.tuulbox.collections)
+
         }
 
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-                implementation(libs.tuulbox.logging)
-                implementation(libs.kotlinx.coroutines.test)
-            }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.tuulbox.logging)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
-        val jsTest by getting {
-            dependencies {
-                implementation(kotlin("test-js"))
-            }
-        }
+        androidMain.dependencies {
+            api(libs.kotlinx.coroutines.android)
+            implementation(libs.androidx.core)
+            implementation(libs.androidx.startup)
 
-        val androidMain by getting {
-            dependencies {
-                api(libs.kotlinx.coroutines.android)
-                implementation(libs.androidx.core)
-                implementation(libs.androidx.startup)
+            // Workaround for AtomicFU plugin not automatically adding JVM dependency for Android.
+            // https://github.com/Kotlin/kotlinx-atomicfu/issues/145
+            implementation(libs.atomicfu)
 
-                // Workaround for AtomicFU plugin not automatically adding JVM dependency for Android.
-                // https://github.com/Kotlin/kotlinx-atomicfu/issues/145
-                implementation(libs.atomicfu)
-
-                implementation(libs.tuulbox.coroutines)
-            }
-        }
-
-        val androidUnitTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
-            }
-        }
-
-        val appleMain by creating {
-            dependsOn(commonMain)
-        }
-
-        val appleTest by creating
-
-        val macosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val macosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val macosArm64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val macosArm64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosArm64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosSimulatorArm64Main by getting {
-            dependsOn(appleMain)
-        }
-        val iosSimulatorArm64Test by getting {
-            dependsOn(appleTest)
+            implementation(libs.tuulbox.coroutines)
         }
 
         all {

--- a/exceptions/build.gradle.kts
+++ b/exceptions/build.gradle.kts
@@ -5,95 +5,21 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-/* ```
- *   common
- *   |-- js
- *   |-- jvm
- *   '-- apple
- *       |-- ios
- *       '-- macos
- * ```
- */
 kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
-    js().browser()
-    iosX64()
-    macosArm64()
     iosArm64()
     iosSimulatorArm64()
+    iosX64()
+    js().browser()
+    jvm()
+    macosArm64()
     macosX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-            }
-        }
-
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
-        }
-
-        val jsTest by getting {
-            dependencies {
-                implementation(kotlin("test-js"))
-            }
-        }
-
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
-            }
-        }
-
-        val appleMain by creating {
-            dependsOn(commonMain)
-        }
-
-        val appleTest by creating
-
-        val macosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val macosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val macosArm64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val macosArm64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosArm64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosSimulatorArm64Main by getting {
-            dependsOn(appleMain)
-        }
-        val iosSimulatorArm64Test by getting {
-            dependsOn(appleTest)
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -12,19 +12,16 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     androidTarget().publishAllLibraryVariants()
-    js().browser()
-
-    iosX64()
     iosArm64()
-    macosX64()
+    iosX64()
+    js().browser()
     macosArm64()
+    macosX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(project(":core"))
-                api(libs.tuulbox.logging)
-            }
+        commonMain.dependencies {
+            api(project(":core"))
+            api(libs.tuulbox.logging)
         }
     }
 }


### PR DESCRIPTION
[Default hierarchy template](https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy-template)

Additional clean up:
- dropped platform specific `kotlin("test-*")`s, as `kotlin("test")` in `commonTest` pulls in the necessary platform specific dependencies