### PR TITLE
Update dependency com.juul.khronicle:khronicle-core to v1.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 equalsverifier = { module = "nl.jqno.equalsverifier:equalsverifier", version = "4.5" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
-khronicle = { module = "com.juul.khronicle:khronicle-core", version = "0.6.0" }
+khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.1.0" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version = "0.5.0" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps `com.juul.khronicle:khronicle-core` from `0.6.0` to `1.1.0` (the latest release).

## Release notes

- **1.1.0** — Maintenance release including Kotlin `2.3.21`, ktor `3.4.3`, AGP v9, atomicfu `0.32.1`, and adds watchOS build targets.
- **1.0.0** — First stable release (no functional changes from `1.0.0-rc1`).
- **1.0.0-rc1** — Breaking changes:
  - `tag` is now required when logging, and has been moved before `throwable` in the parameter order ([JuulLabs/khronicle#185](https://github.com/JuulLabs/khronicle/pull/185)). The existing call sites in `KhronicleLogEngine` already pass `tag` before `throwable`, so no source changes are required here.
  - The previously deprecated `AndroidLogger` was removed ([JuulLabs/khronicle#186](https://github.com/JuulLabs/khronicle/pull/186)). This project does not depend on `khronicle-android`.

## Changes

- `gradle/libs.versions.toml`: bump `khronicle` from `0.6.0` to `1.1.0`.

No call site changes are required. The `KhronicleLogEngine` already uses the `Log.<level>(tag, throwable) { metadata -> ... }` signature that is the supported form in 1.1.0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdc909d5-0648-41f7-9e3b-c526cef2a975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc909d5-0648-41f7-9e3b-c526cef2a975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

