### PR TITLE
Remove workaround for `jvmToolchain` not being honored pre AGP 8.1.0-alpha09

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -51,13 +51,6 @@ kotlin {
 }
 
 android {
-    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
-    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
 
@@ -76,4 +69,3 @@ android {
         disable += "GradleDependency"
     }
 }
-

--- a/log-engine-tuulbox/build.gradle.kts
+++ b/log-engine-tuulbox/build.gradle.kts
@@ -28,13 +28,6 @@ kotlin {
 }
 
 android {
-    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
-    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
 


### PR DESCRIPTION
We've upgraded AGP beyond the versions that need the workaround.