### PR TITLE
Compile kable-core JVM on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew :kable-btleplug-ffi:assemble
+      - run: ./gradlew :kable-core:compileKotlinJvm
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs
         shell: bash


### PR DESCRIPTION
This will slow down PR CI slightly, but protects against cases where a Rust change has platform specific code that changes the internal Kotlin API.