### PR TITLE
Suppress Kotlin compilation warnings on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           validate-wrappers: true
 
-      - run: ./gradlew assemble
+      - run: ./gradlew assemble -PsuppressWarnings=true
       - run: ./gradlew check
       - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,17 @@ allprojects {
         mavenCentral()
     }
 
+    listOf(
+        org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile::class,
+        org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon::class,
+        org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile::class,
+        org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile::class,
+    ).forEach { kClass ->
+        tasks.withType(kClass).configureEach {
+            compilerOptions.suppressWarnings = (findProperty("suppressWarnings") as? String).toBoolean()
+        }
+    }
+
     tasks.withType<Test>().configureEach {
         testLogging {
             events("started", "passed", "skipped", "failed", "standardOut", "standardError")


### PR DESCRIPTION
Compilation warnings on CI are too noisy (makes it difficult to find cause of CI failures).