### PR TITLE
Deprecate `Bluetooth.availability`

### DIFF
--- a/kable-core/src/androidMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/androidMain/kotlin/Bluetooth.kt
@@ -34,18 +34,50 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED as BLUETOOTH_STATE_CHANGED
 
+@Deprecated(
+    message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+        "Will be removed in a future release. " +
+        "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+)
 public actual enum class Reason {
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Off, // BluetoothAdapter.STATE_OFF
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     TurningOff, // BluetoothAdapter.STATE_TURNING_OFF or BluetoothAdapter.STATE_BLE_TURNING_OFF
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     TurningOn, // BluetoothAdapter.STATE_TURNING_ON or BluetoothAdapter.STATE_BLE_TURNING_ON
 
     /**
      * [BluetoothManager] unavailable or [BluetoothManager.getAdapter] returned `null` (indicating
      * that Bluetooth is not available).
      */
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     AdapterNotAvailable,
 
     /** Only applicable on Android 11 (API 30) and lower. */
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     LocationServicesDisabled,
 }
 

--- a/kable-core/src/appleMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/appleMain/kotlin/Bluetooth.kt
@@ -18,11 +18,45 @@ import platform.CoreBluetooth.CBCentralManagerStateUnauthorized
 import platform.CoreBluetooth.CBCentralManagerStateUnsupported
 
 /** https://developer.apple.com/documentation/corebluetooth/cbmanagerstate */
+@Deprecated(
+    message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+        "Will be removed in a future release. " +
+        "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+)
 public actual enum class Reason {
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Off, // CBManagerState.poweredOff
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Resetting, // CBManagerState.resetting
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Unauthorized, // CBManagerState.unauthorized
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Unsupported, // CBManagerState.unsupported
+
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     Unknown, // CBManagerState.unknown
 }
 

--- a/kable-core/src/commonMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/commonMain/kotlin/Bluetooth.kt
@@ -7,6 +7,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.jvm.JvmName
 import com.juul.kable.bluetooth.isSupported as isBluetoothSupported
 
+@Deprecated(
+    message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+        "Will be removed in a future release. " +
+        "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+)
 public expect enum class Reason
 
 public object Bluetooth {
@@ -30,11 +35,32 @@ public object Bluetooth {
         override fun toString(): String = "00000000-0000-1000-8000-00805F9B34FB"
     }
 
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     public sealed class Availability {
+        @Deprecated(
+            message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+                "Will be removed in a future release. " +
+                "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+        )
         public data object Available : Availability()
+
+        @Deprecated(
+            message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+                "Will be removed in a future release. " +
+                "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+        )
         public data class Unavailable(val reason: Reason?) : Availability()
     }
 
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     public val availability: Flow<Availability> = bluetoothAvailability
 
     /**

--- a/kable-core/src/jsMain/kotlin/BluetoothAvailability.kt
+++ b/kable-core/src/jsMain/kotlin/BluetoothAvailability.kt
@@ -12,8 +12,18 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
 import org.w3c.dom.events.Event
 
+@Deprecated(
+    message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+        "Will be removed in a future release. " +
+        "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+)
 public actual enum class Reason {
     /** `window.navigator.bluetooth` is undefined. */
+    @Deprecated(
+        message = "`Bluetooth.availability` has inconsistent behavior across platforms. " +
+            "Will be removed in a future release. " +
+            "See https://github.com/JuulLabs/kable/issues/737 for more details.",
+    )
     BluetoothUndefined,
 }
 


### PR DESCRIPTION
Per #737, deprecating `Bluetooth.availability`.