### PR TITLE
Add ability to create `Peripheral` from `ScanResult`

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -337,6 +337,7 @@ public final class com/juul/kable/PeripheralBuilder {
 
 public final class com/juul/kable/PeripheralKt {
 	public static final fun Peripheral (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
+	public static final fun Peripheral (Landroid/bluetooth/le/ScanResult;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static final fun Peripheral (Lcom/juul/kable/Advertisement;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static final fun Peripheral (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/juul/kable/Peripheral;
 	public static synthetic fun Peripheral$default (Landroid/bluetooth/BluetoothDevice;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/juul/kable/Peripheral;

--- a/kable-core/src/androidMain/kotlin/Peripheral.kt
+++ b/kable-core/src/androidMain/kotlin/Peripheral.kt
@@ -1,6 +1,7 @@
 package com.juul.kable
 
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.le.ScanResult
 
 public actual fun Peripheral(
     advertisement: Advertisement,
@@ -9,6 +10,12 @@ public actual fun Peripheral(
     advertisement as ScanResultAndroidAdvertisement
     return Peripheral(advertisement.bluetoothDevice, builderAction)
 }
+
+@ExperimentalApi // Experimental while evaluating if this API introduces any footguns.
+public fun Peripheral(
+    scanResult: ScanResult,
+    builderAction: PeripheralBuilderAction,
+): Peripheral = Peripheral(scanResult.device, builderAction)
 
 /** @throws IllegalStateException If bluetooth is not supported. */
 public fun Peripheral(


### PR DESCRIPTION
In response to https://github.com/JuulLabs/kable/discussions/936, provides a mechanism of creating a `Peripheral` from an Android native `ScanResult`.

> [!NOTE]
> I don't believe this API will introduce any footguns to consumers, but marking `@ExperimentalApi` to give us time to evaluate.