### PR TITLE
Propagate unknown `onScanFailed` error codes as `IllegalStateException`s

### DIFF
--- a/kable-core/src/androidMain/kotlin/scan/ScanError.kt
+++ b/kable-core/src/androidMain/kotlin/scan/ScanError.kt
@@ -6,7 +6,6 @@ import android.bluetooth.le.ScanCallback.SCAN_FAILED_FEATURE_UNSUPPORTED
 import android.bluetooth.le.ScanCallback.SCAN_FAILED_INTERNAL_ERROR
 import android.bluetooth.le.ScanCallback.SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES
 import android.bluetooth.le.ScanCallback.SCAN_FAILED_SCANNING_TOO_FREQUENTLY
-import com.juul.kable.InternalError
 
 @JvmInline
 internal value class ScanError(internal val errorCode: Int) {
@@ -18,7 +17,7 @@ internal value class ScanError(internal val errorCode: Int) {
         SCAN_FAILED_FEATURE_UNSUPPORTED -> "SCAN_FAILED_FEATURE_UNSUPPORTED"
         SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES -> "SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES"
         SCAN_FAILED_SCANNING_TOO_FREQUENTLY -> "SCAN_FAILED_SCANNING_TOO_FREQUENTLY"
-        else -> throw InternalError("Unsupported error code $errorCode")
+        else -> "UNKNOWN"
     }.let { name -> "$name($errorCode)" }
 }
 
@@ -43,5 +42,5 @@ internal val ScanError.message: String
         SCAN_FAILED_SCANNING_TOO_FREQUENTLY ->
             "Failed to start scan as application tries to scan too frequently"
 
-        else -> throw InternalError("Unsupported error code $errorCode")
+        else -> "Unknown scan error code: $errorCode"
     }


### PR DESCRIPTION
> I had hoped that the error codes defined in `ScanCallback` would be exhaustive.

...apparently they are not.

Additionally, I had hoped that I could look up specific error codes as they were reported (e.g. `100` reported in #850), but I couldn't find anything specific/concrete about error code `100`. Which means I can't even provide helpful a helpful failure message for it; Kable just needs to do what other Android source code does (and default to `Unknown`). 😢 

This PR changes failure behavior of scanning (when an unknown error code is it), to throw `IllegalStateException` instead of `InternalException`.

Closes #850