### PR TITLE
Rename `KableInternalApi` → `InternalKableApi`

### DIFF
--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -199,7 +199,7 @@ public final class com/juul/kable/IdentifierKt {
 public final class com/juul/kable/InternalError : java/lang/Error {
 }
 
-public abstract interface annotation class com/juul/kable/KableInternalApi : java/lang/annotation/Annotation {
+public abstract interface annotation class com/juul/kable/InternalKableApi : java/lang/annotation/Annotation {
 }
 
 public final class com/juul/kable/LazyCharacteristic : com/juul/kable/Characteristic {

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
         all {
             languageSettings {
                 optIn("com.juul.kable.ExperimentalKableApi")
-                optIn("com.juul.kable.KableInternalApi")
+                optIn("com.juul.kable.InternalKableApi")
                 optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
                 optIn("kotlin.js.ExperimentalWasmJsInterop")
                 optIn("kotlin.uuid.ExperimentalUuidApi")

--- a/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
@@ -166,6 +166,6 @@ public interface AndroidPeripheral : Peripheral {
      * This is an internal API and may be removed from a future release. If you are using it, please
      * open an issue and report your use case.
      */
-    @KableInternalApi
+    @InternalKableApi
     public val bluetoothDevice: BluetoothDevice
 }

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -52,7 +52,7 @@ private const val DEFAULT_ATT_MTU = 23
 private const val ATT_MTU_HEADER_SIZE = 3
 
 internal class BluetoothDeviceAndroidPeripheral(
-    @KableInternalApi override val bluetoothDevice: BluetoothDevice,
+    @InternalKableApi override val bluetoothDevice: BluetoothDevice,
     private val autoConnectPredicate: () -> Boolean,
     private val transport: Transport,
     private val phy: Phy,

--- a/kable-core/src/androidMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/androidMain/kotlin/PlatformAdvertisement.kt
@@ -19,6 +19,6 @@ public actual interface PlatformAdvertisement : Advertisement, Parcelable {
      * This is an internal API and may be removed from a future release. If you are using it, please
      * open an issue and report your use case.
      */
-    @KableInternalApi
+    @InternalKableApi
     public val bluetoothDevice: BluetoothDevice
 }

--- a/kable-core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
+++ b/kable-core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
@@ -21,7 +21,7 @@ internal class ScanResultAndroidAdvertisement(
     private val scanResult: ScanResult,
 ) : PlatformAdvertisement {
 
-    @KableInternalApi
+    @InternalKableApi
     override val bluetoothDevice: BluetoothDevice
         get() = scanResult.device
 

--- a/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
+++ b/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
@@ -16,7 +16,7 @@ import kotlin.uuid.Uuid
 internal class CBPeripheralCoreBluetoothAdvertisement(
     override val rssi: Int,
     private val data: Map<String, Any>,
-    @KableInternalApi override val cbPeripheral: CBPeripheral,
+    @InternalKableApi override val cbPeripheral: CBPeripheral,
 ) : PlatformAdvertisement {
 
     override val identifier: Identifier

--- a/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -52,7 +52,7 @@ import platform.CoreBluetooth.CBCharacteristicWriteWithResponse as CBWithRespons
 import platform.CoreBluetooth.CBCharacteristicWriteWithoutResponse as CBWithoutResponse
 
 internal class CBPeripheralCoreBluetoothPeripheral(
-    @KableInternalApi override val cbPeripheral: CBPeripheral,
+    @InternalKableApi override val cbPeripheral: CBPeripheral,
     observationExceptionHandler: ObservationExceptionHandler,
     private val onServicesDiscovered: ServicesDiscoveredAction,
     private val logging: Logging,

--- a/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
@@ -12,7 +12,7 @@ public interface CoreBluetoothPeripheral : Peripheral {
      * This is an internal API and may be removed from a future release. If you are using it, please
      * open an issue and report your use case.
      */
-    @KableInternalApi
+    @InternalKableApi
     public val cbPeripheral: CBPeripheral
 
     @Throws(CancellationException::class, IOException::class)

--- a/kable-core/src/appleMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/appleMain/kotlin/PlatformAdvertisement.kt
@@ -13,6 +13,6 @@ public actual interface PlatformAdvertisement : Advertisement {
      * This is an internal API and may be removed from a future release. If you are using it, please
      * open an issue and report your use case.
      */
-    @KableInternalApi
+    @InternalKableApi
     public val cbPeripheral: CBPeripheral
 }

--- a/kable-core/src/commonMain/kotlin/InternalKableApi.kt
+++ b/kable-core/src/commonMain/kotlin/InternalKableApi.kt
@@ -14,4 +14,4 @@ import kotlin.annotation.AnnotationTarget.PROPERTY
 @RequiresOptIn(message = "This declaration is internal, use at your own risk.", level = ERROR)
 @Retention(BINARY)
 @Target(CLASS, PROPERTY, FUNCTION)
-public annotation class KableInternalApi
+public annotation class InternalKableApi


### PR DESCRIPTION
Follow up to #1028.

Updates internal API annotation to follow standard naming convention for internal API annotations (whereas "internal" appears first in the name), e.g.:

- [`InternalCoroutinesApi`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-internal-coroutines-api/)
- [`InternalSerializationApi`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-internal-serialization-api/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking rename for any downstream code or Gradle opt-ins that still reference `com.juul.kable.KableInternalApi`; behavior of marked APIs is unchanged.
> 
> **Overview**
> Renames the opt-in internal API annotation from **`KableInternalApi`** to **`InternalKableApi`** so it matches common Kotlin library naming (e.g. `InternalCoroutinesApi`).
> 
> All **`@InternalKableApi`** usages on platform escape hatches (`bluetoothDevice`, `cbPeripheral`, etc.) and the **`kable-core`** `languageSettings.optIn` entry are updated accordingly; the JVM **`kable-core.api`** stub reflects the new annotation type. Annotation semantics (`RequiresOptIn`, targets, message) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328ac82c3aa95134cf0c5350e1943cba5e04633b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->