### PR TITLE
Honor caller cancellation during `connect`

### DIFF
--- a/kable-core/src/commonMain/kotlin/SharedRepeatableAction.awaitConnect.kt
+++ b/kable-core/src/commonMain/kotlin/SharedRepeatableAction.awaitConnect.kt
@@ -1,10 +1,17 @@
 package com.juul.kable
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 
 internal suspend fun SharedRepeatableAction<CoroutineScope>.awaitConnect(): CoroutineScope =
     try {
         await()
     } catch (e: IllegalStateException) {
+        // If calling code cancels we'd unintentionally swallow the `CancellationException`, as it
+        // is a subclass of `IllegalStateException`. `ensureActive()` honors caller cancellation.
+        // https://github.com/JuulLabs/kable/issues/1136
+        currentCoroutineContext().ensureActive()
+
         throw IllegalStateException("Cannot connect peripheral that has been cancelled", e)
     }


### PR DESCRIPTION
Closes #1136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Minimal change adding proper cancellation propagation; fixes a bug rather than introducing new behavior.
> 
> **Overview**
> Fixes a bug where coroutine cancellations were being swallowed during peripheral connection. `CancellationException` is a subclass of `IllegalStateException`, so the existing catch block was unintentionally masking caller cancellations. Adds `ensureActive()` check to properly propagate cancellation before wrapping other `IllegalStateException`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b99ae1af8f1be90a2743bd08ead6a1d63d0361f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->