### PR TITLE
Change `kable-default-permissions` Android namespace

### DIFF
--- a/kable-default-permissions/build.gradle.kts
+++ b/kable-default-permissions/build.gradle.kts
@@ -11,5 +11,5 @@ kotlin {
 android {
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
-    namespace = "com.juul.kable.permissions.default"
+    namespace = "com.juul.kable.permissions"
 }

--- a/kable-default-permissions/build.gradle.kts
+++ b/kable-default-permissions/build.gradle.kts
@@ -11,5 +11,5 @@ kotlin {
 android {
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = libs.versions.android.min.get().toInt()
-    namespace = "com.juul.kable"
+    namespace = "com.juul.kable.permissions.default"
 }


### PR DESCRIPTION
Fixes consumers who upgrade to AGP9 (with stricter namespace enforcement) who see the following error:

```
> Task :app:processDebugMainManifest FAILED
[com.juul.kable:kable-core-android-debug:0.43.0] 
transformed/jetified-kable-core-debug/AndroidManifest.xml Error:
	Namespace 'com.juul.kable' is used in multiple modules and/or libraries: com.juul.kable:kable-core-android-debug:0.43.0, com.juul.kable:kable-default-permissions:0.43.0.
Please ensure that all modules and libraries have a unique namespace.
For more information, See https://developer.android.com/studio/build/configure-app-module#set-namespace
app/src/debug/AndroidManifest.xml Error:
	Validation failed, exiting
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-metadata only; no runtime logic or API surface changes beyond satisfying AGP namespace uniqueness.
> 
> **Overview**
> Updates the Android library **namespace** for `kable-default-permissions` from `com.juul.kable` to `com.juul.kable.permissions.default` so it no longer collides with `kable-core` under AGP 9’s stricter namespace checks.
> 
> This is a one-line `build.gradle.kts` change aimed at fixing manifest merge / validation failures when both artifacts are on the classpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a348c4c0329f03b67e4d8391051854f421c2c944. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->