### PR TITLE
Remove deprecated `kotlin.native.ignoreIncorrectDependencies` Gradle option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,6 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
-# Disable native dependency warnings to quiet AtomicFU warnings.
-# Setting can be removed after https://youtrack.jetbrains.com/issue/KT-32476 is fixed.
-kotlin.native.ignoreIncorrectDependencies=true
-
 # Publication configuration
 # https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties
 


### PR DESCRIPTION
```
> Configure project :kable-core
w: ⚠️ Deprecated Gradle Property 'kotlin.native.ignoreIncorrectDependencies' Used
The `kotlin.native.ignoreIncorrectDependencies` deprecated property is used in your build.
Please, stop using it as it is unsupported and may apply no effect to your build.
```