### PR TITLE
Defensive copying in Android legacy, deprecated `BluetoothGattCallback` functions

### DIFF
--- a/core/src/androidMain/kotlin/gatt/Callback.kt
+++ b/core/src/androidMain/kotlin/gatt/Callback.kt
@@ -133,7 +133,8 @@ internal class Callback(
         status: Int,
     ) {
         @Suppress("DEPRECATION")
-        onCharacteristicRead(gatt, characteristic, characteristic.value ?: byteArrayOf(), status)
+        val value = characteristic.value?.copyOf() ?: byteArrayOf()
+        onCharacteristicRead(gatt, characteristic, value, status)
     }
 
     // Added in API 33.
@@ -173,7 +174,8 @@ internal class Callback(
         characteristic: BluetoothGattCharacteristic,
     ) {
         @Suppress("DEPRECATION")
-        onCharacteristicChanged(gatt, characteristic, characteristic.value ?: byteArrayOf())
+        val value = characteristic.value?.copyOf() ?: byteArrayOf()
+        onCharacteristicChanged(gatt, characteristic, value)
     }
 
     // Added in API 33.
@@ -198,7 +200,8 @@ internal class Callback(
         status: Int,
     ) {
         @Suppress("DEPRECATION")
-        onDescriptorRead(gatt, descriptor, status, descriptor.value ?: byteArrayOf())
+        val value = descriptor.value?.copyOf() ?: byteArrayOf()
+        onDescriptorRead(gatt, descriptor, status, value)
     }
 
     // Added in API 33.


### PR DESCRIPTION
The docs now explicitly call out that these deprecated callbacks are not memory safe.

![Screenshot 2024-02-20 at 1 55 09 PM](https://github.com/JuulLabs/kable/assets/20380774/0ee70383-ac72-4d3c-ae19-cefa7c46f172)

Since we still have to use them to support older Android versions, a defensive copy should either:
- guarantee memory safety (if Android doesn't modify the characteristic mid-callback)
- narrow the danger range (if Android can modify the characteristic mid-callback)

Unfortunately I'm not sure which behavior Android has, but I figure this is a win either way -- just a question of total win or partial. 
