### PR TITLE
K2 support

### DIFF
--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -11,21 +11,6 @@ public abstract interface class com/juul/kable/Advertisement {
 	public abstract fun serviceData (Ljava/util/UUID;)[B
 }
 
-public abstract interface class com/juul/kable/AndroidAdvertisement : android/os/Parcelable, com/juul/kable/Advertisement {
-	public abstract fun getAddress ()Ljava/lang/String;
-	public abstract fun getBondState ()Lcom/juul/kable/AndroidAdvertisement$BondState;
-	public abstract fun getBytes ()[B
-}
-
-public final class com/juul/kable/AndroidAdvertisement$BondState : java/lang/Enum {
-	public static final field Bonded Lcom/juul/kable/AndroidAdvertisement$BondState;
-	public static final field Bonding Lcom/juul/kable/AndroidAdvertisement$BondState;
-	public static final field None Lcom/juul/kable/AndroidAdvertisement$BondState;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/AndroidAdvertisement$BondState;
-	public static fun values ()[Lcom/juul/kable/AndroidAdvertisement$BondState;
-}
-
 public abstract interface class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
 	public abstract fun getAddress ()Ljava/lang/String;
 	public abstract fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
@@ -65,10 +50,6 @@ public final class com/juul/kable/AndroidPeripheral$WriteResult : java/lang/Enum
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/AndroidPeripheral$WriteResult;
 	public static fun values ()[Lcom/juul/kable/AndroidPeripheral$WriteResult;
-}
-
-public abstract interface class com/juul/kable/AndroidScanner : com/juul/kable/Scanner {
-	public abstract fun getAdvertisements ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/juul/kable/Bluetooth {
@@ -334,6 +315,21 @@ public final class com/juul/kable/Phy : java/lang/Enum {
 	public static fun values ()[Lcom/juul/kable/Phy;
 }
 
+public abstract interface class com/juul/kable/PlatformAdvertisement : android/os/Parcelable, com/juul/kable/Advertisement {
+	public abstract fun getAddress ()Ljava/lang/String;
+	public abstract fun getBondState ()Lcom/juul/kable/PlatformAdvertisement$BondState;
+	public abstract fun getBytes ()[B
+}
+
+public final class com/juul/kable/PlatformAdvertisement$BondState : java/lang/Enum {
+	public static final field Bonded Lcom/juul/kable/PlatformAdvertisement$BondState;
+	public static final field Bonding Lcom/juul/kable/PlatformAdvertisement$BondState;
+	public static final field None Lcom/juul/kable/PlatformAdvertisement$BondState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/PlatformAdvertisement$BondState;
+	public static fun values ()[Lcom/juul/kable/PlatformAdvertisement$BondState;
+}
+
 public final class com/juul/kable/ProfileKt {
 	public static final fun characteristicOf (Ljava/lang/String;Ljava/lang/String;)Lcom/juul/kable/Characteristic;
 	public static final fun descriptorOf (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/juul/kable/Descriptor;
@@ -385,8 +381,8 @@ public final class com/juul/kable/ScannerBuilder {
 }
 
 public final class com/juul/kable/ScannerKt {
-	public static final fun Scanner (Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/AndroidScanner;
-	public static synthetic fun Scanner$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/AndroidScanner;
+	public static final fun Scanner (Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Scanner;
+	public static synthetic fun Scanner$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Scanner;
 }
 
 public abstract interface class com/juul/kable/Service {

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -219,7 +219,7 @@ public final class com/juul/kable/PeripheralKt {
 	public static synthetic fun peripheral$default (Lkotlinx/coroutines/CoroutineScope;Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 }
 
-public abstract interface class com/juul/kable/PlatformScanner : com/juul/kable/Scanner {
+public abstract interface class com/juul/kable/PlatformAdvertisement : com/juul/kable/Advertisement {
 }
 
 public final class com/juul/kable/ProfileKt {
@@ -253,8 +253,8 @@ public final class com/juul/kable/ScannerBuilder {
 }
 
 public final class com/juul/kable/ScannerKt {
-	public static final fun Scanner (Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/PlatformScanner;
-	public static synthetic fun Scanner$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/PlatformScanner;
+	public static final fun Scanner (Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Scanner;
+	public static synthetic fun Scanner$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Scanner;
 }
 
 public abstract interface class com/juul/kable/Service {

--- a/core/src/androidMain/kotlin/AndroidAdvertisement.kt
+++ b/core/src/androidMain/kotlin/AndroidAdvertisement.kt
@@ -1,22 +1,7 @@
 package com.juul.kable
 
-import android.os.Parcelable
-
 @Deprecated(
-    message = "Moved as nested class of `AndroidAdvertisement`.",
-    replaceWith = ReplaceWith("AndroidAdvertisement.BondState"),
+    "Moved to `PlatformAdvertisement`",
+    replaceWith = ReplaceWith("PlatformAdvertisement"),
 )
-public typealias BondState = AndroidAdvertisement.BondState
-
-public interface AndroidAdvertisement : Advertisement, Parcelable {
-
-    public enum class BondState {
-        None,
-        Bonding,
-        Bonded,
-    }
-
-    public val address: String
-    public val bondState: BondState
-    public val bytes: ByteArray?
-}
+public typealias AndroidAdvertisement = PlatformAdvertisement

--- a/core/src/androidMain/kotlin/AndroidScanner.kt
+++ b/core/src/androidMain/kotlin/AndroidScanner.kt
@@ -1,7 +1,7 @@
 package com.juul.kable
 
-import kotlinx.coroutines.flow.Flow
-
-public interface AndroidScanner : Scanner {
-    public override val advertisements: Flow<AndroidAdvertisement>
-}
+@Deprecated(
+    "Moved to PlatformScanner.",
+    replaceWith = ReplaceWith("PlatformScanner"),
+)
+public typealias AndroidScanner = PlatformScanner

--- a/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -26,13 +26,13 @@ internal class BluetoothLeScannerAndroidScanner(
     private val scanSettings: ScanSettings,
     private val preConflate: Boolean,
     logging: Logging,
-) : AndroidScanner {
+) : PlatformScanner {
 
     private val logger = Logger(logging, tag = "Kable/Scanner", identifier = null)
 
     private val namePrefixFilters = filters.filterIsInstance<NamePrefix>()
 
-    override val advertisements: Flow<AndroidAdvertisement> = callbackFlow {
+    override val advertisements: Flow<PlatformAdvertisement> = callbackFlow {
         val scanner = getBluetoothAdapter().bluetoothLeScanner ?: throw BluetoothDisabledException()
 
         fun sendResult(scanResult: ScanResult) {

--- a/core/src/androidMain/kotlin/PlatformAdvertisement.kt
+++ b/core/src/androidMain/kotlin/PlatformAdvertisement.kt
@@ -1,0 +1,23 @@
+package com.juul.kable
+
+import android.os.Parcelable
+
+@Deprecated(
+    message = "Moved as nested class of `PlatformAdvertisement`.",
+    replaceWith = ReplaceWith("PlatformAdvertisement.BondState"),
+    level = DeprecationLevel.ERROR,
+)
+public typealias BondState = PlatformAdvertisement.BondState
+
+public actual interface PlatformAdvertisement : Advertisement, Parcelable {
+
+    public enum class BondState {
+        None,
+        Bonding,
+        Bonded,
+    }
+
+    public val address: String
+    public val bondState: BondState
+    public val bytes: ByteArray?
+}

--- a/core/src/androidMain/kotlin/PlatformScanner.kt
+++ b/core/src/androidMain/kotlin/PlatformScanner.kt
@@ -1,3 +1,0 @@
-package com.juul.kable
-
-public actual typealias PlatformScanner = AndroidScanner

--- a/core/src/androidMain/kotlin/Profile.kt
+++ b/core/src/androidMain/kotlin/Profile.kt
@@ -24,7 +24,7 @@ public actual data class DiscoveredService internal constructor(
     public actual val characteristics: List<DiscoveredCharacteristic> =
         service.characteristics.map(::DiscoveredCharacteristic)
 
-    override val serviceUuid: Uuid get() = service.uuid
+    actual override val serviceUuid: Uuid get() = service.uuid
     val instanceId: Int get() = service.instanceId
 }
 
@@ -35,8 +35,8 @@ public actual data class DiscoveredCharacteristic internal constructor(
     public actual val descriptors: List<DiscoveredDescriptor> =
         characteristic.descriptors.map(::DiscoveredDescriptor)
 
-    override val serviceUuid: Uuid get() = characteristic.service.uuid
-    override val characteristicUuid: Uuid get() = characteristic.uuid
+    actual override val serviceUuid: Uuid get() = characteristic.service.uuid
+    actual override val characteristicUuid: Uuid get() = characteristic.uuid
     val instanceId: Int get() = characteristic.instanceId
     public actual val properties: Properties get() = Properties(characteristic.properties)
 }
@@ -45,9 +45,9 @@ public actual data class DiscoveredDescriptor internal constructor(
     internal actual val descriptor: PlatformDescriptor,
 ) : Descriptor {
 
-    override val serviceUuid: Uuid get() = descriptor.characteristic.service.uuid
-    override val characteristicUuid: Uuid get() = descriptor.characteristic.uuid
-    override val descriptorUuid: Uuid get() = descriptor.uuid
+    actual override val serviceUuid: Uuid get() = descriptor.characteristic.service.uuid
+    actual override val characteristicUuid: Uuid get() = descriptor.characteristic.uuid
+    actual override val descriptorUuid: Uuid get() = descriptor.uuid
 }
 
 internal fun PlatformCharacteristic.toLazyCharacteristic() = LazyCharacteristic(

--- a/core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
+++ b/core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
@@ -10,12 +10,13 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.ParcelUuid
 import com.benasher44.uuid.Uuid
+import com.juul.kable.PlatformAdvertisement.BondState
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal class ScanResultAndroidAdvertisement(
     private val scanResult: ScanResult,
-) : AndroidAdvertisement {
+) : PlatformAdvertisement {
 
     internal val bluetoothDevice: BluetoothDevice
         get() = scanResult.device

--- a/core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -40,7 +40,7 @@ public actual class ScannerBuilder {
     }
 
     @OptIn(ObsoleteKableApi::class)
-    internal actual fun build(): AndroidScanner = BluetoothLeScannerAndroidScanner(
+    internal actual fun build(): PlatformScanner = BluetoothLeScannerAndroidScanner(
         filters = filters.orEmpty(),
         scanSettings = scanSettings,
         logging = logging,

--- a/core/src/androidMain/kotlin/logs/SystemLogEngine.kt
+++ b/core/src/androidMain/kotlin/logs/SystemLogEngine.kt
@@ -3,27 +3,27 @@ package com.juul.kable.logs
 import android.util.Log
 
 public actual object SystemLogEngine : LogEngine {
-    override fun verbose(throwable: Throwable?, tag: String, message: String) {
+    actual override fun verbose(throwable: Throwable?, tag: String, message: String) {
         Log.v(tag, message, throwable)
     }
 
-    override fun debug(throwable: Throwable?, tag: String, message: String) {
+    actual override fun debug(throwable: Throwable?, tag: String, message: String) {
         Log.d(tag, message, throwable)
     }
 
-    override fun info(throwable: Throwable?, tag: String, message: String) {
+    actual override fun info(throwable: Throwable?, tag: String, message: String) {
         Log.i(tag, message, throwable)
     }
 
-    override fun warn(throwable: Throwable?, tag: String, message: String) {
+    actual override fun warn(throwable: Throwable?, tag: String, message: String) {
         Log.w(tag, message, throwable)
     }
 
-    override fun error(throwable: Throwable?, tag: String, message: String) {
+    actual override fun error(throwable: Throwable?, tag: String, message: String) {
         Log.e(tag, message, throwable)
     }
 
-    override fun assert(throwable: Throwable?, tag: String, message: String) {
+    actual override fun assert(throwable: Throwable?, tag: String, message: String) {
         Log.wtf(tag, message, throwable)
     }
 }

--- a/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
+++ b/core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
@@ -17,7 +17,7 @@ internal class CBPeripheralCoreBluetoothAdvertisement(
     override val rssi: Int,
     val data: Map<String, Any>,
     internal val cbPeripheral: CBPeripheral,
-) : CoreBluetoothAdvertisement {
+) : PlatformAdvertisement {
 
     override val identifier: Identifier
         get() = cbPeripheral.identifier.toUuid()
@@ -69,8 +69,8 @@ internal class CBPeripheralCoreBluetoothAdvertisement(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is CoreBluetoothAdvertisement) return false
-        if (identifier != other.identifier) return false
+        if (other !is PlatformAdvertisement) return false
+        if (other.identifier != identifier) return false
         return true
     }
 

--- a/core/src/appleMain/kotlin/CentralManagerCoreBluetoothScanner.kt
+++ b/core/src/appleMain/kotlin/CentralManagerCoreBluetoothScanner.kt
@@ -21,7 +21,7 @@ internal class CentralManagerCoreBluetoothScanner(
     filters: List<Filter>,
     options: Map<Any?, *>?,
     logging: Logging,
-) : CoreBluetoothScanner {
+) : PlatformScanner {
 
     init {
         require(filters.none { it is Filter.Address }) {
@@ -48,7 +48,7 @@ internal class CentralManagerCoreBluetoothScanner(
         }
     }
 
-    override val advertisements: Flow<CoreBluetoothAdvertisement> =
+    override val advertisements: Flow<PlatformAdvertisement> =
         central.delegate
             .response
             .onStart {

--- a/core/src/appleMain/kotlin/CentralManagerDelegate.kt
+++ b/core/src/appleMain/kotlin/CentralManagerDelegate.kt
@@ -4,6 +4,7 @@ import com.juul.kable.CentralManagerDelegate.ConnectionEvent.DidConnect
 import com.juul.kable.CentralManagerDelegate.ConnectionEvent.DidDisconnect
 import com.juul.kable.CentralManagerDelegate.ConnectionEvent.DidFailToConnect
 import com.juul.kable.CentralManagerDelegate.Response.DidDiscoverPeripheral
+import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,8 +77,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         _connectionState.emitBlocking(DidConnect(didConnectPeripheral.identifier))
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun centralManager(
         central: CBCentralManager,
         didDisconnectPeripheral: CBPeripheral,
@@ -87,8 +87,7 @@ internal class CentralManagerDelegate : NSObject(), CBCentralManagerDelegateProt
         _connectionState.emitBlocking(DidDisconnect(didDisconnectPeripheral.identifier, error))
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun centralManager(
         central: CBCentralManager,
         didFailToConnectPeripheral: CBPeripheral,

--- a/core/src/appleMain/kotlin/CoreBluetoothAdvertisement.kt
+++ b/core/src/appleMain/kotlin/CoreBluetoothAdvertisement.kt
@@ -1,10 +1,7 @@
 package com.juul.kable
 
-import com.benasher44.uuid.Uuid
-import platform.Foundation.NSData
-
-public interface CoreBluetoothAdvertisement : Advertisement {
-    public fun serviceDataAsNSData(uuid: Uuid): NSData?
-    public val manufacturerDataAsNSData: NSData?
-    public fun manufacturerDataAsNSData(companyIdentifierCode: Int): NSData?
-}
+@Deprecated(
+    "Moved to PlatformAdvertisement.",
+    replaceWith = ReplaceWith("PlatformAdvertisement"),
+)
+public typealias CoreBluetoothAdvertisement = PlatformAdvertisement

--- a/core/src/appleMain/kotlin/CoreBluetoothScanner.kt
+++ b/core/src/appleMain/kotlin/CoreBluetoothScanner.kt
@@ -1,7 +1,7 @@
 package com.juul.kable
 
-import kotlinx.coroutines.flow.Flow
-
-public interface CoreBluetoothScanner : Scanner {
-    public override val advertisements: Flow<CoreBluetoothAdvertisement>
-}
+@Deprecated(
+    "Moved to PlatformScanner.",
+    replaceWith = ReplaceWith("PlatformScanner"),
+)
+public typealias CoreBluetoothScanner = PlatformScanner

--- a/core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -10,6 +10,7 @@ import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.Logging.DataProcessor.Operation.Change
 import com.juul.kable.logs.detail
+import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -94,8 +95,7 @@ internal class PeripheralDelegate(
         _response.sendBlocking(DidDiscoverServices(peripheral.identifier, didDiscoverServices))
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didDiscoverIncludedServicesForService: CBService,
@@ -110,8 +110,7 @@ internal class PeripheralDelegate(
 
     /* Discovering Characteristics and their Descriptors */
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didDiscoverCharacteristicsForService: CBService,
@@ -130,8 +129,7 @@ internal class PeripheralDelegate(
         )
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didDiscoverDescriptorsForCharacteristic: CBCharacteristic,
@@ -146,8 +144,7 @@ internal class PeripheralDelegate(
 
     /* Retrieving Characteristic and Descriptor Values */
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didUpdateValueForCharacteristic: CBCharacteristic,
@@ -172,8 +169,7 @@ internal class PeripheralDelegate(
         characteristicChanges.emitBlocking(change)
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didUpdateValueForDescriptor: CBDescriptor,
@@ -190,8 +186,7 @@ internal class PeripheralDelegate(
 
     /* Writing Characteristic and Descriptor Values */
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didWriteValueForCharacteristic: CBCharacteristic,
@@ -210,8 +205,7 @@ internal class PeripheralDelegate(
         )
     }
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didWriteValueForDescriptor: CBDescriptor,
@@ -235,8 +229,7 @@ internal class PeripheralDelegate(
 
     /* Managing Notifications for a Characteristic’s Value */
 
-    // https://kotlinlang.org/docs/reference/native/objc_interop.html#subclassing-swiftobjective-c-classes-and-protocols-from-kotlin
-    @Suppress("CONFLICTING_OVERLOADS")
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didUpdateNotificationStateForCharacteristic: CBCharacteristic,

--- a/core/src/appleMain/kotlin/PlatformAdvertisement.kt
+++ b/core/src/appleMain/kotlin/PlatformAdvertisement.kt
@@ -1,0 +1,10 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+import platform.Foundation.NSData
+
+public actual interface PlatformAdvertisement : Advertisement {
+    public fun serviceDataAsNSData(uuid: Uuid): NSData?
+    public val manufacturerDataAsNSData: NSData?
+    public fun manufacturerDataAsNSData(companyIdentifierCode: Int): NSData?
+}

--- a/core/src/appleMain/kotlin/PlatformScanner.kt
+++ b/core/src/appleMain/kotlin/PlatformScanner.kt
@@ -1,3 +1,0 @@
-package com.juul.kable
-
-public actual typealias PlatformScanner = CoreBluetoothScanner

--- a/core/src/appleMain/kotlin/Profile.kt
+++ b/core/src/appleMain/kotlin/Profile.kt
@@ -25,7 +25,7 @@ public actual data class DiscoveredService internal constructor(
             .map { it as PlatformCharacteristic }
             .map(::DiscoveredCharacteristic)
 
-    override val serviceUuid: Uuid = service.UUID.toUuid()
+    actual override val serviceUuid: Uuid = service.UUID.toUuid()
 }
 
 public actual data class DiscoveredCharacteristic internal constructor(
@@ -38,8 +38,8 @@ public actual data class DiscoveredCharacteristic internal constructor(
             .map { it as PlatformDescriptor }
             .map(::DiscoveredDescriptor)
 
-    override val serviceUuid: Uuid = characteristic.service!!.UUID.toUuid()
-    override val characteristicUuid: Uuid = characteristic.UUID.toUuid()
+    actual override val serviceUuid: Uuid = characteristic.service!!.UUID.toUuid()
+    actual override val characteristicUuid: Uuid = characteristic.UUID.toUuid()
 
     public actual val properties: Properties = Properties(characteristic.properties.toInt())
 }
@@ -48,9 +48,9 @@ public actual data class DiscoveredDescriptor internal constructor(
     internal actual val descriptor: PlatformDescriptor,
 ) : Descriptor {
 
-    override val serviceUuid: Uuid = descriptor.characteristic!!.service!!.UUID.toUuid()
-    override val characteristicUuid: Uuid = descriptor.characteristic!!.UUID.toUuid()
-    override val descriptorUuid: Uuid = descriptor.UUID.toUuid()
+    actual override val serviceUuid: Uuid = descriptor.characteristic!!.service!!.UUID.toUuid()
+    actual override val characteristicUuid: Uuid = descriptor.characteristic!!.UUID.toUuid()
+    actual override val descriptorUuid: Uuid = descriptor.UUID.toUuid()
 }
 
 internal fun PlatformCharacteristic.toLazyCharacteristic() = LazyCharacteristic(

--- a/core/src/appleMain/kotlin/logs/SystemLogEngine.kt
+++ b/core/src/appleMain/kotlin/logs/SystemLogEngine.kt
@@ -3,27 +3,27 @@ package com.juul.kable.logs
 import platform.Foundation.NSLog
 
 public actual object SystemLogEngine : LogEngine {
-    override fun verbose(throwable: Throwable?, tag: String, message: String) {
+    actual override fun verbose(throwable: Throwable?, tag: String, message: String) {
         log("V", tag, message, throwable)
     }
 
-    override fun debug(throwable: Throwable?, tag: String, message: String) {
+    actual override fun debug(throwable: Throwable?, tag: String, message: String) {
         log("D", tag, message, throwable)
     }
 
-    override fun info(throwable: Throwable?, tag: String, message: String) {
+    actual override fun info(throwable: Throwable?, tag: String, message: String) {
         log("I", tag, message, throwable)
     }
 
-    override fun warn(throwable: Throwable?, tag: String, message: String) {
+    actual override fun warn(throwable: Throwable?, tag: String, message: String) {
         log("W", tag, message, throwable)
     }
 
-    override fun error(throwable: Throwable?, tag: String, message: String) {
+    actual override fun error(throwable: Throwable?, tag: String, message: String) {
         log("E", tag, message, throwable)
     }
 
-    override fun assert(throwable: Throwable?, tag: String, message: String) {
+    actual override fun assert(throwable: Throwable?, tag: String, message: String) {
         log("A", tag, message, throwable)
     }
 

--- a/core/src/commonMain/kotlin/PlatformAdvertisement.kt
+++ b/core/src/commonMain/kotlin/PlatformAdvertisement.kt
@@ -1,0 +1,3 @@
+package com.juul.kable
+
+public expect interface PlatformAdvertisement : Advertisement

--- a/core/src/commonMain/kotlin/PlatformScanner.kt
+++ b/core/src/commonMain/kotlin/PlatformScanner.kt
@@ -1,3 +1,3 @@
 package com.juul.kable
 
-public expect interface PlatformScanner : Scanner
+public typealias PlatformScanner = Scanner<PlatformAdvertisement>

--- a/core/src/commonMain/kotlin/Profile.kt
+++ b/core/src/commonMain/kotlin/Profile.kt
@@ -85,12 +85,15 @@ internal expect class PlatformDescriptor
 
 /** Wrapper around platform specific Bluetooth LE service. Holds a strong reference to underlying service. */
 public expect class DiscoveredService : Service {
+    override val serviceUuid: Uuid
     internal val service: PlatformService
     public val characteristics: List<DiscoveredCharacteristic>
 }
 
 /** Wrapper around platform specific Bluetooth LE characteristic. Holds a strong reference to underlying characteristic. */
 public expect class DiscoveredCharacteristic : Characteristic {
+    override val serviceUuid: Uuid
+    override val characteristicUuid: Uuid
     internal val characteristic: PlatformCharacteristic
     public val descriptors: List<DiscoveredDescriptor>
     public val properties: Properties
@@ -98,6 +101,9 @@ public expect class DiscoveredCharacteristic : Characteristic {
 
 /** Wrapper around platform specific Bluetooth LE descriptor. Holds a strong reference to underlying descriptor. */
 public expect class DiscoveredDescriptor : Descriptor {
+    override val serviceUuid: Uuid
+    override val characteristicUuid: Uuid
+    override val descriptorUuid: Uuid
     internal val descriptor: PlatformDescriptor
 }
 

--- a/core/src/commonMain/kotlin/Scanner.kt
+++ b/core/src/commonMain/kotlin/Scanner.kt
@@ -2,8 +2,8 @@ package com.juul.kable
 
 import kotlinx.coroutines.flow.Flow
 
-public interface Scanner {
-    public val advertisements: Flow<Advertisement>
+public interface Scanner<out T : Advertisement> {
+    public val advertisements: Flow<T>
 }
 
 @Suppress("FunctionName") // Builder function.

--- a/core/src/commonMain/kotlin/logs/SystemLogEngine.kt
+++ b/core/src/commonMain/kotlin/logs/SystemLogEngine.kt
@@ -1,3 +1,10 @@
 package com.juul.kable.logs
 
-public expect object SystemLogEngine : LogEngine
+public expect object SystemLogEngine : LogEngine {
+    override fun verbose(throwable: Throwable?, tag: String, message: String)
+    override fun debug(throwable: Throwable?, tag: String, message: String)
+    override fun info(throwable: Throwable?, tag: String, message: String)
+    override fun warn(throwable: Throwable?, tag: String, message: String)
+    override fun error(throwable: Throwable?, tag: String, message: String)
+    override fun assert(throwable: Throwable?, tag: String, message: String)
+}

--- a/core/src/jsMain/kotlin/BluetoothAdvertisingEventWebBluetoothAdvertisement.kt
+++ b/core/src/jsMain/kotlin/BluetoothAdvertisingEventWebBluetoothAdvertisement.kt
@@ -8,7 +8,7 @@ import org.khronos.webgl.DataView
 
 internal class BluetoothAdvertisingEventWebBluetoothAdvertisement(
     private val advertisement: BluetoothAdvertisingEvent,
-) : WebBluetoothAdvertisement {
+) : PlatformAdvertisement {
 
     internal val bluetoothDevice: BluetoothDevice
         get() = advertisement.device

--- a/core/src/jsMain/kotlin/BluetoothWebBluetoothScanner.kt
+++ b/core/src/jsMain/kotlin/BluetoothWebBluetoothScanner.kt
@@ -24,7 +24,7 @@ internal class BluetoothWebBluetoothScanner(
     bluetooth: Bluetooth,
     filters: List<Filter>,
     logging: Logging,
-) : WebBluetoothScanner {
+) : PlatformScanner {
 
     private val logger = Logger(logging, tag = "Kable/Scanner", identifier = null)
 
@@ -33,7 +33,7 @@ internal class BluetoothWebBluetoothScanner(
 
     private val options = filters.toBluetoothLEScanOptions()
 
-    override val advertisements: Flow<WebBluetoothAdvertisement> = callbackFlow {
+    override val advertisements: Flow<PlatformAdvertisement> = callbackFlow {
         check(supportsScanning) { "Scanning unavailable" }
 
         logger.info { message = "Starting scan" }

--- a/core/src/jsMain/kotlin/PlatformAdvertisement.kt
+++ b/core/src/jsMain/kotlin/PlatformAdvertisement.kt
@@ -1,0 +1,9 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+import org.khronos.webgl.DataView
+
+public actual interface PlatformAdvertisement : Advertisement {
+    public fun serviceDataAsDataView(uuid: Uuid): DataView?
+    public fun manufacturerDataAsDataView(companyIdentifierCode: Int): DataView?
+}

--- a/core/src/jsMain/kotlin/PlatformScanner.kt
+++ b/core/src/jsMain/kotlin/PlatformScanner.kt
@@ -1,3 +1,0 @@
-package com.juul.kable
-
-public actual typealias PlatformScanner = WebBluetoothScanner

--- a/core/src/jsMain/kotlin/Profile.kt
+++ b/core/src/jsMain/kotlin/Profile.kt
@@ -25,7 +25,7 @@ public actual data class DiscoveredService internal constructor(
     public actual val characteristics: List<DiscoveredCharacteristic>,
 ) : Service {
 
-    override val serviceUuid: Uuid = service.uuid.toUuid()
+    actual override val serviceUuid: Uuid = service.uuid.toUuid()
 }
 
 public actual data class DiscoveredCharacteristic internal constructor(
@@ -33,8 +33,8 @@ public actual data class DiscoveredCharacteristic internal constructor(
     public actual val descriptors: List<DiscoveredDescriptor>,
 ) : Characteristic {
 
-    override val serviceUuid: Uuid = characteristic.service.uuid.toUuid()
-    override val characteristicUuid: Uuid = characteristic.uuid.toUuid()
+    actual override val serviceUuid: Uuid = characteristic.service.uuid.toUuid()
+    actual override val characteristicUuid: Uuid = characteristic.uuid.toUuid()
 
     public actual val properties: Properties = Properties(characteristic.properties)
 }
@@ -43,9 +43,9 @@ public actual data class DiscoveredDescriptor internal constructor(
     internal actual val descriptor: PlatformDescriptor,
 ) : Descriptor {
 
-    override val serviceUuid: Uuid = descriptor.characteristic.service.uuid.toUuid()
-    override val characteristicUuid: Uuid = descriptor.characteristic.uuid.toUuid()
-    override val descriptorUuid: Uuid = descriptor.uuid.toUuid()
+    actual override val serviceUuid: Uuid = descriptor.characteristic.service.uuid.toUuid()
+    actual override val characteristicUuid: Uuid = descriptor.characteristic.uuid.toUuid()
+    actual override val descriptorUuid: Uuid = descriptor.uuid.toUuid()
 }
 
 internal suspend fun PlatformService.toDiscoveredService(logger: Logger): DiscoveredService {

--- a/core/src/jsMain/kotlin/WebBluetoothAdvertisement.kt
+++ b/core/src/jsMain/kotlin/WebBluetoothAdvertisement.kt
@@ -1,9 +1,7 @@
 package com.juul.kable
 
-import com.benasher44.uuid.Uuid
-import org.khronos.webgl.DataView
-
-public interface WebBluetoothAdvertisement : Advertisement {
-    public fun serviceDataAsDataView(uuid: Uuid): DataView?
-    public fun manufacturerDataAsDataView(companyIdentifierCode: Int): DataView?
-}
+@Deprecated(
+    "Moved to PlatformAdvertisement.",
+    replaceWith = ReplaceWith("PlatformAdvertisement"),
+)
+public typealias WebBluetoothAdvertisement = PlatformAdvertisement

--- a/core/src/jsMain/kotlin/WebBluetoothScanner.kt
+++ b/core/src/jsMain/kotlin/WebBluetoothScanner.kt
@@ -1,7 +1,7 @@
 package com.juul.kable
 
-import kotlinx.coroutines.flow.Flow
-
-public interface WebBluetoothScanner : Scanner {
-    public override val advertisements: Flow<WebBluetoothAdvertisement>
-}
+@Deprecated(
+    "Moved to PlatformScanner.",
+    replaceWith = ReplaceWith("PlatformScanner"),
+)
+public typealias WebBluetoothScanner = PlatformScanner

--- a/core/src/jsMain/kotlin/external/BluetoothRemoteGATTCharacteristic.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothRemoteGATTCharacteristic.kt
@@ -9,7 +9,7 @@ import kotlin.js.Promise
  * https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic
  * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothgattcharacteristic-interface
  */
-internal abstract external class BluetoothRemoteGATTCharacteristic : EventTarget {
+internal external class BluetoothRemoteGATTCharacteristic : EventTarget {
 
     val service: BluetoothRemoteGATTService
     val uuid: UUID

--- a/core/src/jsMain/kotlin/external/BluetoothRemoteGATTDescriptor.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothRemoteGATTDescriptor.kt
@@ -9,7 +9,7 @@ import kotlin.js.Promise
  * https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTDescriptor
  * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattdescriptor
  */
-internal abstract external class BluetoothRemoteGATTDescriptor : EventTarget {
+internal external class BluetoothRemoteGATTDescriptor : EventTarget {
     val uuid: UUID
     val characteristic: BluetoothRemoteGATTCharacteristic
     fun readValue(): Promise<DataView>

--- a/core/src/jsMain/kotlin/external/BluetoothRemoteGATTService.kt
+++ b/core/src/jsMain/kotlin/external/BluetoothRemoteGATTService.kt
@@ -8,7 +8,7 @@ import kotlin.js.Promise
  * https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTService
  * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattservice
  */
-internal abstract external class BluetoothRemoteGATTService : EventTarget {
+internal external class BluetoothRemoteGATTService : EventTarget {
 
     val uuid: UUID
 

--- a/core/src/jsMain/kotlin/logs/SystemLogEngine.kt
+++ b/core/src/jsMain/kotlin/logs/SystemLogEngine.kt
@@ -2,11 +2,11 @@ package com.juul.kable.logs
 
 public actual object SystemLogEngine : LogEngine {
 
-    override fun verbose(throwable: Throwable?, tag: String, message: String) {
+    actual override fun verbose(throwable: Throwable?, tag: String, message: String) {
         debug(throwable, tag, message)
     }
 
-    override fun debug(throwable: Throwable?, tag: String, message: String) {
+    actual override fun debug(throwable: Throwable?, tag: String, message: String) {
         if (throwable == null) {
             console.asDynamic().debug("[%s] %s", tag, message)
         } else {
@@ -14,7 +14,7 @@ public actual object SystemLogEngine : LogEngine {
         }
     }
 
-    override fun info(throwable: Throwable?, tag: String, message: String) {
+    actual override fun info(throwable: Throwable?, tag: String, message: String) {
         if (throwable == null) {
             console.info("[%s] %s", tag, message)
         } else {
@@ -22,7 +22,7 @@ public actual object SystemLogEngine : LogEngine {
         }
     }
 
-    override fun warn(throwable: Throwable?, tag: String, message: String) {
+    actual override fun warn(throwable: Throwable?, tag: String, message: String) {
         if (throwable == null) {
             console.warn("[%s] %s", tag, message)
         } else {
@@ -30,7 +30,7 @@ public actual object SystemLogEngine : LogEngine {
         }
     }
 
-    override fun error(throwable: Throwable?, tag: String, message: String) {
+    actual override fun error(throwable: Throwable?, tag: String, message: String) {
         if (throwable == null) {
             console.error("[%s] %s", tag, message)
         } else {
@@ -38,7 +38,7 @@ public actual object SystemLogEngine : LogEngine {
         }
     }
 
-    override fun assert(throwable: Throwable?, tag: String, message: String) {
+    actual override fun assert(throwable: Throwable?, tag: String, message: String) {
         if (throwable == null) {
             console.asDynamic().assert(false, "[%s] %s", tag, message)
         } else {

--- a/core/src/jvmMain/kotlin/com/juul/kable/PlatformAdvertisement.kt
+++ b/core/src/jvmMain/kotlin/com/juul/kable/PlatformAdvertisement.kt
@@ -1,0 +1,3 @@
+package com.juul.kable
+
+public actual interface PlatformAdvertisement : Advertisement

--- a/core/src/jvmMain/kotlin/com/juul/kable/PlatformScanner.kt
+++ b/core/src/jvmMain/kotlin/com/juul/kable/PlatformScanner.kt
@@ -1,3 +1,0 @@
-package com.juul.kable
-
-public actual interface PlatformScanner : Scanner

--- a/core/src/jvmMain/kotlin/com/juul/kable/Profile.kt
+++ b/core/src/jvmMain/kotlin/com/juul/kable/Profile.kt
@@ -12,7 +12,7 @@ public actual class DiscoveredService : Service {
         get() = jvmNotImplementedException()
     public actual val characteristics: List<DiscoveredCharacteristic>
         get() = jvmNotImplementedException()
-    override val serviceUuid: Uuid
+    actual override val serviceUuid: Uuid
         get() = jvmNotImplementedException()
 }
 
@@ -24,9 +24,9 @@ public actual class DiscoveredCharacteristic : Characteristic {
         get() = jvmNotImplementedException()
     public actual val properties: Characteristic.Properties
         get() = jvmNotImplementedException()
-    override val serviceUuid: Uuid
+    actual override val serviceUuid: Uuid
         get() = jvmNotImplementedException()
-    override val characteristicUuid: Uuid
+    actual override val characteristicUuid: Uuid
         get() = jvmNotImplementedException()
 }
 
@@ -34,10 +34,10 @@ public actual class DiscoveredCharacteristic : Characteristic {
 public actual class DiscoveredDescriptor : Descriptor {
     internal actual val descriptor: PlatformDescriptor
         get() = jvmNotImplementedException()
-    override val serviceUuid: Uuid
+    actual override val serviceUuid: Uuid
         get() = jvmNotImplementedException()
-    override val characteristicUuid: Uuid
+    actual override val characteristicUuid: Uuid
         get() = jvmNotImplementedException()
-    override val descriptorUuid: Uuid
+    actual override val descriptorUuid: Uuid
         get() = jvmNotImplementedException()
 }

--- a/core/src/jvmMain/kotlin/com/juul/kable/logs/SystemLogEngine.kt
+++ b/core/src/jvmMain/kotlin/com/juul/kable/logs/SystemLogEngine.kt
@@ -4,27 +4,27 @@ import com.juul.kable.jvmNotImplementedException
 
 public actual object SystemLogEngine : LogEngine {
 
-    override fun verbose(throwable: Throwable?, tag: String, message: String) {
+    actual override fun verbose(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 
-    override fun debug(throwable: Throwable?, tag: String, message: String) {
+    actual override fun debug(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 
-    override fun info(throwable: Throwable?, tag: String, message: String) {
+    actual override fun info(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 
-    override fun warn(throwable: Throwable?, tag: String, message: String) {
+    actual override fun warn(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 
-    override fun error(throwable: Throwable?, tag: String, message: String) {
+    actual override fun error(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 
-    override fun assert(throwable: Throwable?, tag: String, message: String) {
+    actual override fun assert(throwable: Throwable?, tag: String, message: String) {
         jvmNotImplementedException()
     }
 }


### PR DESCRIPTION
Changes needed to get #683 compiling (i.e. changes needed to support K2).

Dropped per platform `Scanner` interfaces, instead `Scanner` now carries a generic (`Scanner<T : Advertisement>`) of what advertisement type it will emit via its `advertisements` flow. Each platform scanner implements the common `Scanner<T : Advertisement>` interface rather than each platform (e.g. `AndroidScanner`) interface. This change was necessary because K2 does not allow `expect`/`actual` interfaces to differ (signatures must match exactly). Whereas `AndroidScanner` would have an `advertisements` flow of type `Flow<AndroidAdvertisement>` which did not match the `expect` interface that had `Flow<Advertisement>`.

On JS, some `external` classes (that were used in `actual` type aliases) were made concrete (not `abstract`) in order to match the `expect` side (`PlatformService`, `PlatformCharacteristic`, `PlatformDescriptor`).

Special thanks to @cedrickcooke for helping me wrangle a solution that minimized the need for larger API changes.