### PR TITLE
Update "maven central" badge to use `kable-core` artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ configuration may need to be adjusted under the following conditions:
 
 ### Gradle
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/core)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/kable-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.kable/kable-core)
 
 Kable can be configured via Gradle Kotlin DSL as follows:
 


### PR DESCRIPTION
Brendan Weinstein on [Slack](https://kotlinlang.slack.com/archives/CCSFQJD7V/p1734908522284909) caught that the "maven central" badge was using the wrong Maven coordinates for version reference.

Rendered markdown [here](https://github.com/JuulLabs/kable/tree/twyatt/maven-central-badge?tab=readme-ov-file#gradle).