### PR TITLE
Use `jso` from kotlin-wrappers library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 tuulbox-collections = { module = "com.juul.tuulbox:collections", version.ref = "tuulbox" }
 tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 uuid = { module = "com.benasher44:uuid", version = "0.8.4" }
+wrappers-bom = { module = "org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom", version = "1.0.0-pre.781" }
+wrappers-web = { module = "org.jetbrains.kotlin-wrappers:kotlin-web" }
 
 [plugins]
 android-library = { id = "com.android.library", version = "8.5.1" }

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -47,6 +47,11 @@ kotlin {
 
             implementation(libs.tuulbox.coroutines)
         }
+
+        jsMain.dependencies {
+            api(libs.wrappers.web)
+            api(project.dependencies.platform(libs.wrappers.bom))
+        }
     }
 }
 

--- a/kable-core/src/jsMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/jsMain/kotlin/Bluetooth.kt
@@ -8,6 +8,7 @@ import com.juul.kable.external.BluetoothAvailabilityChanged
 import com.juul.kable.external.BluetoothLEScanFilterInit
 import com.juul.kable.external.BluetoothServiceUUID
 import com.juul.kable.external.RequestDeviceOptions
+import js.objects.jso
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.await
 import kotlinx.coroutines.channels.awaitClose

--- a/kable-core/src/jsMain/kotlin/BluetoothLEScanOptions.kt
+++ b/kable-core/src/jsMain/kotlin/BluetoothLEScanOptions.kt
@@ -4,6 +4,7 @@ import com.benasher44.uuid.Uuid
 import com.juul.kable.external.BluetoothLEScanFilterInit
 import com.juul.kable.external.BluetoothLEScanOptions
 import com.juul.kable.external.BluetoothManufacturerDataFilterInit
+import js.objects.jso
 
 /** Convert list of public API type to Web Bluetooth (JavaScript) type. */
 internal fun List<FilterPredicate>.toBluetoothLEScanOptions(): BluetoothLEScanOptions = jso {

--- a/kable-core/src/jsMain/kotlin/FilterSet.kt
+++ b/kable-core/src/jsMain/kotlin/FilterSet.kt
@@ -3,6 +3,7 @@ package com.juul.kable
 import com.benasher44.uuid.Uuid
 import com.juul.kable.external.BluetoothLEScanFilterInit
 import com.juul.kable.external.BluetoothManufacturerDataFilterInit
+import js.objects.jso
 
 /**
  * Filtering on Service Data is not supported because it is not implemented:

--- a/kable-core/src/jsMain/kotlin/jso.kt
+++ b/kable-core/src/jsMain/kotlin/jso.kt
@@ -1,8 +1,0 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
-package com.juul.kable
-
-// Copied from:
-// https://github.com/JetBrains/kotlin-wrappers/blob/8a118e3261c093cf1b88002502ca36f17d356394/kotlin-js/src/main/kotlin/js/core/jso.kt
-internal inline fun <T : Any> jso(): T = js("({})")
-internal inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)


### PR DESCRIPTION
Uses `jso` (for creating JavaScript objects) from the JetBrain's [kotlin-wrappers](https://github.com/JetBrains/kotlin-wrappers) library.

Related to #721.