### PR TITLE
Automatically derive uniffi bindgen version inside uniffi-plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.8.0" }
 mockk = { module = "io.mockk:mockk", version = "1.14.6" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16" }
+tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version = "0.5.0" }
 tuulbox-collections = { module = "com.juul.tuulbox:collections", version.ref = "tuulbox" }
 tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 wrappers-bom = { module = "org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom", version = "2025.12.0" }

--- a/uniffi-plugin/build.gradle.kts
+++ b/uniffi-plugin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.plugin)
+    implementation(libs.tomlkt)
 }
 
 gradlePlugin {


### PR DESCRIPTION
While trying to test #1079 with an up-to-date `main` I hit an unrelated failure due to uniffi version mismatch. Turns out I had hard-coded a version in here, and renovate is not unhinged enough to try parsing Cargo.toml out from Kotlin string literals 😆.

Now the plugin will parse `kable-btleplug-ffi/Cargo.toml` so this problem shouldn't happen again.