### PR TITLE
Update `android-compile` version to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-compile = "36"
+android-compile = "37"
 android-min = "21"
 atomicfu = "0.33.0"
 coroutines = "1.11.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version-catalog change for compile SDK only; no application logic or runtime behavior changes.
> 
> **Overview**
> Bumps the Android **compile SDK** version from **36** to **37** in `gradle/libs.versions.toml` via the `android-compile` version catalog entry.
> 
> This aligns the project’s Android library builds with API level 37 for compilation; `android-min` and other versions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449cdcbc74f93dbcc9b21d47a3b7740159fd2aaf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->