### PR TITLE
Make peripheral builder argument optional

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -350,6 +350,8 @@ public final class com/juul/kable/PeripheralBuilder {
 public final class com/juul/kable/PeripheralKt {
 	public static final fun Peripheral (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static final fun Peripheral (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun Peripheral$default (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun Peripheral$default (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 }
 
 public final class com/juul/kable/Peripheral_deprecatedKt {

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -258,6 +258,7 @@ public final class com/juul/kable/PeripheralBuilder {
 
 public final class com/juul/kable/PeripheralKt {
 	public static final fun Peripheral (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun Peripheral$default (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 }
 
 public final class com/juul/kable/Peripheral_deprecatedKt {

--- a/kable-core/src/androidMain/kotlin/Peripheral.kt
+++ b/kable-core/src/androidMain/kotlin/Peripheral.kt
@@ -12,7 +12,7 @@ public actual fun Peripheral(
 
 public fun Peripheral(
     bluetoothDevice: BluetoothDevice,
-    builderAction: PeripheralBuilderAction,
+    builderAction: PeripheralBuilderAction = {},
 ): Peripheral {
     val builder = PeripheralBuilder().apply(builderAction)
     return BluetoothDeviceAndroidPeripheral(

--- a/kable-core/src/appleMain/kotlin/Peripheral.kt
+++ b/kable-core/src/appleMain/kotlin/Peripheral.kt
@@ -23,7 +23,7 @@ public fun Peripheral(
 @Suppress("FunctionName") // Builder function.
 public fun Peripheral(
     cbPeripheral: CBPeripheral,
-    builderAction: PeripheralBuilderAction,
+    builderAction: PeripheralBuilderAction = {},
 ): CoreBluetoothPeripheral {
     val builder = PeripheralBuilder().apply(builderAction)
     return CBPeripheralCoreBluetoothPeripheral(

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -289,7 +289,7 @@ internal typealias PeripheralBuilderAction = PeripheralBuilder.() -> Unit
 
 public expect fun Peripheral(
     advertisement: Advertisement,
-    builderAction: PeripheralBuilderAction,
+    builderAction: PeripheralBuilderAction = {},
 ): Peripheral
 
 /**

--- a/kable-core/src/jsMain/kotlin/Peripheral.kt
+++ b/kable-core/src/jsMain/kotlin/Peripheral.kt
@@ -13,7 +13,7 @@ public actual fun Peripheral(
 @Suppress("FunctionName") // Builder function.
 internal fun Peripheral(
     bluetoothDevice: BluetoothDevice,
-    builderAction: PeripheralBuilderAction = {},
+    builderAction: PeripheralBuilderAction,
 ): WebBluetoothPeripheral = Peripheral(bluetoothDevice, PeripheralBuilder().apply(builderAction))
 
 @Suppress("FunctionName") // Builder function.


### PR DESCRIPTION
Allows creating a `Peripheral` without specifying the builder configuration.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

```kotlin
// OK ✅                           
Peripheral(advertisement) {}

// Error ⛔️
Peripheral(advertisement)
```
</td>
<td>

```kotlin
// OK ✅                           
Peripheral(advertisement) {}

// OK ✅
Peripheral(advertisement)
```
</td>
</tr>
</table>

Closes #791.