### PR TITLE
Fix Rust compilation errors

### DIFF
--- a/kable-btleplug-ffi/src/peripheral.rs
+++ b/kable-btleplug-ffi/src/peripheral.rs
@@ -125,10 +125,12 @@ impl Peripheral {
                             break;
                         },
                         Some(event) = events.next() => match event {
-                            CentralEvent::DeviceConnected(connected) =>
-                                if connected == id.platform { callbacks.connected() }
-                            CentralEvent::DeviceDisconnected(disconnected) =>
-                                if disconnected == id.platform {
+                            CentralEvent::DeviceConnected(connected)
+                                if connected == id.platform => {
+                                    callbacks.connected()
+                                }
+                            CentralEvent::DeviceDisconnected(disconnected)
+                                if disconnected == id.platform => {
                                     *cached_peripheral.lock().unwrap() = None;
                                     callbacks.disconnected()
                                 }
@@ -174,9 +176,10 @@ impl Peripheral {
                 _ = peripheral_token.cancelled() => break,
                 _ = connect_token.cancelled() => break,
                 Some(event) = events.next() => match event {
-                    CentralEvent::DeviceConnected(_) | CentralEvent::DeviceUpdated(_) => {
-                        if adapter.peripheral(&self.id.platform).await.is_ok() { break; }
-                    },
+                    CentralEvent::DeviceConnected(_) | CentralEvent::DeviceUpdated(_)
+                        if adapter.peripheral(&self.id.platform).await.is_ok() => {
+                            break;
+                        },
                     _ => {}
                 }
             }


### PR DESCRIPTION
Fixes Rust compilation errors as seen in a number of CI runs:

- https://github.com/JuulLabs/kable/pull/1135
  - https://github.com/JuulLabs/kable/actions/runs/24829001588/job/72673440839?pr=1135
- https://github.com/JuulLabs/kable/pull/1134
  - https://github.com/JuulLabs/kable/actions/runs/24800441108/job/72582401803?pr=1134
- https://github.com/JuulLabs/kable/pull/1113
  - https://github.com/JuulLabs/kable/actions/runs/25129095680/job/74006367547?pr=1113

<details>
<summary>Error snippet</summary>

```
    Checking btleplug-ffi v0.0.0 (/Users/runner/work/kable/kable/kable-btleplug-ffi)
error: this `if` can be collapsed into the outer `match`
   --> src/peripheral.rs:129:33
    |
129 | ...                   if connected == id.platform { callbacks.connected() }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match
    = note: `-D clippy::collapsible-match` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::collapsible_match)]`
help: collapse nested if block
    |
128 -                             CentralEvent::DeviceConnected(connected) =>
129 -                                 if connected == id.platform { callbacks.connected() }
128 +                             CentralEvent::DeviceConnected(connected)f connected == id.platform => { callbacks.connected()
    |

error: this `if` can be collapsed into the outer `match`
   --> src/peripheral.rs:131:33
    |
131 | / ...                   if disconnected == id.platform {
132 | | ...                       *cached_peripheral.lock().unwrap() = None;
133 | | ...                       callbacks.disconnected()
134 | | ...                   }
    | |_______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match
help: collapse nested if block
    |
130 ~                             CentralEvent::DeviceDisconnected(disconnected)f disconnected == id.platform => {
131 |                                     *cached_peripheral.lock().unwrap() = None;
132 ~                                     callbacks.disconnected()
    |

error: this `if` can be collapsed into the outer `match`
   --> src/peripheral.rs:178:25
    |
178 |                         if adapter.peripheral(&self.id.platform).await.is_ok() { break; }
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match
help: collapse nested if block
    |
177 ~                     CentralEvent::DeviceConnected(_) | CentralEvent::DeviceUpdated(_)
178 ~                         if adapter.peripheral(&self.id.platform).await.is_ok() => { break; },
    |

error: could not compile `btleplug-ffi` (lib) due to 3 previous errors
```
</details>

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple syntax correction with no functional changes to the logic.
> 
> **Overview**
> Fixes Rust match arm syntax by converting inline `if` statements to proper match guards in two event handling loops. The changes affect the `DeviceConnected`/`DeviceDisconnected` event handlers and the reconnection logic, converting from a pattern followed by a block containing an `if` to using the `if` as a match guard directly on the pattern. No functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f97c83024ca9fbb1941d9c1b5e6ed2de6136db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->