### PR TITLE
Omit `distribution` for `setup-java`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew :kable-core:compileKotlinJvm
@@ -50,7 +49,6 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew :kable-btleplug-ffi:assemble
@@ -47,7 +46,6 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
 

--- a/.github/workflows/sensortag-android.yml
+++ b/.github/workflows/sensortag-android.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew :android:assemble

--- a/.github/workflows/sensortag-ios.yml
+++ b/.github/workflows/sensortag-ios.yml
@@ -19,7 +19,6 @@ jobs:
           xcode-version: latest-stable
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
 

--- a/.github/workflows/sensortag-web.yml
+++ b/.github/workflows/sensortag-web.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew :shared:wasmJsBrowserDistribution

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
-          distribution: temurin
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
         with:


### PR DESCRIPTION
With [5.5.0](https://github.com/actions/setup-java/releases/tag/v5.5.0) of [`setup-java`](https://github.com/actions/setup-java), `distribution` is no longer needed:

> `distribution`: Java [distribution](https://github.com/actions/setup-java#supported-distributions). Required unless `java-version-file` points to `.sdkmanrc` with a recognized distribution suffix (for example `java=21.0.5-tem`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow simplification with no application or security logic changes; behavior should match prior Temurin setup as long as `.sdkmanrc` keeps a recognized distribution suffix.
> 
> **Overview**
> Removes the explicit **`distribution: temurin`** input from every **`actions/setup-java@v5`** step across CI, Pages, Publish, SensorTag, and signing workflows.
> 
> Each step still uses **`java-version-file: .sdkmanrc`**, which already pins **`java=17.0.19-tem`**; **`setup-java` 5.5.0+** infers Temurin from that suffix, so the extra **`distribution`** line is no longer required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3213921adff40e49d63b4b1367fc152b67c8357c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->