### PR TITLE
Remove `davidtaylor-juul` as a CODEOWNER of `appleMain`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # https://help.github.com/articles/about-codeowners/
 
-*                @JuulLabs/conx-kotlin-reviewers @twyatt
-appleMain/       @JuulLabs/conx-kotlin-reviewers @davidtaylor-juul @twyatt
+* @JuulLabs/conx-kotlin-reviewers @twyatt


### PR DESCRIPTION
@davidtaylor-juul was being pulled into reviews disproportionately for reviews that didn't necessarily need Core Bluetooth expertise.

Instead, I'll manually add @davidtaylor-juul as a reviewer if I'm uncertain about a Core Bluetooth related change.