### PR TITLE
Optimize scan filtering

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.7.0" }
 mockk = { module = "io.mockk:mockk", version = "1.13.17" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.14.1" }
 tuulbox-collections = { module = "com.juul.tuulbox:collections", version.ref = "tuulbox" }
 tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 wrappers-bom = { module = "org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom", version = "2025.4.3" }

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
         androidUnitTest.dependencies {
             implementation(libs.equalsverifier)
             implementation(libs.mockk)
+            implementation(libs.robolectric)
         }
 
         jsMain.dependencies {

--- a/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -26,11 +26,21 @@ import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filter
+import kotlin.reflect.KClass
 import kotlin.uuid.toJavaUuid
 import kotlin.uuid.toKotlinUuid
 
+private data class ScanFilters(
+
+    /** [ScanFilter]s applied using Android's native filtering. */
+    val native: List<ScanFilter>,
+
+    /** [FilterPredicate]s applied via flow [filter][Flow.filter] operator. */
+    val flow: List<FilterPredicate>,
+)
+
 internal class BluetoothLeScannerAndroidScanner(
-    private val filters: List<FilterPredicate>,
+    filters: List<FilterPredicate>,
     private val scanSettings: ScanSettings,
     private val preConflate: Boolean,
     logging: Logging,
@@ -38,7 +48,7 @@ internal class BluetoothLeScannerAndroidScanner(
 
     private val logger = Logger(logging, tag = "Kable/Scanner", identifier = null)
 
-    private val scanFilters = filters.toNativeScanFilters()
+    private val scanFilters = filters.toScanFilters()
 
     override val advertisements: Flow<PlatformAdvertisement> = callbackFlow {
         logger.debug { message = "Initializing scan" }
@@ -87,7 +97,7 @@ internal class BluetoothLeScannerAndroidScanner(
         logger.info {
             message = logMessage("Starting", preConflate, scanFilters)
         }
-        scanner.startScan(scanFilters, scanSettings, callback)
+        scanner.startScan(scanFilters.native, scanSettings, callback)
 
         awaitClose {
             logger.info {
@@ -102,24 +112,24 @@ internal class BluetoothLeScannerAndroidScanner(
             }
         }
     }.filter { advertisement ->
-        // Short-circuit (i.e. don't filter) if native scan filters were applied.
-        if (scanFilters.isNotEmpty()) return@filter true
-
-        // Perform filtering here, since we were not able to use native scan filters.
-        filters.matches(
-            services = advertisement.uuids,
-            name = advertisement.name,
-            address = advertisement.address,
-            manufacturerData = advertisement.manufacturerData,
-            serviceData = advertisement.serviceData?.mapKeys { (key) -> key.uuid.toKotlinUuid() },
-        )
+        if (scanFilters.flow.isEmpty()) {
+            true
+        } else {
+            scanFilters.flow.matches(
+                services = advertisement.uuids,
+                name = advertisement.name,
+                address = advertisement.address,
+                manufacturerData = advertisement.manufacturerData,
+                serviceData = advertisement.serviceData?.mapKeys { (key) -> key.uuid.toKotlinUuid() },
+            )
+        }
     }
 }
 
 private fun logMessage(
     prefix: String,
     preConflate: Boolean,
-    scanFilters: List<ScanFilter>,
+    scanFilters: ScanFilters,
 ) = buildString {
     append(prefix)
     append(' ')
@@ -127,23 +137,60 @@ private fun logMessage(
     if (preConflate) {
         append("pre-conflated ")
     }
-    if (scanFilters.isEmpty()) {
+    if (scanFilters.native.isEmpty() && scanFilters.flow.isEmpty()) {
         append("without filters")
     } else {
-        append("with ${scanFilters.size} filter(s)")
+        append("with ${scanFilters.native.count()} native and ${scanFilters.flow.count()} flow filter(s)")
     }
 }
 
-private fun List<FilterPredicate>.toNativeScanFilters(): List<ScanFilter> =
+private fun List<FilterPredicate>.toScanFilters(): ScanFilters =
     if (all(FilterPredicate::supportsNativeScanFiltering)) {
-        map(FilterPredicate::toNativeScanFilter)
+        ScanFilters(
+            native = map(FilterPredicate::toNativeScanFilter),
+            flow = emptyList(),
+        )
+    } else if (count() == 1) {
+        val nativeFilters = mutableMapOf<KClass<*>, Filter>()
+        val flowFilters = mutableListOf<Filter>()
+        single().filters.forEach { filter ->
+            if (filter.canFilterNatively && filter::class !in nativeFilters) {
+                nativeFilters[filter::class] = filter
+            } else {
+                flowFilters += filter
+            }
+        }
+        ScanFilters(
+            native = listOf(nativeFilters.values.toList().toNativeScanFilter()),
+            flow = listOf(FilterPredicate(flowFilters)),
+        )
     } else {
-        emptyList()
+        ScanFilters(
+            native = emptyList(),
+            flow = this,
+        )
     }
 
-private fun FilterPredicate.toNativeScanFilter(): ScanFilter =
+// Scan filter does not support name prefix filtering, and only allows at most one each of the
+// following: service uuid, manufacturer data, service data.
+private val FilterPredicate.supportsNativeScanFiltering: Boolean
+    get() = !containsNamePrefix() && serviceCount() <= 1 && manufacturerDataCount() <= 1 && serviceDataCount() <= 1
+
+private val Filter.canFilterNatively: Boolean
+    get() = when (this) {
+        is Name.Exact -> true
+        is Address -> true
+        is ManufacturerData -> true
+        is ServiceData -> true
+        is Service -> true
+        else -> false
+    }
+
+private fun FilterPredicate.toNativeScanFilter(): ScanFilter = filters.toNativeScanFilter()
+
+private fun List<Filter>.toNativeScanFilter(): ScanFilter =
     ScanFilter.Builder().apply {
-        filters.map { filter ->
+        onEach { filter ->
             when (filter) {
                 is Name.Exact -> setDeviceName(filter.exact)
                 is Address -> setDeviceAddress(filter.address)
@@ -154,11 +201,6 @@ private fun FilterPredicate.toNativeScanFilter(): ScanFilter =
             }
         }
     }.build()
-
-// Scan filter does not support name prefix filtering, and only allows at most one each of the
-// following: service uuid, manufacturer data, service data.
-private fun FilterPredicate.supportsNativeScanFiltering(): Boolean =
-    !containsNamePrefix() && serviceCount() <= 1 && manufacturerDataCount() <= 1 && serviceDataCount() <= 1
 
 private fun FilterPredicate.containsNamePrefix(): Boolean =
     filters.any { it is Name.Prefix }

--- a/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -174,17 +174,17 @@ internal fun List<FilterPredicate>.toScanFilters(): ScanFilters =
 // Android's `ScanFilter` does not support name prefix filtering, and only allows at most one of each filter type.
 private val FilterPredicate.supportsNativeScanFiltering: Boolean
     get() {
-        var nameExact = 0
         var service = 0
+        var nameExact = 0
+        var address = 0
         var manufacturerData = 0
         var serviceData = 0
-        var address = 0
         filters.forEach { filter ->
             when (filter) {
-                is Name.Prefix -> return false
-                is Name.Exact -> if (++nameExact > 1) return false
-                is Address -> if (++address > 1) return false
                 is Service -> if (++service > 1) return false
+                is Name.Exact -> if (++nameExact > 1) return false
+                is Name.Prefix -> return false
+                is Address -> if (++address > 1) return false
                 is ManufacturerData -> if (++manufacturerData > 1) return false
                 is ServiceData -> if (++serviceData > 1) return false
             }
@@ -194,11 +194,11 @@ private val FilterPredicate.supportsNativeScanFiltering: Boolean
 
 private val Filter.canFilterNatively: Boolean
     get() = when (this) {
+        is Service -> true
         is Name.Exact -> true
         is Address -> true
         is ManufacturerData -> true
         is ServiceData -> true
-        is Service -> true
         else -> false
     }
 
@@ -208,11 +208,11 @@ private fun List<Filter>.toNativeScanFilter(): ScanFilter =
     ScanFilter.Builder().apply {
         onEach { filter ->
             when (filter) {
+                is Service -> setServiceUuid(ParcelUuid(filter.uuid.toJavaUuid()))
                 is Name.Exact -> setDeviceName(filter.exact)
                 is Address -> setDeviceAddress(filter.address)
                 is ManufacturerData -> setManufacturerData(filter.id, filterDataCompat(filter.data), filter.dataMask)
                 is ServiceData -> setServiceData(ParcelUuid(filter.uuid.toJavaUuid()), filterDataCompat(filter.data), filter.dataMask)
-                is Service -> setServiceUuid(ParcelUuid(filter.uuid.toJavaUuid()))
                 else -> throw AssertionError("Unsupported filter element")
             }
         }

--- a/kable-core/src/androidUnitTest/kotlin/com/juul/kable/ScanFiltersTests.kt
+++ b/kable-core/src/androidUnitTest/kotlin/com/juul/kable/ScanFiltersTests.kt
@@ -1,0 +1,208 @@
+package com.juul.kable
+
+import android.bluetooth.le.ScanFilter
+import android.os.ParcelUuid
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.toJavaUuid
+
+@RunWith(RobolectricTestRunner::class)
+class ScanFiltersTests {
+
+    @Test
+    fun toScanFilters_filterPredicatesWithOnlyNativeFilters_allNativeFilters() {
+        val serviceUuid1 = Bluetooth.BaseUuid + 1
+        val name1 = "exact1"
+        val address1 = "00:1A:2B:3C:4D:5E"
+
+        val serviceUuid2 = Bluetooth.BaseUuid + 2
+        val name2 = "exact2"
+
+        val filterPredicates = listOf(
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid1),
+                    Filter.Name.Exact(name1),
+                    Filter.Address(address1),
+                ),
+            ),
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid2),
+                    Filter.Name.Exact(name2),
+                ),
+            ),
+        )
+
+        assertEquals(
+            expected = ScanFilters(
+                native = listOf(
+                    ScanFilter.Builder().apply {
+                        setServiceUuid(ParcelUuid(serviceUuid1.toJavaUuid()))
+                        setDeviceName(name1)
+                        setDeviceAddress(address1)
+                    }.build(),
+                    ScanFilter.Builder().apply {
+                        setServiceUuid(ParcelUuid(serviceUuid2.toJavaUuid()))
+                        setDeviceName(name2)
+                    }.build(),
+                ),
+                flow = emptyList(),
+            ),
+            actual = filterPredicates.toScanFilters(),
+        )
+    }
+
+    @Test
+    fun toScanFilters_singleFilterPredicateWithMultipleNameFilters_overlaysNativeAndFlowFilters() {
+        val serviceUuid = Bluetooth.BaseUuid + 1
+        val nameA = "exactA"
+        val nameB = "exactB"
+
+        val filterPredicates = listOf(
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid),
+                    Filter.Name.Exact(nameA),
+                    Filter.Name.Exact(nameB),
+                ),
+            ),
+        )
+
+        assertEquals(
+            expected = ScanFilters(
+                native = listOf(
+                    ScanFilter.Builder().apply {
+                        setServiceUuid(ParcelUuid(serviceUuid.toJavaUuid()))
+                        setDeviceName(nameA)
+                    }.build(),
+                ),
+                flow = listOf(
+                    FilterPredicate(listOf(Filter.Name.Exact(nameB))),
+                ),
+            ),
+            actual = filterPredicates.toScanFilters(),
+        )
+    }
+
+    @Test
+    fun toScanFilters_multipleFilterPredicatesWithMultipleNameFilters_allFlowFilters() {
+        val serviceUuid1 = Bluetooth.BaseUuid + 1
+        val name1A = "exactA"
+        val name1B = "exactB"
+
+        val serviceUuid2 = Bluetooth.BaseUuid + 2
+
+        val filterPredicates = listOf(
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid1),
+                    Filter.Name.Exact(name1A),
+                    Filter.Name.Exact(name1B),
+                ),
+            ),
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid2),
+                ),
+            ),
+        )
+
+        assertEquals(
+            expected = ScanFilters(
+                native = emptyList(),
+                flow = listOf(
+                    FilterPredicate(
+                        listOf(
+                            Filter.Service(serviceUuid1),
+                            Filter.Name.Exact(name1A),
+                            Filter.Name.Exact(name1B),
+                        ),
+                    ),
+                    FilterPredicate(
+                        listOf(
+                            Filter.Service(serviceUuid2),
+                        ),
+                    ),
+                ),
+            ),
+            actual = filterPredicates.toScanFilters(),
+        )
+    }
+
+    @Test
+    fun toScanFilters_singleFilterPredicate_overlaysNativeAndFlowFilters() {
+        val serviceUuid = Bluetooth.BaseUuid + 1
+        val namePrefix = "prefix"
+
+        val filterPredicates = listOf(
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid),
+                    Filter.Name.Prefix(namePrefix),
+                ),
+            ),
+        )
+
+        assertEquals(
+            expected = ScanFilters(
+                native = listOf(
+                    ScanFilter.Builder().apply {
+                        setServiceUuid(ParcelUuid(serviceUuid.toJavaUuid()))
+                    }.build(),
+                ),
+                flow = listOf(
+                    FilterPredicate(listOf(Filter.Name.Prefix(namePrefix))),
+                ),
+            ),
+            actual = filterPredicates.toScanFilters(),
+        )
+    }
+
+    @Test
+    fun toScanFilters_multipleFilterPredicates_allFlowFilters() {
+        val serviceUuid1 = Bluetooth.BaseUuid + 1
+        val namePrefix1 = "prefix1"
+
+        val serviceUuid2 = Bluetooth.BaseUuid + 2
+        val namePrefix2 = "prefix2"
+
+        val filterPredicates = listOf(
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid1),
+                    Filter.Name.Prefix(namePrefix1),
+                ),
+            ),
+            FilterPredicate(
+                listOf(
+                    Filter.Service(serviceUuid2),
+                    Filter.Name.Prefix(namePrefix2),
+                ),
+            ),
+        )
+
+        assertEquals(
+            expected = ScanFilters(
+                native = emptyList(),
+                flow = listOf(
+                    FilterPredicate(
+                        listOf(
+                            Filter.Service(serviceUuid1),
+                            Filter.Name.Prefix(namePrefix1),
+                        ),
+                    ),
+                    FilterPredicate(
+                        listOf(
+                            Filter.Service(serviceUuid2),
+                            Filter.Name.Prefix(namePrefix2),
+                        ),
+                    ),
+                ),
+            ),
+            actual = filterPredicates.toScanFilters(),
+        )
+    }
+}


