### PR TITLE
Restore `kotlin-parcelize-runtime` dependency in published Android metadata

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 kable = { module = "com.juul.kable:kable-core" }
 kable-permissions = { module = "com.juul.kable:kable-default-permissions" }
 khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.1.0" }
+kotlin-parcelize-runtime = { module = "org.jetbrains.kotlin:kotlin-parcelize-runtime", version.ref = "kotlin" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version = "0.5.0" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -83,6 +83,7 @@ kotlin {
             api(libs.kotlinx.coroutines.android)
             implementation(libs.androidx.core)
             implementation(libs.androidx.startup)
+            implementation(libs.kotlin.parcelize.runtime)
             implementation(libs.tuulbox.coroutines)
         }
 


### PR DESCRIPTION
## Why

The 0.43.1 → 0.44.0 migration (#1124) from `com.android.library` to `com.android.kotlin.multiplatform.library` stopped propagating the runtime dependency that the `kotlin-parcelize` plugin adds into the published Gradle module metadata and POM for `kable-core-android`:

| Published metadata | 0.43.1 | 0.44.0 |
|---|---|---|
| `.module` | `releaseRuntimeElements-published` declares `kotlin-parcelize-runtime:2.4.0` | no parcelize entry in any variant |
| POM | `kotlin-parcelize-runtime`, runtime scope | dropped |

Since `ScanResultAndroidAdvertisement` is `@Parcelize`, consumers that don't apply `kotlin-parcelize` themselves now fail R8 full-mode builds with `Missing class kotlinx.parcelize.Parcelize`. Details in #1201.

## What

Declare the dependency explicitly in `androidMain`, restoring the ≤ 0.43.1 published shape. This is what the `kotlin-parcelize` plugin itself does for Android compilations; the artifact is a 15 KB annotations-only jar whose sole dependency is `kotlin-stdlib`, and R8 strips the unused annotation classes from consumer APKs. (The non-propagation may ultimately be a KGP/AGP interop bug worth escalating upstream, but the explicit declaration is harmless, self-documenting, and unbreaks consumers now.)

## Verification

`./gradlew :kable-core:generateMetadataFileForAndroidPublication :kable-core:generatePomFileForAndroidPublication` on this branch: the `.module` again declares `kotlin-parcelize-runtime` in `androidRuntimeElements-published`, and the POM carries it at runtime scope, version `2.4.0` (tracks the `kotlin` catalog version).

Alternative to #1203, which ships a `-dontwarn` consumer keep rule in the AAR instead of the dependency. Merge whichever you prefer and close the other.

Fixes #1201.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-metadata and a small annotations-only runtime dependency on Android; no auth, data, or core BLE logic changes.
> 
> **Overview**
> After the move to `com.android.kotlin.multiplatform.library`, **`kotlin-parcelize-runtime` stopped appearing** in published `.module` / POM metadata for `kable-core-android`, so apps using `@Parcelize` types (e.g. `ScanResultAndroidAdvertisement`) without applying `kotlin-parcelize` themselves could hit R8 **Missing class kotlinx.parcelize.Parcelize**.
> 
> This PR **declares `kotlin-parcelize-runtime` explicitly** on `androidMain` (catalog entry + `implementation` in `kable-core/build.gradle.kts`), matching the ≤0.43.1 published dependency shape and fixing consumer builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bab061ff51f3a0649b512f77416192c5dbca46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->