### PR TITLE
Remove `androidSourceSetLayoutVersion` Gradle option

### DIFF
--- a/samples/sensortag/gradle.properties
+++ b/samples/sensortag/gradle.properties
@@ -1,3 +1,2 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
The Android source layout is version 2 by default and this property was removed in Kotlin 2.0.0.

Example CI warnings:

```
w: ⚠️ Deprecated Gradle Property 'kotlin.mpp.androidSourceSetLayoutVersion' Used
The `kotlin.mpp.androidSourceSetLayoutVersion` deprecated property is used in your build.
Solutions:
 * It is unsupported, please stop using it.
 * Android Source Set Layout V2 is enabled by default and can't be changed. Leave your questions here https://youtrack.jetbrains.com/issue/KT-82265
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-only Gradle config cleanup with no runtime or build-behavior change beyond silencing deprecation warnings.
> 
> **Overview**
> Drops **`kotlin.mpp.androidSourceSetLayoutVersion=2`** from `samples/sensortag/gradle.properties`.
> 
> That Gradle property is **deprecated and unsupported in Kotlin 2.0+**; Android source set layout v2 is already the default, so the line only triggered CI deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2741dbea4a630d52109bd1fcf8a70a2d28839f23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->