### PR DESCRIPTION
Closes #889

Optimizes scan filtering when non-native filter(s) are combined with native filter(s), by favoring native scan filtering and moving non-native supported filters to flow filtering.

Take the following example:

<table>
<tr>
<td align="center"><b>Code</b></td>
<td align="center"><b>Graphical representation</b></td>
</tr>
<tr>
<td>

```kotlin
filter {
    match {
        service = listOf(Filter.Service(B))
        // AND
        name = listOf(Filter.Name.Prefix("A_"))
        // AND
        serviceData = listOf(Filter.ServiceData(..))
    }
}
```
</td>
<td>

![Issue 890](https://github.com/user-attachments/assets/98e3b236-32d8-4cb2-80cd-cb57ade29056)
</td>
</tr>
</table>

This PR will optimize the scan by establishing a native filter for the `Filter.Service` and `Filter.ServiceData` and having the `Filter.Name.Prefix` filtering occur via flow operator.

| Before the PR | After the PR |
|-|-|
| ![Issue 890 before](https://github.com/user-attachments/assets/a6ef3382-0541-4ceb-afda-0ac383ea8ce7) | ![Issue 890 after](https://github.com/user-attachments/assets/48e52790-37c1-4284-827f-89092c8c5155) |

This optimization is only possible when a single `match` is specified (i.e. filters will not be `OR`'d). This is because when there are multiple filter `match` declarations, then it would be difficult to reliably determine which native filter was applied to know what "overlayed" filters should occur at the flow operator level. To illustrate this limitation, take the following example:

<table>
<tr>
<td align="center"><b>Code</b></td>
<td align="center"><b>Graphical representation</b></td>
</tr>
<tr>
<td>

```kotlin
filter {
    match {
        service = listOf(Filter.Service(A))
        // AND
        name = listOf(Filter.Name.Prefix("A_"))
    }
    // OR
    match {
        service = listOf(Filter.Service(B))
        // AND
        name = listOf(Filter.Name.Prefix("B_"))
    }
}
```
</td>
<td>

![Issue 890 limitation](https://github.com/user-attachments/assets/3bc9e606-5a9c-43cf-a6e3-e3c4774f5b60)
</td>
</tr>
</table>

Then, during a scan there isn't a clear way to filter at the flow operator:

![Issue 890 limitation2](https://github.com/user-attachments/assets/ada01d40-59be-4034-8518-1bc37cc0dceb)

As such, for these situations (more than one `match` with non-native filters): all filters will occur at the flow operator level.