### PR TITLE
Provide ability to pre-conflate scanned advertisements

### DIFF
--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -376,9 +376,11 @@ public abstract interface class com/juul/kable/Scanner {
 public final class com/juul/kable/ScannerBuilder {
 	public fun <init> ()V
 	public final fun getFilters ()Ljava/util/List;
+	public final fun getPreConflate ()Z
 	public final fun getScanSettings ()Landroid/bluetooth/le/ScanSettings;
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
 	public final fun setFilters (Ljava/util/List;)V
+	public final fun setPreConflate (Z)V
 	public final fun setScanSettings (Landroid/bluetooth/le/ScanSettings;)V
 }
 

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -35,7 +35,7 @@ internal class BluetoothLeScannerAndroidScanner(
     override val advertisements: Flow<AndroidAdvertisement> = callbackFlow {
         val scanner = getBluetoothAdapter().bluetoothLeScanner ?: throw BluetoothDisabledException()
 
-        fun send(scanResult: ScanResult) {
+        fun sendResult(scanResult: ScanResult) {
             val advertisement = ScanResultAndroidAdvertisement(scanResult)
             when {
                 preConflate -> trySend(advertisement)
@@ -48,11 +48,11 @@ internal class BluetoothLeScannerAndroidScanner(
         val callback = object : ScanCallback() {
 
             override fun onScanResult(callbackType: Int, result: ScanResult) {
-                send(result)
+                sendResult(result)
             }
 
             override fun onBatchScanResults(results: MutableList<ScanResult>) {
-                results.forEach(::send)
+                results.forEach(::sendResult)
             }
 
             override fun onScanFailed(errorCode: Int) {

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -39,9 +39,10 @@ internal class BluetoothLeScannerAndroidScanner(
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
                 val scanResult = ScanResultAndroidAdvertisement(result)
-                when (shouldUseBlockingSend) {
-                    true -> trySendBlocking(scanResult)
-                    else -> trySend(scanResult)
+                if (shouldUseBlockingSend){
+                    trySendBlocking(scanResult)
+                } else {
+                    trySend(scanResult)
                 }.onFailure {
                     logger.warn { message = "Unable to deliver scan result due to failure in flow or premature closing." }
                 }
@@ -52,9 +53,10 @@ internal class BluetoothLeScannerAndroidScanner(
                 runCatching {
                     results.forEach {
                         val scanResult = ScanResultAndroidAdvertisement(it)
-                        when (shouldUseBlockingSend) {
-                            true -> trySendBlocking(scanResult)
-                            else -> trySend(scanResult)
+                        if (shouldUseBlockingSend) {
+                            trySendBlocking(scanResult)
+                        } else {
+                            trySend(scanResult)
                         }.getOrThrow()
                     }
                 }.onFailure {

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.filter
 internal class BluetoothLeScannerAndroidScanner(
     private val filters: List<Filter>,
     private val scanSettings: ScanSettings,
-    private val sendBlocking: Boolean,
+    private val preConflate: Boolean,
     logging: Logging,
 ) : AndroidScanner {
 
@@ -38,8 +38,8 @@ internal class BluetoothLeScannerAndroidScanner(
         fun send(scanResult: ScanResult) {
             val advertisement = ScanResultAndroidAdvertisement(scanResult)
             when {
-                sendBlocking -> trySendBlocking(advertisement)
-                else -> trySend(advertisement)
+                preConflate -> trySend(advertisement)
+                else -> trySendBlocking(advertisement)
             }.onFailure {
                 logger.warn { message = "Unable to deliver scan result due to failure in flow or premature closing." }
             }

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -69,7 +69,6 @@ internal class BluetoothLeScannerAndroidScanner(
                     is Address -> setDeviceAddress(filter.address)
                     is ManufacturerData -> setManufacturerData(filter.id, filter.data, filter.dataMask)
                     is Service -> setServiceUuid(ParcelUuid(filter.uuid)).build()
-                    else -> {}
                 }
             }.build()
         }

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -74,22 +74,14 @@ internal class BluetoothLeScannerAndroidScanner(
         }
 
         logger.info {
-            message = if (scanFilters.isEmpty()) {
-                "Starting scan without filters"
-            } else {
-                "Starting scan with ${scanFilters.size} filter(s)"
-            }
+            message = logMessage("Starting", preConflate, scanFilters)
         }
         checkBluetoothAdapterState(STATE_ON)
         scanner.startScan(scanFilters, scanSettings, callback)
 
         awaitClose {
             logger.info {
-                message = if (scanFilters.isEmpty()) {
-                    "Stopping scan without filters"
-                } else {
-                    "Stopping scan with ${scanFilters.size} filter(s)"
-                }
+                message = logMessage("Stopping", preConflate, scanFilters)
             }
             // Can't check BLE state here, only Bluetooth, but should assume `IllegalStateException` means BLE has been disabled.
             try {
@@ -104,5 +96,19 @@ internal class BluetoothLeScannerAndroidScanner(
 
         // Perform `Filter.NamePrefix` filtering here, since it isn't supported natively.
         namePrefixFilters.any { filter -> filter.matches(advertisement.name) }
+    }
+}
+
+private fun logMessage(prefix: String, preConflate: Boolean, scanFilters: List<ScanFilter>) = buildString {
+    append(prefix)
+    append(' ')
+    append("scan ")
+    if (preConflate) {
+        append("pre-conflated ")
+    }
+    if (scanFilters.isEmpty()) {
+        append("without filters")
+    } else {
+        append("with ${scanFilters.size} filter(s)")
     }
 }

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -39,7 +39,7 @@ internal class BluetoothLeScannerAndroidScanner(
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
                 val scanResult = ScanResultAndroidAdvertisement(result)
-                if (shouldUseBlockingSend){
+                if (shouldUseBlockingSend) {
                     trySendBlocking(scanResult)
                 } else {
                     trySend(scanResult)

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -21,7 +21,7 @@ public actual class ScannerBuilder {
 
     /**
      * Allows for the [Scanner] to be configured to use either a blocking or non-blocking send
-     * operation from within the callback flow. This is designed to provide an escape hatch
+     * operation from within the callback flow. This is intended to provide an escape hatch
      * for users that run into threading issues on certain devices.
      */
     @Suppress("MemberVisibilityCanBePrivate")

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -19,6 +19,13 @@ public actual class ScannerBuilder {
 
     private var logging: Logging = Logging()
 
+    /**
+     * Allows for the [Scanner] to be configured to use either a blocking or non-blocking send
+     * operation from within the callback flow. This is designed to provide an escape hatch
+     * for users that run into threading issues on certain devices.
+     */
+    public var shouldUseBlockingSend: Boolean = true
+
     public actual fun logging(init: LoggingBuilder) {
         logging = Logging().apply(init)
     }
@@ -28,5 +35,6 @@ public actual class ScannerBuilder {
         filters = filters.orEmpty(),
         scanSettings = scanSettings,
         logging = logging,
+        shouldUseBlockingSend = shouldUseBlockingSend
     )
 }

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -44,6 +44,6 @@ public actual class ScannerBuilder {
         filters = filters.orEmpty(),
         scanSettings = scanSettings,
         logging = logging,
-        sendBlocking = preConflate,
+        preConflate = preConflate,
     )
 }

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -33,7 +33,7 @@ public actual class ScannerBuilder {
      *
      * See https://github.com/JuulLabs/kable/issues/654 for more details.
      */
-    public var preConflate: Boolean = true
+    public var preConflate: Boolean = false
 
     public actual fun logging(init: LoggingBuilder) {
         logging = Logging().apply(init)

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -24,6 +24,7 @@ public actual class ScannerBuilder {
      * operation from within the callback flow. This is designed to provide an escape hatch
      * for users that run into threading issues on certain devices.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     public var shouldUseBlockingSend: Boolean = true
 
     public actual fun logging(init: LoggingBuilder) {


### PR DESCRIPTION
It was observed in #654 that using the default blocking send under certain conditions on various devices could result in ANRs being triggered when performing scans.  This PR provides a way for users to opt in to make the Android scanner's `callbackFlow` use a non-blocking `trySend` instead of `trySendBlocking`, with no change to the existing behavior.

Closes #654 