### PR TITLE
Prefix Maven artifacts with `kable-`

### DIFF
--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=kable-core

--- a/exceptions/gradle.properties
+++ b/exceptions/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=kable-exceptions

--- a/log-engine-khronicle/gradle.properties
+++ b/log-engine-khronicle/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=kable-log-engine-khronicle


### PR DESCRIPTION
We've seen issues for library consumers that manifest in various ways when multiple libraries have the same Maven artifact name.

Most recently, with the K2 upgrade, on the consumer side, we saw failures similar to:

```
e: KLIB resolver: Could not find "com.juul.tuulbox:encoding" in [/Users/ci/Library/Application Support/kotlin/daemon]
```

This occurred because our internal project had an `encoding` module which clashed with Tuulbox's _and_ another of our internal libraries artifacts named `encoding`.

We resolved it by renaming our internal library's Maven artifact to be prefixed.

Additionally, it seems to be standard for libraries to prefix their Maven artifact names, for example: [kotlinx-coroutines-core](https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core)