### PR TITLE
Fix nullability of `connectGattCompat` function

### DIFF
--- a/kable-core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -101,7 +101,7 @@ private fun BluetoothDevice.connectGattCompat(
     autoConnect: Boolean,
     callback: BluetoothGattCallback,
     transport: Int,
-): BluetoothGatt = when {
+): BluetoothGatt? = when {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> connectGatt(context, autoConnect, callback, transport)
     else -> connectGatt(context, autoConnect, callback)
 }


### PR DESCRIPTION
Was incorrectly marked as non-nullable, but `connectGatt` may return `null`.