### PR TITLE
Drop `macosX64` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ repositories {
 kotlin {
     androidTarget()
     js().browser()
-    macosX64()
+    macosArm64()
     iosX64()
     iosArm64()
     jvm()

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
         iosSimulatorArm64()
         iosX64()
         macosArm64()
-        macosX64()
     }
 
     androidTarget().publishLibraryVariants("debug", "release")

--- a/kable-log-engine-khronicle/build.gradle.kts
+++ b/kable-log-engine-khronicle/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
         iosSimulatorArm64()
         iosX64()
         macosArm64()
-        macosX64()
     }
 
     js().browser()


### PR DESCRIPTION
Kotlin 2.3.20 deprecated `macosX64` support.

https://kotlinlang.org/docs/whatsnew2320.html#breaking-changes-and-deprecations

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes a platform target with no changes to core logic or security-sensitive code. Users on Intel Macs can use Rosetta with the ARM64 build.
> 
> **Overview**
> Removes `macosX64()` from the Kotlin Multiplatform targets in `kable-core/build.gradle.kts`, discontinuing support for macOS Intel (x64) architecture in the core library. The library will continue to support macOS Apple Silicon via the existing `macosArm64()` target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465f965c95f702662cd00caa1c48041f2e79510e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->