### PR TITLE
Remove explicit enabling of inline classes

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -118,10 +118,6 @@ kotlin {
         val iosSimulatorArm64Test by getting {
             dependsOn(appleTest)
         }
-
-        all {
-            languageSettings.enableLanguageFeature("InlineClasses")
-        }
     }
 }
 


### PR DESCRIPTION
`inline` classes are [stable since Kotlin 1.5.0](https://kotlinlang.org/docs/whatsnew15.html#language-features), there is no need to enable them explicitly.