### PR TITLE
Fix crash in peripheral `<init>` when parent job is already complete

### DIFF
--- a/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -106,8 +106,8 @@ internal class BluetoothDeviceAndroidPeripheral(
      */
     private val scope = CoroutineScope(
         parentCoroutineContext +
-                SupervisorJob(parentCoroutineContext.job).apply { invokeOnCompletion(::dispose) } +
-                CoroutineName("Kable/Peripheral/${bluetoothDevice.address}"),
+            SupervisorJob(parentCoroutineContext.job).apply { invokeOnCompletion(::dispose) } +
+            CoroutineName("Kable/Peripheral/${bluetoothDevice.address}"),
     )
 
     private val connectAction = scope.sharedRepeatableAction(::establishConnection)

--- a/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -99,8 +99,8 @@ internal class CBPeripheralCoreBluetoothPeripheral(
      */
     private val scope = CoroutineScope(
         parentCoroutineContext +
-                SupervisorJob(parentCoroutineContext.job).apply { invokeOnCompletion(::dispose) } +
-                CoroutineName("Kable/Peripheral/${cbPeripheral.identifier.UUIDString}"),
+            SupervisorJob(parentCoroutineContext.job).apply { invokeOnCompletion(::dispose) } +
+            CoroutineName("Kable/Peripheral/${cbPeripheral.identifier.UUIDString}"),
     )
 
     init {


### PR DESCRIPTION
This PR doesn't attempt any big refactors re. scoping, just makes sure that `dispose`/`finalCleanup` are called near the end of peripheral initialization to avoid unexpected nulls.