### PR TITLE
JVM Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - run: ./gradlew :kable-btleplug-ffi:assemble
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com
         working-directory: kable-btleplug-ffi/build/libs
+        shell: bash
       - uses: actions/upload-artifact@v4
         with:
           name: kable-btleplug-ffi-${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ['macos-13','macos-latest','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
+        runner: ['macos-13','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -24,11 +24,13 @@ jobs:
         with:
           validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+      - run: unzip kable-btleplug-ffi.jar
+        working-directory: kable-btleplug-ffi/build/libs
+      - run: rm -rf META-INF com
+      - uses: actions/upload-artifact@v4
         with:
-          name: kable-btleplug-ffi-${{ matrix.runner }}
-          path: kable-btleplug-ffi/build/libs/kable-btleplug-ffi.jar
+          name: kable-btleplug-ffi-dylibs
+          path: kable-btleplug-ffi/build/libs/
           if-no-files-found: error
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   assemble-rust:
     strategy:
+      fail-fast: false
       matrix:
         runner: ['macos-13','macos-latest','ubuntu-24.04-arm','ubuntu-latest','windows-11-arm','windows-latest']
     runs-on: ${{ matrix.runner }}
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: gradle/actions/setup-gradle@v4
         with:
           validate-wrappers: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,25 @@ jobs:
         with:
           validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
-      - run: unzip kable-btleplug-ffi.jar
+      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com
         working-directory: kable-btleplug-ffi/build/libs
-      - run: rm -rf META-INF com
       - uses: actions/upload-artifact@v4
         with:
-          name: kable-btleplug-ffi-dylibs
+          name: kable-btleplug-ffi-${{ matrix.runner }}
           path: kable-btleplug-ffi/build/libs/
           if-no-files-found: error
+          retention-days: 1
 
   build:
     runs-on: macos-latest
+    needs: assemble-rust
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: kable-btleplug-ffi/build/external
+          pattern: kable-btleplug-ffi-*
+          merge-multiple: true
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -48,3 +54,9 @@ jobs:
       - run: ./gradlew assemble -PsuppressWarnings=true
       - run: ./gradlew check
       - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal
+      - uses: actions/upload-artifact@v4
+        with:
+          name: maven-local-artifacts
+          path: ~/.m2/repository/
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
-      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com
+      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com kable-btleplug-ffi.jar
         working-directory: kable-btleplug-ffi/build/libs
         shell: bash
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,15 @@ on:
 jobs:
   assemble-rust:
     strategy:
+      permissions:
+        contents: write
       fail-fast: false
       matrix:
-        runner: ['macos-13','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
+        runner:
+          - macos-13
+          - ubuntu-24.04-arm
+          - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -21,8 +27,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs
@@ -49,8 +53,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
 
       - run: ./gradlew assemble -PsuppressWarnings=true
       - run: ./gradlew check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,22 @@ on:
       - main
 
 jobs:
+  assemble-rust:
+    strategy:
+      matrix:
+        runner: ['macos-13','macos-latest','ubuntu-24.04-arm','ubuntu-latest','windows-11-arm','windows-latest']
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
+      - run: ./gradlew :kable-btleplug-ffi:assemble
+
   build:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ['macos-13','macos-latest','ubuntu-24.04-arm','ubuntu-latest','windows-11-arm','windows-latest']
+        runner: ['macos-13','macos-latest','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,12 @@ jobs:
         with:
           validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kable-btleplug-ffi-${{ matrix.runner }}
+          path: kable-btleplug-ffi/build/libs/kable-btleplug-ffi.jar
+          if-no-files-found: error
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
-      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com kable-btleplug-ffi.jar
+      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs
         shell: bash
       - uses: actions/upload-artifact@v4
@@ -55,9 +55,3 @@ jobs:
       - run: ./gradlew assemble -PsuppressWarnings=true
       - run: ./gradlew check
       - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal
-      - uses: actions/upload-artifact@v4
-        with:
-          name: maven-local-artifacts
-          path: ~/.m2/repository/
-          if-no-files-found: error
-          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   assemble-rust:
+    permissions:
+      contents: write
     strategy:
-      permissions:
-        contents: write
       fail-fast: false
       matrix:
         runner:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
         with:
           validate-wrappers: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,15 @@ on:
 jobs:
   assemble-rust:
     strategy:
+      permissions:
+        contents: write
       fail-fast: false
       matrix:
-        runner: ['macos-13','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
+        runner:
+          - macos-13
+          - ubuntu-24.04-arm
+          - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -18,8 +24,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
       - run: ./gradlew :kable-btleplug-ffi:assemble
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,42 @@ on:
       - published
 
 jobs:
-  publish:
-    runs-on: macos-latest
+  assemble-rust:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ['macos-13','ubuntu-24.04-arm','ubuntu-latest','windows-latest']
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
+      - run: ./gradlew :kable-btleplug-ffi:assemble
+      - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
+        working-directory: kable-btleplug-ffi/build/libs
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kable-btleplug-ffi-${{ matrix.runner }}
+          path: kable-btleplug-ffi/build/libs/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    runs-on: macos-latest
+    needs: assemble-rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: kable-btleplug-ffi/build/external
+          pattern: kable-btleplug-ffi-*
+          merge-multiple: true
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   assemble-rust:
+    permissions:
+      contents: write
     strategy:
-      permissions:
-        contents: write
       fail-fast: false
       matrix:
         runner:

--- a/kable-btleplug-ffi/build.gradle.kts
+++ b/kable-btleplug-ffi/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm")
-    id("com.juul.kable.uniffi")
     id("com.vanniktech.maven.publish")
+    id("com.juul.kable.uniffi")
 }
 
 kotlin {

--- a/kable-btleplug-ffi/build.gradle.kts
+++ b/kable-btleplug-ffi/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm")
     id("com.juul.kable.uniffi")
+    id("com.vanniktech.maven.publish")
 }
 
 kotlin {

--- a/uniffi-plugin/src/main/kotlin/tasks/CopyDynamicLibraryResourcesTask.kt
+++ b/uniffi-plugin/src/main/kotlin/tasks/CopyDynamicLibraryResourcesTask.kt
@@ -25,5 +25,9 @@ internal fun TaskContainer.registerCopyDynamicLibraryResourcesTask(accessor: Uni
             include { it.name.matches(target.os.library) }
             into("${target.os.jnaName}-${target.arch.jnaName}")
         }
+
+        val external = project.layout.buildDirectory.dir("external")
+        inputs.files(external)
+        from(external)
     }
 }

--- a/uniffi-plugin/src/main/kotlin/tasks/UniffiBindgenTasks.kt
+++ b/uniffi-plugin/src/main/kotlin/tasks/UniffiBindgenTasks.kt
@@ -35,6 +35,9 @@ internal fun TaskContainer.registerUniffiBindgenTasks(accessor: UniffiKotlinExte
     named("clean") { dependsOn("cleanUniffiBindgenCargoProject") }
     named("compileKotlin") { dependsOn("generateKotlinBindings") }
 
+    // sourcesJar is created by the maven publishing plugin, so this plugin has to be applied after that one
+    named("sourcesJar") { dependsOn("generateKotlinBindings") }
+
     register("cleanUniffiBindgenCargoProject") {
         group = UNIFFI_TASK_GROUP
 


### PR DESCRIPTION
# Overview

Spin up a matrix of runners for the alternative platforms and build `kable-btleplug-ffi`'s jar on each of them. Rip apart the jar, and upload the dynamic library as an artifact. Then, on the main build runner, download those artifacts to a special folder that gets embedded as java resources.

# Deficiencies
- Rust isn't installed on the Windows 11 ARM runners, so I've skipped that platform for now.
- Building the whole jar for the alternative platforms is inefficient/slow. We could just do a `cargo build --release` and then manually copy the output file to the right place, but the current approach avoids duplicating hard-coded string paths into multiple locations.
- Just building the jar for `kable-btleplug-ffi` doesn't go far enough to guarantee that the FFI exposes the same interface on all platforms. To do that, we'd need to actually build `kable-core:jvmJar` or similar (which would be even slower).