### PR TITLE
Allow for advertisement manufacturer data length to exceed filter data mask length

### DIFF
--- a/kable-core/src/commonMain/kotlin/Filter.kt
+++ b/kable-core/src/commonMain/kotlin/Filter.kt
@@ -146,8 +146,9 @@ internal fun Filter.Name.matches(name: String?): Boolean {
 internal fun Filter.ManufacturerData.matches(data: ByteArray?): Boolean {
     if (data == null) return false
     if (dataMask == null) return this.data.contentEquals(data)
-    requireDataAndMaskHaveSameLength(data, dataMask)
-    for (i in this.data.indices) {
+    val lastMaskIndex = dataMask.indexOfLast { it != 0.toByte() }
+    if (lastMaskIndex > data.lastIndex) return false
+    for (i in 0..lastMaskIndex) {
         if (dataMask[i] and this.data[i] != dataMask[i] and data[i]) return false
     }
     return true

--- a/kable-core/src/commonTest/kotlin/FilterPredicateTests.kt
+++ b/kable-core/src/commonTest/kotlin/FilterPredicateTests.kt
@@ -160,6 +160,90 @@ class FilterPredicateTests {
         val predicate = ManufacturerDataFilter(37, byteArrayOf(2), byteArrayOf(2)).toPredicate()
         assertTrue(predicate.matches(manufacturerData = ManufacturerData(37, byteArrayOf(3))))
     }
+
+    @Test
+    fun matches_manufacturerDataFilterVsDataWithLengthLongerThanFilterDataThatMatches_isTrue() {
+        val texasInstrumentsCompanyId = 0x000D
+        val sensorTagManufacturerData = byteArrayOf(0x03, 0x00, 0x00)
+
+        val predicate = ManufacturerDataFilter(
+            id = texasInstrumentsCompanyId,
+            data = byteArrayOf(0x03),
+            dataMask = byteArrayOf(0xFF.toByte()),
+        ).toPredicate()
+
+        assertTrue(
+            predicate.matches(
+                manufacturerData = ManufacturerData(
+                    code = texasInstrumentsCompanyId,
+                    data = sensorTagManufacturerData,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun matches_manufacturerDataFilterVsDataWithLengthLongerThanFilterDataThatDoesNotMatch_isFalse() {
+        val texasInstrumentsCompanyId = 0x000D
+        val sensorTagManufacturerData = byteArrayOf(0x03, 0x00, 0x00)
+
+        val predicate = ManufacturerDataFilter(
+            id = texasInstrumentsCompanyId,
+            data = byteArrayOf(0x02),
+            dataMask = byteArrayOf(0x0F.toByte()),
+        ).toPredicate()
+
+        assertFalse(
+            predicate.matches(
+                manufacturerData = ManufacturerData(
+                    code = texasInstrumentsCompanyId,
+                    data = sensorTagManufacturerData,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun matches_manufacturerDataFilterVsDataWithLengthShorterThanFilterDataButMatchesMaskPortion_isTrue() {
+        val texasInstrumentsCompanyId = 0x000D
+        val sensorTagManufacturerData = byteArrayOf(0x03, 0x00, 0x00)
+
+        val predicate = ManufacturerDataFilter(
+            id = texasInstrumentsCompanyId,
+            data = byteArrayOf(0x03, 0x00, 0x00, 0x00),
+            dataMask = byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x00.toByte()),
+        ).toPredicate()
+
+        assertTrue(
+            predicate.matches(
+                manufacturerData = ManufacturerData(
+                    code = texasInstrumentsCompanyId,
+                    data = sensorTagManufacturerData,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun matches_manufacturerDataFilterVsDataWithLengthShorterThanFilterData_isFalse() {
+        val texasInstrumentsCompanyId = 0x000D
+        val sensorTagManufacturerData = byteArrayOf(0x03, 0x00, 0x00)
+
+        val predicate = ManufacturerDataFilter(
+            id = texasInstrumentsCompanyId,
+            data = byteArrayOf(0x03, 0x00, 0x00, 0x00),
+            dataMask = byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()),
+        ).toPredicate()
+
+        assertFalse(
+            predicate.matches(
+                manufacturerData = ManufacturerData(
+                    code = texasInstrumentsCompanyId,
+                    data = sensorTagManufacturerData,
+                ),
+            ),
+        )
+    }
 }
 
 private fun Filter.toPredicate() = FilterPredicate(listOf(this))


### PR DESCRIPTION
Closes #814

As seen on the ["Web Bluetooth / Manufacturer Data Filter Sample"](https://googlechrome.github.io/samples/web-bluetooth/manufacturer-data-filter.html?companyIdentifier=0x000D&dataPrefix=03&mask=FF), the actual manufacturer data of a SensorTag (`030000`) is allowed to exceed the length of the specified _filter_ for **manufacturer data** and **mask** (`03` and `FF`, respectively, in the screenshot):

<img width="817" alt="Screenshot 2025-01-19 at 11 26 30 PM" src="https://github.com/user-attachments/assets/df19a5c2-31f0-4f7c-8c48-835daff233d1" />