### PR TITLE
Have `allowDuplicateKeys` default to `true`

### DIFF
--- a/kable-core/src/appleMain/kotlin/ScannerBuilder.kt
+++ b/kable-core/src/appleMain/kotlin/ScannerBuilder.kt
@@ -25,7 +25,7 @@ public actual class ScannerBuilder {
      * Specifies whether the scan should run without duplicate filtering. This corresponds to
      * Core Bluetooth's [CBCentralManagerScanOptionAllowDuplicatesKey] scanning option.
      */
-    public var allowDuplicateKeys: Boolean? = null
+    public var allowDuplicateKeys: Boolean? = true
 
     /**
      * Causes the scanner to scan for peripherals soliciting any of the services contained in the


### PR DESCRIPTION
Change the default to match Android's behavior.

Without this change (with `allowDuplicateKeys` using Core Bluetooth's default, which is `false`) only 1 or 2 advertisement events are received during a scan, and doesn't give the feel of a "realtime" scan (with RSSI value, etc updating while scanning).