### PR TITLE
Drop `ConnectionRejectedException`

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -108,12 +108,6 @@ public final class com/juul/kable/Characteristic$Properties {
 	public final synthetic fun unbox-impl ()I
 }
 
-public final class com/juul/kable/ConnectionRejectedException : java/io/IOException {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public abstract interface class com/juul/kable/Descriptor {
 	public abstract fun getCharacteristicUuid ()Ljava/util/UUID;
 	public abstract fun getDescriptorUuid ()Ljava/util/UUID;

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -63,12 +63,6 @@ public final class com/juul/kable/Characteristic$Properties {
 	public final synthetic fun unbox-impl ()I
 }
 
-public final class com/juul/kable/ConnectionRejectedException : java/io/IOException {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public abstract interface class com/juul/kable/Descriptor {
 	public abstract fun getCharacteristicUuid ()Ljava/util/UUID;
 	public abstract fun getDescriptorUuid ()Ljava/util/UUID;

--- a/kable-core/src/androidMain/kotlin/BluetoothDevice.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDevice.kt
@@ -16,6 +16,7 @@ import com.juul.kable.gatt.Callback
 import com.juul.kable.logs.Logging
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.io.IOException
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 
@@ -52,10 +53,7 @@ internal fun BluetoothDevice.connect(
                     ?: connectGattCompat(context, true, callback, transport.intValue)
 
             else -> connectGattCompat(context, autoConnect, callback, transport.intValue)
-        }
-            ?: error(
-                "Connection rejected by Android system due to either: bluetooth hardware unavailable, invalid MAC address, or Binder remote-invocation error",
-            )
+        } ?: throw IOException("Binder remote-invocation error")
     } catch (t: Throwable) {
         threading.release()
         throw t

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -21,7 +21,9 @@ import com.juul.kable.State.Disconnected
 import com.juul.kable.WriteType.WithResponse
 import com.juul.kable.WriteType.WithoutResponse
 import com.juul.kable.bluetooth.checkBluetoothIsOn
+import com.juul.kable.bluetooth.checkBluetoothIsSupported
 import com.juul.kable.bluetooth.clientCharacteristicConfigUuid
+import com.juul.kable.bluetooth.requireNonZeroAddress
 import com.juul.kable.gatt.Response.OnCharacteristicRead
 import com.juul.kable.gatt.Response.OnCharacteristicWrite
 import com.juul.kable.gatt.Response.OnDescriptorRead
@@ -92,13 +94,14 @@ internal class BluetoothDeviceAndroidPeripheral(
     override val type: Type
         get() = typeFrom(bluetoothDevice.type)
 
-    override val address: String = bluetoothDevice.address
+    override val address: String = requireNonZeroAddress(bluetoothDevice.address)
 
     @ExperimentalApi
     override val name: String?
         get() = bluetoothDevice.name
 
     private suspend fun establishConnection(scope: CoroutineScope): CoroutineScope {
+        checkBluetoothIsSupported()
         checkBluetoothIsOn()
 
         logger.info { message = "Connecting" }

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -118,7 +118,7 @@ internal class BluetoothDeviceAndroidPeripheral(
                 logging,
                 threadingStrategy,
                 disconnectTimeout,
-            ) ?: throw ConnectionRejectedException()
+            )
 
             suspendUntil<State.Connecting.Services>()
             discoverServices()

--- a/kable-core/src/androidMain/kotlin/bluetooth/CheckMacAddress.kt
+++ b/kable-core/src/androidMain/kotlin/bluetooth/CheckMacAddress.kt
@@ -1,0 +1,11 @@
+package com.juul.kable.bluetooth
+
+import android.bluetooth.BluetoothDevice
+
+private const val ZERO_MAC_ADDRESS = "00:00:00:00:00:00"
+
+/** Performs the same MAC address validation as performed in [BluetoothDevice.connectGatt]. */
+internal fun requireNonZeroAddress(address: String): String {
+    require(ZERO_MAC_ADDRESS != address) { "Invalid address: $address" }
+    return address
+}

--- a/kable-core/src/commonMain/kotlin/GattStatusException.kt
+++ b/kable-core/src/commonMain/kotlin/GattStatusException.kt
@@ -2,11 +2,6 @@ package com.juul.kable
 
 import kotlinx.io.IOException
 
-public class ConnectionRejectedException(
-    message: String? = null,
-    cause: Throwable? = null,
-) : IOException(message, cause)
-
 public class GattStatusException(
     message: String? = null,
     cause: Throwable? = null,

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -119,7 +119,9 @@ public interface Peripheral : CoroutineScope {
      * supervisor scope, meaning any failures in launched coroutines will not fail other launched
      * coroutines nor cause a disconnect.
      *
-     * @throws IllegalStateException when a connection request is rejected by the system (e.g. bluetooth hardware unavailable, invalid MAC address, or Binder remote-invocation error).
+     * @throws IllegalStateException when a connection request could not be made (e.g. bluetooth hardware unavailable, invalid MAC address, or Binder remote-invocation error).
+     * @throws NotConnectedException if unable to establish connection (e.g. connection lost while discovering services).
+     * @throws IOException (Android) if request failed due to Binder remote-invocation error.
      * @throws CancellationException if [Peripheral]'s [CoroutineScope] has been [cancelled][Peripheral.cancel].
      */
     public suspend fun connect(): CoroutineScope

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -119,7 +119,7 @@ public interface Peripheral : CoroutineScope {
      * supervisor scope, meaning any failures in launched coroutines will not fail other launched
      * coroutines nor cause a disconnect.
      *
-     * @throws ConnectionRejectedException when a connection request is rejected by the system (e.g. bluetooth hardware unavailable).
+     * @throws IllegalStateException when a connection request is rejected by the system (e.g. bluetooth hardware unavailable, invalid MAC address, or Binder remote-invocation error).
      * @throws CancellationException if [Peripheral]'s [CoroutineScope] has been [cancelled][Peripheral.cancel].
      */
     public suspend fun connect(): CoroutineScope

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -119,7 +119,7 @@ public interface Peripheral : CoroutineScope {
      * supervisor scope, meaning any failures in launched coroutines will not fail other launched
      * coroutines nor cause a disconnect.
      *
-     * @throws IllegalStateException when a connection request could not be made (e.g. bluetooth hardware unavailable, invalid MAC address, or Binder remote-invocation error).
+     * @throws IllegalStateException when a connection request could not be made (e.g. bluetooth not supported).
      * @throws NotConnectedException if unable to establish connection (e.g. connection lost while discovering services).
      * @throws IOException (Android) if request failed due to Binder remote-invocation error.
      * @throws CancellationException if [Peripheral]'s [CoroutineScope] has been [cancelled][Peripheral.cancel].

--- a/kable-core/src/commonMain/kotlin/bluetooth/CheckBluetoothIsSupported.kt
+++ b/kable-core/src/commonMain/kotlin/bluetooth/CheckBluetoothIsSupported.kt
@@ -1,0 +1,5 @@
+package com.juul.kable.bluetooth
+
+internal suspend fun checkBluetoothIsSupported() {
+    check(isSupported()) { "Bluetooth not supported" }
+}


### PR DESCRIPTION
Continuing effort to simplify exception hierarchy (#724).

Inspecting the Android source (at Android API 34):

<details>
<summary><code>BluetoothDevice.java#L3257-3285</code></summary>

<img width="970" alt="BluetoothDevice java" src="https://github.com/user-attachments/assets/c2e3e95d-8f2a-425b-9a60-12c95012b5a7">
</details>

The possible reasons for `BluetoothDevice.connectGatt` returning `null` are:

1. Line 3272: Bluetooth not supported
2. Line 3275: `BluetoothDevice` has a "NULL" MAC address (`00:00:00:00:00:00`)
3. Line 3281 + 3284: `RemoteException` was thrown/caught

This PR now throws appropriate exceptions for the above conditions:

1. `IllegalStateException("Bluetooth not supported")`
2. `IllegalArgumentException("Invalid address: $address")` — _thrown at `Peripheral` construction_
3. `IOException("Binder remote-invocation error")`

> [!TIP]
> More details about `RemoteException` can be found in [Android RemoteExceptions and Services](https://stackoverflow.com/a/3177154) Stackoverflow answer.