### PR TITLE
Use Dokka v2 API

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
           cache-read-only: true
           validate-wrappers: true
 
-      - run: ./gradlew dokkaHtmlMultiModule
+      - run: ./gradlew dokkaGenerate
       - run: >
           tar
           --dereference --hard-dereference

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,15 @@ plugins {
     alias(libs.plugins.api)
 }
 
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.fileProvider(layout.buildDirectory.file("dokkaHtmlMultiModule").map { it.asFile })
+dokka {
+    dokkaPublications.html {
+        outputDirectory.set(layout.buildDirectory.dir("dokkaHtmlMultiModule"))
+    }
+}
+
+dependencies {
+    dokka(project(":kable-core"))
+    dokka(project(":kable-log-engine-khronicle"))
 }
 
 apiValidation {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 # Disable native dependency warnings to quiet AtomicFU warnings.

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -87,3 +87,9 @@ android {
         disable += "MissingPermission"
     }
 }
+
+dokka {
+    pluginsConfiguration.html {
+        footerMessage.set("(c) JUUL Labs, Inc.")
+    }
+}

--- a/kable-log-engine-khronicle/build.gradle.kts
+++ b/kable-log-engine-khronicle/build.gradle.kts
@@ -23,3 +23,9 @@ kotlin {
         }
     }
 }
+
+dokka {
+    pluginsConfiguration.html {
+        footerMessage.set("(c) JUUL Labs, Inc.")
+    }
+}


### PR DESCRIPTION
```
> Configure project :
warning: Dokka Gradle plugin V1 is deprecated
    
    Dokka Gradle plugin V1 is deprecated, and will be removed in Dokka version 2.1.0
    Please migrate to Dokka Gradle plugin V2. This will require updating your project.
    To learn about migrating read the migration guide https://kotl.in/dokka-gradle-migration
```