### PR TITLE
Ship consumer keep rule for `kotlinx.parcelize.Parcelize`

### DIFF
--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -33,6 +33,11 @@ kotlin {
             // Android version bumps to make sure we aren't missing any newly introduced permission requirements.
             disable += "MissingPermission"
         }
+
+        optimization {
+            consumerKeepRules.file("consumer-rules.pro")
+            consumerKeepRules.publish = true
+        }
     }
 
     // Build fails on Linux ARM64 host (when building Rust bindings for JAR distribution), so we

--- a/kable-core/consumer-rules.pro
+++ b/kable-core/consumer-rules.pro
@@ -1,0 +1,3 @@
+# ScanResultAndroidAdvertisement is @Parcelize; the annotation is referenced in bytecode but
+# kotlin-parcelize-runtime is not a dependency, so silence the R8 (full mode) missing-class check.
+-dontwarn kotlinx.parcelize.Parcelize


### PR DESCRIPTION
## Why

Same regression as #1201: since the migration to `com.android.kotlin.multiplatform.library` (#1124), the published Android metadata no longer carries the runtime dependency that the `kotlin-parcelize` plugin adds, so consumers that don't apply `kotlin-parcelize` themselves fail R8 full-mode builds with:

```
Missing class kotlinx.parcelize.Parcelize (referenced from: com.juul.kable.ScanResultAndroidAdvertisement)
```

## What

The `@Parcelize` annotation is BINARY retention and never loaded at runtime — it is the only `kotlinx.parcelize` reference in the entire AAR — so instead of a dependency, embed a `-dontwarn kotlinx.parcelize.Parcelize` consumer keep rule in the AAR via `optimization.consumerKeepRules`.

Note: `consumerKeepRules.publish` defaults to **false** and must be set explicitly, or the rules file is silently omitted from the AAR.

## Verification

`./gradlew :kable-core:bundleAndroidMainAar` — the AAR now contains `proguard.txt` with the rule (it previously shipped only `R.txt`).

Alternative to #1202, which restores the dependency instead (matching the ≤ 0.43.1 published shape). Merge whichever you prefer and close the other.

Fixes #1201.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change (consumer Proguard rules); no runtime behavior or API changes beyond fixing shrinker warnings for an annotation that is not loaded at runtime.
> 
> **Overview**
> Fixes consumer **R8 full-mode** failures (`Missing class kotlinx.parcelize.Parcelize` on `ScanResultAndroidAdvertisement`) after the Android KMP library migration stopped shipping the parcelize runtime on the published artifact.
> 
> Adds **`consumer-rules.pro`** with `-dontwarn kotlinx.parcelize.Parcelize` and wires it through **`android.optimization.consumerKeepRules`** with **`publish = true`** so the rule is embedded in the AAR as `proguard.txt` for downstream apps that do not apply `kotlin-parcelize` themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71aaf5d0a7ae6886367728a8ba139117adc4108f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->