### PR TITLE
Add `Options` builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [`Scanner`] may be configured via the following DSL (shown are defaults, whe
 val scanner = Scanner {
     filters {
         match {
-            name = "My device"
+            name = Filter.Name.Exact("My device")
         }
     }
     logging {
@@ -293,16 +293,16 @@ specified options, the browser shows the user a list of peripherals matching the
 user is then returned (as a [`Peripheral`] object).
 
 ```kotlin
-val options = Options(
+val options = Options {
     filters {
         match {
             name = Filter.Name.Prefix("Example")
         }
-    },
+    }
     optionalServices = listOf(
         uuidFrom("f000aa80-0451-4000-b000-000000000000"),
         uuidFrom("f000aa81-0451-4000-b000-000000000000"),
-    ),
+    )
 )
 val peripheral = scope.requestPeripheral(options).await()
 ```

--- a/kable-core/src/jsMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/jsMain/kotlin/Bluetooth.kt
@@ -103,7 +103,7 @@ private fun Options.filters(): List<BluetoothLEScanFilterInit> =
     if (filterSets?.isNotEmpty() == true) {
         filterSets.toBluetoothLEScanFilterInit()
     } else {
-        FiltersBuilder().apply(filters).build().toBluetoothLEScanFilterInit()
+        filterPredicates.toBluetoothLEScanFilterInit()
     }
 
 // Note: Web Bluetooth requires that UUIDs be provided as lowercase strings.

--- a/kable-core/src/jsMain/kotlin/OptionsBuilder.kt
+++ b/kable-core/src/jsMain/kotlin/OptionsBuilder.kt
@@ -1,0 +1,32 @@
+package com.juul.kable
+
+import com.benasher44.uuid.Uuid
+
+public class OptionsBuilder internal constructor() {
+
+    private var filterPredicates: List<FilterPredicate> = emptyList()
+
+    /**
+     * Filters to apply when requesting devices. If predicates are non-empty, then only devices
+     * that match at least one of the predicates will appear in the `requestDevice` picker.
+     *
+     * Filtering on Service Data is not supported because it is not implemented:
+     * https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md
+     *
+     * Filtering on Manufacturer Data is supported and a good explanation can be found here:
+     * https://github.com/WebBluetoothCG/web-bluetooth/blob/main/data-filters-explainer.md
+     */
+    public fun filters(builder: FiltersBuilder.() -> Unit) {
+        filterPredicates = FiltersBuilder().apply(builder).build()
+    }
+
+    /**
+     * Access is only granted to services listed as [service filters][Filter.Service] in [filters].
+     * If any additional services need to be accessed, they must be specified in [optionalServices].
+     *
+     * https://webbluetoothcg.github.io/web-bluetooth/#device-discovery
+     */
+    public var optionalServices: List<Uuid>? = null
+
+    internal fun build() = Options(null, optionalServices, filterPredicates)
+}


### PR DESCRIPTION
Brings JavaScript-side API (of specifying filters) in line with the other platforms (see #695) by providing an `Options` builder that contains a `filters { }` bulder.

Closes #723