### PR TITLE
Remove explicit `POM_ARTIFACT_ID` configuration

### DIFF
--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=core
-android.useAndroidX=true

--- a/exceptions/gradle.properties
+++ b/exceptions/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=exceptions

--- a/log-engine-khronicle/gradle.properties
+++ b/log-engine-khronicle/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=log-engine-khronicle

--- a/log-engine-tuulbox/gradle.properties
+++ b/log-engine-tuulbox/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=log-engine-tuulbox
-android.useAndroidX=true


### PR DESCRIPTION
The Maven artifact name defaults to the module name, so the module `gradle.properties` files are superfluous when the `POM_ARTIFACT_ID` matches the module name.