### PR TITLE
Force update disconnection state

### DIFF
--- a/kable-core/src/jsMain/kotlin/Connection.kt
+++ b/kable-core/src/jsMain/kotlin/Connection.kt
@@ -205,7 +205,7 @@ internal class Connection(
             } finally {
                 disconnectGatt()
                 // Force the state as there are cases where the disconnected callback is not invoked
-                state.update { Disconnected() }
+                state.value = Disconnected()
             }
         }
     }

--- a/kable-core/src/jsMain/kotlin/Connection.kt
+++ b/kable-core/src/jsMain/kotlin/Connection.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex

--- a/kable-core/src/jsMain/kotlin/Connection.kt
+++ b/kable-core/src/jsMain/kotlin/Connection.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -203,6 +204,8 @@ internal class Connection(
                 logger.warn { message = "Timed out after $disconnectTimeout waiting for disconnect" }
             } finally {
                 disconnectGatt()
+                // Force the state as there are cases where the disconnected callback is not invoked
+                state.update { Disconnected() }
             }
         }
     }


### PR DESCRIPTION
If a connection request is made on Web and it fails, sometimes the disconnection callback is never invoked. When this happens the `TimeoutCancellationException` is thrown in the `disconnect` method, but this leaves the state as `Disconnecting` and it never reaches `Disconnected`.

The reason it never reaches `Disconnected` is because the sole place that state change occurs is in the callback, but the callback is never invoked.

This change forces the transistion to `Disconnected` in the `finally` block so that consumers do not get stuck waiting forever. They will still be stuck until the timeout occurs however because we get blocked at line 200 in the main `try` block:
```kotlin
    state.filterIsInstance<Disconnected>().first()
```