### PR TITLE
Drop usage of AtomicFu plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.maven.publish) apply false
-    alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.api)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 android-compile = "36"
 android-min = "21"
-atomicfu = "0.33.0"
 coroutines = "1.11.0"
 jna = "5.18.1"
 jvm-toolchain = "17"
@@ -11,7 +10,7 @@ tuulbox = "8.1.0"
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version = "1.18.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2.0" }
-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.33.0" }
 equalsverifier = { module = "nl.jqno.equalsverifier:equalsverifier", version = "4.5" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.1.0" }
@@ -33,7 +32,6 @@ wrappers-web = { module = "org.jetbrains.kotlin-wrappers:kotlin-web" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.13.2" }
 api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.1" }
-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "5.2.0" }

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    alias(libs.plugins.atomicfu)
     id("com.android.library")
     id("com.vanniktech.maven.publish")
     id("kotlin-parcelize")
@@ -38,6 +37,7 @@ kotlin {
         all {
             languageSettings {
                 optIn("com.juul.kable.ExperimentalApi")
+                optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
                 optIn("kotlin.js.ExperimentalWasmJsInterop")
                 optIn("kotlin.uuid.ExperimentalUuidApi")
                 optIn("kotlinx.cinterop.UnsafeNumber")
@@ -47,6 +47,7 @@ kotlin {
         commonMain.dependencies {
             api(libs.kotlinx.coroutines.core)
             api(libs.kotlinx.io)
+            implementation(libs.atomicfu)
         }
 
         commonTest.dependencies {
@@ -60,11 +61,6 @@ kotlin {
             api(libs.kotlinx.coroutines.android)
             implementation(libs.androidx.core)
             implementation(libs.androidx.startup)
-
-            // Workaround for AtomicFU plugin not automatically adding JVM dependency for Android.
-            // https://github.com/Kotlin/kotlinx-atomicfu/issues/145
-            implementation(libs.atomicfu)
-
             implementation(libs.tuulbox.coroutines)
         }
 

--- a/kable-core/src/androidMain/kotlin/ThreadingStrategy.kt
+++ b/kable-core/src/androidMain/kotlin/ThreadingStrategy.kt
@@ -2,21 +2,22 @@ package com.juul.kable
 
 import com.juul.kable.OnDemandThreadingStrategy.acquire
 import com.juul.kable.OnDemandThreadingStrategy.release
-import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
-private val threadNumber = atomic(0)
-private fun generateThreadName() = "Kable#${threadNumber.incrementAndGet()}"
+private val threadNumber = AtomicInt(0)
+private fun generateThreadName() = "Kable#${threadNumber.incrementAndFetch()}"
 
 public interface ThreadingStrategy {
     public fun acquire(): Threading

--- a/kable-core/src/appleMain/kotlin/CentralManager.kt
+++ b/kable-core/src/appleMain/kotlin/CentralManager.kt
@@ -1,7 +1,6 @@
 package com.juul.kable
 
 import com.juul.kable.logs.Logging
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import platform.CoreBluetooth.CBCentralManager
@@ -9,6 +8,7 @@ import platform.CoreBluetooth.CBCharacteristic
 import platform.CoreBluetooth.CBCharacteristicWriteType
 import platform.CoreBluetooth.CBPeripheral
 import platform.Foundation.NSData
+import kotlin.concurrent.AtomicReference
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.uuid.Uuid
@@ -35,7 +35,7 @@ public class CentralManager internal constructor(
 
     public companion object {
 
-        private val configuration = atomic<Configuration?>(null)
+        private val configuration = AtomicReference<Configuration?>(null)
         private val lazyDefault = lazy { CentralManager(configuration.value?.toOptions()) }
         internal val Default by lazyDefault
 

--- a/kable-core/src/commonMain/kotlin/Observation.kt
+++ b/kable-core/src/commonMain/kotlin/Observation.kt
@@ -3,10 +3,10 @@ package com.juul.kable
 import com.juul.kable.State.Connecting.Observes
 import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.atomics.AtomicBoolean
 
 internal class Observation(
     private val state: StateFlow<State>,
@@ -26,10 +26,10 @@ internal class Observation(
     private val subscribers = mutableListOf<OnSubscriptionAction>()
     private val mutex = Mutex()
 
-    private val _didStartObservation = atomic(false)
+    private val _didStartObservation = AtomicBoolean(false)
     private var didStartObservation: Boolean
-        get() = _didStartObservation.value
-        set(value) { _didStartObservation.value = value }
+        get() = _didStartObservation.load()
+        set(value) { _didStartObservation.store(value) }
 
     private val isConnected: Boolean
         get() = state.value.isAtLeast<Observes>()

--- a/kable-core/src/commonMain/kotlin/SharedRepeatableAction.kt
+++ b/kable-core/src/commonMain/kotlin/SharedRepeatableAction.kt
@@ -1,6 +1,5 @@
 package com.juul.kable
 
-import com.juul.kable.SharedRepeatableAction.State
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CancellationException
@@ -9,7 +8,6 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.job
-import kotlinx.coroutines.sync.withLock
 
 internal fun <T> CoroutineScope.sharedRepeatableAction(
     action: suspend (scope: CoroutineScope) -> T,


### PR DESCRIPTION
As suggested by https://github.com/Kotlin/kotlinx-atomicfu/issues/511#issuecomment-2654402439, use atomic types provided by the Kotlin stdlib so we don't have to lean on AtomicFu plugin for transformations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency primitives across BLE threading, observation lifecycle, and Apple central configuration; behavior should match but multiplatform atomic semantics deserve regression testing.
> 
> **Overview**
> Removes the **AtomicFU Gradle plugin** and switches hot-path atomics to **Kotlin stdlib** types (`AtomicInt`, `AtomicBoolean`, `AtomicReference`) with `ExperimentalAtomicApi` opted in on `kable-core`.
> 
> **Build:** The plugin is dropped from the root and `kable-core`; `org.jetbrains.kotlinx:atomicfu` stays as a **runtime** dependency in `commonMain` (and the duplicate Android-only workaround is removed) so **`kotlinx.atomicfu.locks`** (`reentrantLock`, `synchronized`) still work in places like `ThreadingStrategy` and `SharedRepeatableAction`.
> 
> **Code:** `atomic()` / `.value` / `incrementAndGet()` call sites are updated to stdlib APIs (e.g. thread naming uses `incrementAndFetch()`, observation state uses `load()`/`store()`, Apple `CentralManager` config uses `AtomicReference`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72f131c04aecb8f6645c1b6071654687eeafe6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->