### PR TITLE
fix crash on ios LogMessage

### DIFF
--- a/kable-core/src/appleMain/kotlin/logs/LogMessage.kt
+++ b/kable-core/src/appleMain/kotlin/logs/LogMessage.kt
@@ -19,26 +19,26 @@ internal fun LogMessage.detail(error: NSError?) {
     if (error != null) detail("error", error.toString())
 }
 
-internal fun LogMessage.detail(service: CBService? = null) {
-    detail("service", service?.UUID?.UUIDString ?: "Unknown UUID")
+private fun LogMessage.detail(service: CBService? = null) {
+    detail("service", service?.UUID?.UUIDString ?: "null UUID")
 }
 
-internal fun LogMessage.detail(characteristic: CBCharacteristic) {
+private fun LogMessage.detail(characteristic: CBCharacteristic) {
     val serviceUuid = characteristic.service
         ?.UUID
         ?.toUuid()
     if (serviceUuid == null) {
-        detail("service", "Unknown")
+        detail("service", "null UUID")
         return
     }
 
     detail(serviceUuid, characteristic.UUID.toUuid())
 }
 
-internal fun LogMessage.detail(descriptor: CBDescriptor) {
+private fun LogMessage.detail(descriptor: CBDescriptor) {
     val characteristic = descriptor.characteristic
     if (characteristic == null) {
-        detail("characteristic", "Unknown")
+        detail("characteristic", "null UUID")
         return
     }
 
@@ -47,7 +47,7 @@ internal fun LogMessage.detail(descriptor: CBDescriptor) {
         ?.toUuid()
 
     if (serviceUuid == null) {
-        detail("service", "Unknown")
+        detail("service", "null UUID")
         return
     }
 
@@ -56,4 +56,13 @@ internal fun LogMessage.detail(descriptor: CBDescriptor) {
         characteristic.UUID.toUuid(),
         descriptor.UUID.toUuid(),
     )
+}
+
+internal fun LogMessage.detail(attribute: CBAttribute) {
+    when (attribute) {
+        is CBService -> detail(attribute)
+        is CBCharacteristic -> detail(attribute)
+        is CBDescriptor -> detail(attribute)
+        else -> detail("unknown attribute", attribute.UUID.toUuid())
+    }
 }

--- a/kable-core/src/appleMain/kotlin/logs/LogMessage.kt
+++ b/kable-core/src/appleMain/kotlin/logs/LogMessage.kt
@@ -19,21 +19,41 @@ internal fun LogMessage.detail(error: NSError?) {
     if (error != null) detail("error", error.toString())
 }
 
-internal fun LogMessage.detail(service: CBService) {
-    detail("service", service.UUID.UUIDString)
+internal fun LogMessage.detail(service: CBService? = null) {
+    detail("service", service?.UUID?.UUIDString ?: "Unknown UUID")
 }
 
 internal fun LogMessage.detail(characteristic: CBCharacteristic) {
-    detail(
-        characteristic.service!!.UUID.toUuid(),
-        characteristic.UUID.toUuid(),
-    )
+    val serviceUuid = characteristic.service
+        ?.UUID
+        ?.toUuid()
+    if (serviceUuid == null) {
+        detail("service", "Unknown")
+        return
+    }
+
+    detail(serviceUuid, characteristic.UUID.toUuid())
 }
 
 internal fun LogMessage.detail(descriptor: CBDescriptor) {
+    val characteristic = descriptor.characteristic
+    if (characteristic == null) {
+        detail("characteristic", "Unknown")
+        return
+    }
+
+    val serviceUuid = characteristic.service
+        ?.UUID
+        ?.toUuid()
+
+    if (serviceUuid == null) {
+        detail("service", "Unknown")
+        return
+    }
+
     detail(
-        descriptor.characteristic!!.service!!.UUID.toUuid(),
-        descriptor.characteristic!!.UUID.toUuid(),
+        serviceUuid,
+        characteristic.UUID.toUuid(),
         descriptor.UUID.toUuid(),
     )
 }


### PR DESCRIPTION
These changes fix the issue regarding inconsistence type inference in iOS. The original error is as follows:
```
*** First throw call stack:
(0x193fff21c 0x191499abc 0x194069614 0x193f13a1c 0x193f13aa0 0x10b6c6c8c 0x10b6bda98 0x10b6c0538 0x1bd7cad94 0x1bd7caec4 0x1bd7c7a18 0x1bd786a40 0x1bd78422c 0x1bd784114 0x100d90584 0x100daa064 0x100d9891c 0x100d995d8 0x100d98758 0x100d995a4 0x100da5894 0x100da4eb0 0x21e5f4a0c 0x21e5f4aac)
libc++abi: terminating due to uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[CBDescriptor service]: unrecognized selector sent to instance 0x128ac2400'
*** First throw call stack:
(0x193fff21c 0x191499abc 0x194069614 0x193f13a1c 0x193f13aa0 0x10b6c6c8c 0x10b6bda98 0x10b6c0538 0x1bd7cad94 0x1bd7caec4 0x1bd7c7a18 0x1bd786a40 0x1bd78422c 0x1bd784114 0x100d90584 0x100daa064 0x100d9891c 0x100d995d8 0x100d98758 0x100d995a4 0x100da5894 0x100da4eb0 0x21e5f4a0c 0x21e5f4aac)
terminating due to uncaught exception of type NSException
Message from debugger: killed