### PR TITLE
Add `forceCharacteristicEqualityByUuid` peripheral builder option

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -323,6 +323,7 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 public final class com/juul/kable/PeripheralBuilder {
 	public final fun autoConnectIf (Lkotlin/jvm/functions/Function0;)V
 	public final fun getDisconnectTimeout-UwyO8pc ()J
+	public final fun getForceCharacteristicEqualityByUuid ()Z
 	public final fun getPhy ()Lcom/juul/kable/Phy;
 	public final fun getThreadingStrategy ()Lcom/juul/kable/ThreadingStrategy;
 	public final fun getTransport ()Lcom/juul/kable/Transport;
@@ -330,6 +331,7 @@ public final class com/juul/kable/PeripheralBuilder {
 	public final fun observationExceptionHandler (Lkotlin/jvm/functions/Function3;)V
 	public final fun onServicesDiscovered (Lkotlin/jvm/functions/Function2;)V
 	public final fun setDisconnectTimeout-LRDsOJo (J)V
+	public final fun setForceCharacteristicEqualityByUuid (Z)V
 	public final fun setPhy (Lcom/juul/kable/Phy;)V
 	public final fun setThreadingStrategy (Lcom/juul/kable/ThreadingStrategy;)V
 	public final fun setTransport (Lcom/juul/kable/Transport;)V

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -267,10 +267,12 @@ public final class com/juul/kable/Peripheral$DefaultImpls {
 
 public final class com/juul/kable/PeripheralBuilder {
 	public final fun getDisconnectTimeout-UwyO8pc ()J
+	public final fun getForceCharacteristicEqualityByUuid ()Z
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
 	public final fun observationExceptionHandler (Lkotlin/jvm/functions/Function3;)V
 	public final fun onServicesDiscovered (Lkotlin/jvm/functions/Function2;)V
 	public final fun setDisconnectTimeout-LRDsOJo (J)V
+	public final fun setForceCharacteristicEqualityByUuid (Z)V
 }
 
 public final class com/juul/kable/PeripheralKt {

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -88,7 +88,7 @@ internal class BluetoothDeviceAndroidPeripheral(
     private val _mtu = MutableStateFlow<Int?>(null)
     override val mtu = _mtu.asStateFlow()
 
-    private val observers = Observers<ByteArray>(this, logging, observationExceptionHandler)
+    private val observers = Observers<ByteArray>(this, logging, false, observationExceptionHandler)
 
     private val connection = MutableStateFlow<Connection?>(null)
     private fun connectionOrThrow() =

--- a/kable-core/src/androidMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/androidMain/kotlin/PeripheralBuilder.kt
@@ -117,4 +117,6 @@ public actual class PeripheralBuilder internal actual constructor() {
     public var threadingStrategy: ThreadingStrategy = OnDemandThreadingStrategy
 
     public actual var disconnectTimeout: Duration = defaultDisconnectTimeout
+
+    public actual var forceCharacteristicEqualityByUuid: Boolean = false
 }

--- a/kable-core/src/appleMain/kotlin/Peripheral.kt
+++ b/kable-core/src/appleMain/kotlin/Peripheral.kt
@@ -32,5 +32,6 @@ public fun Peripheral(
         builder.onServicesDiscovered,
         builder.logging,
         builder.disconnectTimeout,
+        builder.forceCharacteristicEqualityByUuid,
     )
 }

--- a/kable-core/src/appleMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/appleMain/kotlin/PeripheralBuilder.kt
@@ -58,4 +58,6 @@ public actual class PeripheralBuilder internal actual constructor() {
     }
 
     public actual var disconnectTimeout: Duration = defaultDisconnectTimeout
+
+    public actual var forceCharacteristicEqualityByUuid: Boolean = false
 }

--- a/kable-core/src/commonMain/kotlin/ObservationEvent.kt
+++ b/kable-core/src/commonMain/kotlin/ObservationEvent.kt
@@ -18,14 +18,18 @@ internal sealed class ObservationEvent<out T> {
     object Disconnected : ObservationEvent<Nothing>()
 }
 
-internal fun <T> ObservationEvent<T>.isAssociatedWith(characteristic: Characteristic): Boolean {
+internal fun <T> ObservationEvent<T>.isAssociatedWith(
+    characteristic: Characteristic,
+    forceCharacteristicEqualityByUuid: Boolean,
+): Boolean {
     val eventCharacteristic = this.characteristic
     return when {
         // `characteristic` is null for Disconnected, which applies to all characteristics.
         eventCharacteristic == null -> true
 
-        eventCharacteristic is DiscoveredCharacteristic && characteristic is DiscoveredCharacteristic ->
-            eventCharacteristic == characteristic
+        !forceCharacteristicEqualityByUuid &&
+            eventCharacteristic is DiscoveredCharacteristic &&
+            characteristic is DiscoveredCharacteristic -> eventCharacteristic == characteristic
 
         else ->
             eventCharacteristic.characteristicUuid == characteristic.characteristicUuid &&

--- a/kable-core/src/commonMain/kotlin/Observers.kt
+++ b/kable-core/src/commonMain/kotlin/Observers.kt
@@ -45,6 +45,7 @@ internal expect fun Peripheral.observationHandler(): Observation.Handler
 internal class Observers<T>(
     private val peripheral: Peripheral,
     private val logging: Logging,
+    private val forceCharacteristicEqualityByUuid: Boolean,
     private val exceptionHandler: ObservationExceptionHandler,
 ) {
 
@@ -77,7 +78,7 @@ internal class Observers<T>(
                     exceptionHandler(ObservationExceptionPeripheral(peripheral), e)
                 }
             }
-            .filter { event -> event.isAssociatedWith(characteristic) }
+            .filter { event -> event.isAssociatedWith(characteristic, forceCharacteristicEqualityByUuid) }
             .onEach { event ->
                 if (event is Error) {
                     exceptionHandler(ObservationExceptionPeripheral(peripheral), event.cause)

--- a/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/commonMain/kotlin/PeripheralBuilder.kt
@@ -78,4 +78,17 @@ public expect class PeripheralBuilder internal constructor() {
      * Only applicable on Android.
      */
     public var disconnectTimeout: Duration
+
+    /**
+     * Determines if characteristic equality should use UUID comparison (true), or compare by
+     * reference (false). Default is to compare by reference (false).
+     *
+     * Provides a workaround for I/O operations stalling when a peripheral has multiple
+     * characteristics with the same UUID until https://github.com/JuulLabs/kable/issues/1016 is
+     * fixed.
+     *
+     * Only applicable on Apple.
+     */
+    @ObsoleteKableApi // Will be removed after https://github.com/JuulLabs/kable/issues/1016 is fixed.
+    public var forceCharacteristicEqualityByUuid: Boolean
 }

--- a/kable-core/src/jsMain/kotlin/BluetoothDeviceWebBluetoothPeripheral.kt
+++ b/kable-core/src/jsMain/kotlin/BluetoothDeviceWebBluetoothPeripheral.kt
@@ -64,7 +64,7 @@ internal class BluetoothDeviceWebBluetoothPeripheral(
     @ExperimentalApi
     override val name: String? get() = bluetoothDevice.name
 
-    private val observers = Observers<DataView>(this, logging, observationExceptionHandler)
+    private val observers = Observers<DataView>(this, logging, false, observationExceptionHandler)
 
     private suspend fun establishConnection(scope: CoroutineScope): CoroutineScope {
         logger.info { message = "Connecting" }

--- a/kable-core/src/jsMain/kotlin/PeripheralBuilder.kt
+++ b/kable-core/src/jsMain/kotlin/PeripheralBuilder.kt
@@ -54,6 +54,8 @@ public actual class PeripheralBuilder internal actual constructor() {
 
     public actual var disconnectTimeout: Duration = defaultDisconnectTimeout
 
+    public actual var forceCharacteristicEqualityByUuid: Boolean = false
+
     internal fun build(bluetoothDevice: BluetoothDevice) =
         BluetoothDeviceWebBluetoothPeripheral(
             bluetoothDevice,

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/PeripheralBuilder.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/PeripheralBuilder.kt
@@ -50,4 +50,6 @@ public actual class PeripheralBuilder internal actual constructor() {
     }
 
     public actual var disconnectTimeout: Duration = defaultDisconnectTimeout
+
+    public actual var forceCharacteristicEqualityByUuid: Boolean = false
 }

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugPeripheral.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugPeripheral.kt
@@ -93,7 +93,7 @@ internal class BtleplugPeripheral(
 
     internal val ffi = com.juul.kable.btleplug.ffi.Peripheral(identifier.ffi, callbacks)
 
-    private val observers = Observers<ByteArray>(this, logging) { cause ->
+    private val observers = Observers<ByteArray>(this, logging, false) { cause ->
         logger.error(cause) { message = "Exception in observers" }
     }
 


### PR DESCRIPTION
Provides an option as a workaround until #1016 can be tackled.