### PR TITLE
Ensure teardown is completed when observation coroutines are canceled

### DIFF
--- a/core/src/commonMain/kotlin/Observers.kt
+++ b/core/src/commonMain/kotlin/Observers.kt
@@ -83,7 +83,9 @@ internal class Observers<T>(
             .mapNotNull { event -> (event as? CharacteristicChange)?.data }
             .onCompletion {
                 try {
-                    // If this suspending function is canceled the peripheral could end up in an indeterminate state.
+                    // `NonCancellable` used to prevent interruption of resetting the observation
+                    // state, which can prevent subsequent re-observation.
+                    // See https://github.com/JuulLabs/kable/issues/677 for more details.
                     withContext(NonCancellable) {
                         observation.onCompletion(onSubscription)
                     }

--- a/core/src/commonMain/kotlin/Observers.kt
+++ b/core/src/commonMain/kotlin/Observers.kt
@@ -5,6 +5,7 @@ import com.juul.kable.ObservationEvent.Error
 import com.juul.kable.logs.Logging
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
 internal expect fun Peripheral.observationHandler(): Observation.Handler
@@ -81,7 +83,10 @@ internal class Observers<T>(
             .mapNotNull { event -> (event as? CharacteristicChange)?.data }
             .onCompletion {
                 try {
-                    observation.onCompletion(onSubscription)
+                    // If this suspending function is canceled the peripheral could end up in an indeterminate state.
+                    withContext(NonCancellable) {
+                        observation.onCompletion(onSubscription)
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {


### PR DESCRIPTION
It turns out that any suspending function called after cancelation of the coroutine will itself be canceled. [The kotlin documentation](https://kotlinlang.org/docs/cancellation-and-timeouts.html#run-non-cancellable-block) recommends using `withContext(NonCancellable) {}` in these cases.

Fixes #677

I wanted to write a test for this, but the observation tests don't use any suspend functions so it wasn't clear to me how. It did fix the problem for me, however.