### PR TITLE
Fix mac runner used for publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - macos-13
+          - macos-15-intel
           - ubuntu-24.04-arm
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Publishing 0.40.1 failed because the runner doesn't exist anymore 😅 missed this when I fixed it for CI