### PR TITLE
Explicitly pull in AtomicFU dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath(libs.atomicfu)
+        classpath(libs.atomicfu.gradle)
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -23,11 +23,10 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":exceptions"))
             api(libs.kotlinx.coroutines.core)
             api(libs.uuid)
+            api(project(":exceptions"))
             implementation(libs.tuulbox.collections)
-
         }
 
         commonTest.dependencies {
@@ -40,6 +39,11 @@ kotlin {
             api(libs.kotlinx.coroutines.android)
             implementation(libs.androidx.core)
             implementation(libs.androidx.startup)
+
+            // Workaround for AtomicFU plugin not automatically adding JVM dependency for Android.
+            // https://github.com/Kotlin/kotlinx-atomicfu/issues/145
+            implementation(libs.atomicfu)
+
             implementation(libs.tuulbox.coroutines)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 android-compile = "34"
 android-min = "21"
+atomicfu = "0.23.2"
 coroutines = "1.8.0"
 jvm-toolchain = "11"
 kotlin = "1.9.23"
@@ -9,7 +10,8 @@ tuulbox = "7.2.0"
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version = "1.12.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version = "0.23.2" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+atomicfu-gradle = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
 khronicle = { module = "com.juul.khronicle:khronicle-core", version = "0.1.0" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
In #649, I wrongfully assumed that the AtomicFU dependency workaround was no longer needed — it is still needed. 😢 