### PR TITLE
Provide `Peripheral(Identifier)` builder function

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -350,8 +350,10 @@ public final class com/juul/kable/PeripheralBuilder {
 public final class com/juul/kable/PeripheralKt {
 	public static final fun Peripheral (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static final fun Peripheral (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
+	public static final fun Peripheral (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static synthetic fun Peripheral$default (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 	public static synthetic fun Peripheral$default (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
+	public static synthetic fun Peripheral$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;
 }
 
 public final class com/juul/kable/Peripheral_deprecatedKt {

--- a/kable-core/src/androidMain/kotlin/Peripheral.kt
+++ b/kable-core/src/androidMain/kotlin/Peripheral.kt
@@ -10,6 +10,12 @@ public actual fun Peripheral(
     return Peripheral(advertisement.bluetoothDevice, builderAction)
 }
 
+/** @throws IllegalStateException If bluetooth is not supported. */
+public fun Peripheral(
+    identifier: Identifier,
+    builderAction: PeripheralBuilderAction = {},
+): Peripheral = Peripheral(getBluetoothAdapter().getRemoteDevice(identifier), builderAction)
+
 public fun Peripheral(
     bluetoothDevice: BluetoothDevice,
     builderAction: PeripheralBuilderAction = {},


### PR DESCRIPTION
Closes #790