### PR TITLE
Handle when peripheral services change

### DIFF
--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -41,6 +41,10 @@ import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 
+// Number of service discovery attempts to make if no services are discovered.
+// https://github.com/JuulLabs/kable/issues/295
+private const val DISCOVER_SERVICES_RETRIES = 5
+
 internal class BluetoothDeviceAndroidPeripheral(
     private val bluetoothDevice: BluetoothDevice,
     private val autoConnectPredicate: () -> Boolean,
@@ -163,7 +167,7 @@ internal class BluetoothDeviceAndroidPeripheral(
         }.rssi
 
     private suspend fun discoverServices() {
-        connectionOrThrow().discoverServices()
+        connectionOrThrow().discoverServices(retries = DISCOVER_SERVICES_RETRIES)
         unwrapCancellationExceptions {
             onServicesDiscovered(ServicesDiscoveredPeripheral(this))
         }

--- a/kable-core/src/androidMain/kotlin/gatt/Callback.kt
+++ b/kable-core/src/androidMain/kotlin/gatt/Callback.kt
@@ -61,6 +61,7 @@ internal class Callback(
 
     val onResponse = Channel<Response>(CONFLATED)
     val onMtuChanged = Channel<OnMtuChanged>(CONFLATED)
+    val onServiceChanged = Channel<OnServiceChanged>(CONFLATED)
 
     override fun onPhyUpdate(
         gatt: BluetoothGatt,
@@ -275,7 +276,7 @@ internal class Callback(
 
     override fun onServiceChanged(gatt: BluetoothGatt) {
         logger.debug { message = "onServiceChanged" }
-        // todo: https://github.com/JuulLabs/kable/issues/662
+        onServiceChanged.trySendOrLog(OnServiceChanged)
     }
 
     private fun <E> SendChannel<E>.trySendOrLog(element: E) {

--- a/kable-core/src/androidMain/kotlin/gatt/Response.kt
+++ b/kable-core/src/androidMain/kotlin/gatt/Response.kt
@@ -97,6 +97,8 @@ internal data class OnMtuChanged(
     override val status: GattStatus,
 ) : Response()
 
+internal object OnServiceChanged
+
 /**
  * Represents the possible GATT statuses as defined in [BluetoothGatt]:
  *

--- a/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -13,6 +13,7 @@ import com.juul.kable.logs.detail
 import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -84,8 +85,14 @@ internal class PeripheralDelegate(
         ) : Response()
     }
 
+    data class OnServiceChanged(
+        val cbServices: List<CBService>,
+    )
+
     private val _response = Channel<Response>(BUFFERED)
     val response: ReceiveChannel<Response> = _response
+
+    val onServiceChanged = Channel<OnServiceChanged>(CONFLATED)
 
     private val logger = Logger(logging, tag = "Kable/Delegate", identifier = identifier)
 
@@ -288,10 +295,16 @@ internal class PeripheralDelegate(
         peripheral: CBPeripheral,
         didModifyServices: List<*>,
     ) {
+        // Cast should be safe since `didModifyServices` type is `[CBService]`, according to:
+        // https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/peripheral(_:didmodifyservices:)
+        @Suppress("UNCHECKED_CAST")
+        val invalidatedServices = didModifyServices as List<CBService>
+
         logger.debug {
             message = "didModifyServices"
+            detail("invalidatedServices", invalidatedServices.toString())
         }
-        // todo
+        onServiceChanged.sendBlocking(OnServiceChanged(invalidatedServices))
     }
 
     /* Monitoring L2CAP Channels */

--- a/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
@@ -41,8 +41,10 @@ public expect class PeripheralBuilder internal constructor() {
 
     /**
      * Registers a [ServicesDiscoveredAction] for the [Peripheral] that is invoked after initial
-     * service discover (upon establishing a connection). Is **not** invoked upon subsequent service
-     * re-discoveries (due to peripheral service database changing while connected).
+     * service discovery (upon establishing a connection).
+     *
+     * Is **not** invoked upon subsequent service re-discoveries (due to peripheral service database
+     * changing while connected).
      */
     public fun onServicesDiscovered(action: ServicesDiscoveredAction)
 

--- a/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
@@ -38,6 +38,12 @@ internal val defaultDisconnectTimeout = 5.seconds
 
 public expect class PeripheralBuilder internal constructor() {
     public fun logging(init: LoggingBuilder)
+
+    /**
+     * Registers a [ServicesDiscoveredAction] for the [Peripheral] that is invoked after initial
+     * service discover (upon establishing a connection). Is **not** invoked upon subsequent service
+     * re-discoveries (due to peripheral service database changing while connected).
+     */
     public fun onServicesDiscovered(action: ServicesDiscoveredAction)
 
     /**


### PR DESCRIPTION
Re-discovers services when peripheral service database changes.

> [!WARNING]
> Does not re-discover on JavaScript, as event is not supported on Chrome, per [Implementation Status](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md#gatt-communication-api):
> ![Screenshot 2024-09-19 at 1 03 27 PM](https://github.com/user-attachments/assets/3aff791f-668e-4fec-bf8b-1eb25eb2e75d)


Closes #662