### PR TITLE
Make `Properties` constructor experimentally public

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -93,6 +93,7 @@ public abstract interface class com/juul/kable/Characteristic {
 
 public final class com/juul/kable/Characteristic$Properties {
 	public static final synthetic fun box-impl (I)Lcom/juul/kable/Characteristic$Properties;
+	public static fun constructor-impl (I)I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (ILjava/lang/Object;)Z
 	public static final fun equals-impl0 (II)Z

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -52,6 +52,7 @@ public abstract interface class com/juul/kable/Characteristic {
 
 public final class com/juul/kable/Characteristic$Properties {
 	public static final synthetic fun box-impl (I)Lcom/juul/kable/Characteristic$Properties;
+	public static fun constructor-impl (I)I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (ILjava/lang/Object;)Z
 	public static final fun equals-impl0 (II)Z

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings {
+                optIn("com.juul.kable.ExperimentalApi")
                 optIn("kotlin.js.ExperimentalWasmJsInterop")
                 optIn("kotlin.uuid.ExperimentalUuidApi")
             }

--- a/kable-core/src/commonMain/kotlin/ExperimentalApi.kt
+++ b/kable-core/src/commonMain/kotlin/ExperimentalApi.kt
@@ -1,12 +1,13 @@
 package com.juul.kable
 
 import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.CONSTRUCTOR
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.TYPEALIAS
 
 /** Marks API that is experimental and/or likely to change. */
-@Target(TYPEALIAS, FUNCTION, PROPERTY, CLASS)
+@Target(TYPEALIAS, FUNCTION, PROPERTY, CLASS, CONSTRUCTOR)
 @Retention(AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.ERROR)
 public annotation class ExperimentalApi

--- a/kable-core/src/commonMain/kotlin/Profile.kt
+++ b/kable-core/src/commonMain/kotlin/Profile.kt
@@ -56,6 +56,7 @@ public interface Characteristic {
     public val characteristicUuid: Uuid
 
     @JvmInline
+    @Suppress("ktlint:standard:annotation")
     public value class Properties @ExperimentalApi constructor(public val value: Int) {
         internal infix fun or(other: Properties): Properties = Properties(value or other.value)
         internal infix fun and(other: Properties): Properties = Properties(value and other.value)

--- a/kable-core/src/commonMain/kotlin/Profile.kt
+++ b/kable-core/src/commonMain/kotlin/Profile.kt
@@ -56,7 +56,7 @@ public interface Characteristic {
     public val characteristicUuid: Uuid
 
     @JvmInline
-    public value class Properties internal constructor(public val value: Int) {
+    public value class Properties @ExperimentalApi constructor(public val value: Int) {
         internal infix fun or(other: Properties): Properties = Properties(value or other.value)
         internal infix fun and(other: Properties): Properties = Properties(value and other.value)
         override fun toString(): String =

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugPeripheral.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugPeripheral.kt
@@ -51,7 +51,6 @@ import com.juul.kable.btleplug.ffi.Uuid as FfiUuid
 private const val DEFAULT_ATT_MTU = 23
 private const val ATT_MTU_HEADER_SIZE = 3
 
-@OptIn(ExperimentalApi::class)
 internal class BtleplugPeripheral(
     override val identifier: Identifier,
     private val onServicesDiscovered: ServicesDiscoveredAction,


### PR DESCRIPTION
Closes #1111

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: API visibility change with experimental opt-in requirement; no security or core logic modifications.
> 
> **Overview**
> Makes the `Characteristic.Properties` constructor publicly accessible (marked as `@ExperimentalApi`), allowing users to create `Properties` instances directly from integer values. The `@ExperimentalApi` annotation target is extended to support constructors, and the build configuration now globally opts in to experimental APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a256e6259924605f5d886e668fde59165caaf600. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->