### PR TITLE
Update android-compile version to 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-compile = "35"
+android-compile = "36"
 android-min = "21"
 atomicfu = "0.32.1"
 coroutines = "1.10.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple version bump for Android compile SDK with no logic changes.
> 
> **Overview**
> Updates the Android compile SDK version from 35 to 36 in `gradle/libs.versions.toml`. This version bump allows the project to use new Android APIs and features available in API level 36 during compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4eb47fe56ce3e5f2c95d2d906f51e46aefbbd15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->