### PR TITLE
Create copy of `observations` in `Observers.onConnected`

### DIFF
--- a/kable-core/src/commonMain/kotlin/Observers.kt
+++ b/kable-core/src/commonMain/kotlin/Observers.kt
@@ -101,7 +101,7 @@ internal class Observers<T>(
 
     suspend fun onConnected() {
         synchronized(lock) {
-            observations.entries
+            observations.entries.toSet()
         }.forEach { (_, observation) ->
             // Pipe failures to `characteristicChanges` while honoring in-flight connection cancellations.
             try {


### PR DESCRIPTION
Closes #840