### PR TITLE
Build Linux dynamic libraries with cross for older glibc compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - macos-15-intel
-          - ubuntu-24.04-arm
-          - ubuntu-latest
-          - windows-latest
+        include:
+          - runner: macos-15-intel
+          - runner: windows-latest
+
+          # Linux dynamic libraries are built with `cross` (in Docker containers) to link against
+          # an older glibc than provided by the GitHub runners, for compatibility with older Linux
+          # distributions (e.g. Raspberry Pi OS).
+          # https://github.com/JuulLabs/kable/issues/990
+          - runner: ubuntu-latest
+            cargo: cross
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            cargo: cross
+            target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -26,13 +35,18 @@ jobs:
         with:
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
+      - if: matrix.cargo == 'cross'
+        run: cargo install cross --git https://github.com/cross-rs/cross
       - run: ./gradlew :kable-core:compileKotlinJvm
+        env:
+          UNIFFI_CARGO: ${{ matrix.cargo }}
+          UNIFFI_TARGET: ${{ matrix.target }}
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs
         shell: bash
       - uses: actions/upload-artifact@v7
         with:
-          name: kable-btleplug-ffi-${{ matrix.runner }}
+          name: kable-btleplug-ffi-${{ matrix.target || matrix.runner }}
           path: kable-btleplug-ffi/build/libs/
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - macos-15-intel
-          - ubuntu-24.04-arm
-          - ubuntu-latest
-          - windows-latest
+        include:
+          - runner: macos-15-intel
+          - runner: windows-latest
+
+          # Linux dynamic libraries are built with `cross` (in Docker containers) to link against
+          # an older glibc than provided by the GitHub runners, for compatibility with older Linux
+          # distributions (e.g. Raspberry Pi OS).
+          # https://github.com/JuulLabs/kable/issues/990
+          - runner: ubuntu-latest
+            cargo: cross
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            cargo: cross
+            target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -23,13 +32,18 @@ jobs:
         with:
           java-version-file: .sdkmanrc
       - uses: gradle/actions/setup-gradle@v6
+      - if: matrix.cargo == 'cross'
+        run: cargo install cross --git https://github.com/cross-rs/cross
       - run: ./gradlew :kable-btleplug-ffi:assemble
+        env:
+          UNIFFI_CARGO: ${{ matrix.cargo }}
+          UNIFFI_TARGET: ${{ matrix.target }}
       - run: unzip kable-btleplug-ffi.jar && rm -rf META-INF com *.jar
         working-directory: kable-btleplug-ffi/build/libs
         shell: bash
       - uses: actions/upload-artifact@v7
         with:
-          name: kable-btleplug-ffi-${{ matrix.runner }}
+          name: kable-btleplug-ffi-${{ matrix.target || matrix.runner }}
           path: kable-btleplug-ffi/build/libs/
           if-no-files-found: error
           retention-days: 1

--- a/kable-btleplug-ffi/Cross.toml
+++ b/kable-btleplug-ffi/Cross.toml
@@ -1,0 +1,9 @@
+# Build Linux dynamic libraries against CentOS 7's glibc 2.17 (rather than the glibc of the default
+# `cross` images) for compatibility with older Linux distributions (e.g. Raspberry Pi OS).
+# https://github.com/JuulLabs/kable/issues/990
+
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos"

--- a/kable-btleplug-ffi/build.gradle.kts
+++ b/kable-btleplug-ffi/build.gradle.kts
@@ -16,4 +16,11 @@ kotlin {
 uniffiKotlin {
     optimized = System.getenv("CI").toBoolean()
     packageName = "com.juul.kable.btleplug.ffi"
+
+    // CI builds Linux dynamic libraries with `cross` (https://github.com/cross-rs/cross) so that
+    // they link against an older glibc than what is available on the GitHub runners, for
+    // compatibility with older Linux distributions (e.g. Raspberry Pi OS).
+    // https://github.com/JuulLabs/kable/issues/990
+    System.getenv("UNIFFI_CARGO")?.takeIf(String::isNotBlank)?.let { cargoCommand = it }
+    System.getenv("UNIFFI_TARGET")?.takeIf(String::isNotBlank)?.let { target = it }
 }

--- a/uniffi-plugin/src/main/kotlin/TaskExtensions.kt
+++ b/uniffi-plugin/src/main/kotlin/TaskExtensions.kt
@@ -14,6 +14,7 @@ fun TaskInputs.rustSources() {
     // Optional
     files(
         "Cargo.lock",
+        "Cross.toml",
         "rust-toolchain.toml",
         "rustfmt.toml",
     )

--- a/uniffi-plugin/src/main/kotlin/UniffiKotlinExtension.kt
+++ b/uniffi-plugin/src/main/kotlin/UniffiKotlinExtension.kt
@@ -4,19 +4,39 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Optional
 
 interface UniffiKotlinExtension {
+    /**
+     * Command used to build the dynamic library, for example `cross`
+     * (https://github.com/cross-rs/cross). Defaults to `cargo`.
+     */
+    @get:Optional
+    val cargoCommand: Property<String>
+
     /** When true, adds the `--release` tag to cargo builds. */
     val optimized: Property<Boolean>
 
     /** Package name to use for generated kotlin code. */
     val packageName: Property<String>
+
+    /**
+     * Rust target triple (e.g. `aarch64-unknown-linux-gnu`) to build the dynamic library for.
+     * Defaults to the host's target.
+     */
+    @get:Optional
+    val target: Property<String>
 }
 
 internal class UniffiKotlinExtensionAccessor(
     private val extension: UniffiKotlinExtension,
 ) {
+    val cargoCommand: String
+        get() = extension.cargoCommand.getOrElse("cargo")
+
     val optimized: Boolean
         get() = extension.optimized.get()
 
     val packageName: String
         get() = extension.packageName.get()
+
+    val target: UniffiTarget
+        get() = extension.target.orNull?.let(UniffiTarget::parse) ?: UniffiTarget.current
 }

--- a/uniffi-plugin/src/main/kotlin/UniffiTarget.kt
+++ b/uniffi-plugin/src/main/kotlin/UniffiTarget.kt
@@ -10,5 +10,13 @@ data class UniffiTarget(val arch: UniffiArch, val os: UniffiOs) {
         val current: UniffiTarget by lazy {
             UniffiTarget(UniffiArch.current, UniffiOs.current)
         }
+
+        fun parse(triple: String): UniffiTarget {
+            val arch = UniffiArch.entries.singleOrNull { triple.startsWith("${it.tripleComponent}-") }
+                ?: error("Unsupported architecture in target triple: $triple")
+            val os = UniffiOs.entries.singleOrNull { triple.endsWith("-${it.tripleComponent}") }
+                ?: error("Unsupported OS in target triple: $triple")
+            return UniffiTarget(arch, os)
+        }
     }
 }

--- a/uniffi-plugin/src/main/kotlin/tasks/CargoBuildTask.kt
+++ b/uniffi-plugin/src/main/kotlin/tasks/CargoBuildTask.kt
@@ -2,7 +2,6 @@ package com.juul.kable.uniffi.plugin.tasks
 
 import com.juul.kable.uniffi.plugin.UNIFFI_TASK_GROUP
 import com.juul.kable.uniffi.plugin.UniffiKotlinExtensionAccessor
-import com.juul.kable.uniffi.plugin.UniffiTarget
 import com.juul.kable.uniffi.plugin.cargoBuild
 import com.juul.kable.uniffi.plugin.rustSources
 import org.gradle.api.tasks.Exec
@@ -13,12 +12,14 @@ internal fun TaskContainer.registerCargoBuildTask(accessor: UniffiKotlinExtensio
     register<Exec>("cargoBuild") {
         group = UNIFFI_TASK_GROUP
 
+        inputs.property("cargoCommand", accessor.cargoCommand)
         inputs.property("optimized", accessor.optimized)
+        inputs.property("target", accessor.target.triple)
         inputs.rustSources()
-        outputs.cargoBuild(UniffiTarget.current, accessor.optimized)
+        outputs.cargoBuild(accessor.target, accessor.optimized)
 
-        commandLine("cargo", "build")
-        args("--target", UniffiTarget.current.triple)
+        commandLine(accessor.cargoCommand, "build")
+        args("--target", accessor.target.triple)
         if (accessor.optimized) {
             args("--release")
         }

--- a/uniffi-plugin/src/main/kotlin/tasks/CopyDynamicLibraryResourcesTask.kt
+++ b/uniffi-plugin/src/main/kotlin/tasks/CopyDynamicLibraryResourcesTask.kt
@@ -2,7 +2,6 @@ package com.juul.kable.uniffi.plugin.tasks
 
 import com.juul.kable.uniffi.plugin.KOTLIN_SOURCE_SET
 import com.juul.kable.uniffi.plugin.UniffiKotlinExtensionAccessor
-import com.juul.kable.uniffi.plugin.UniffiTarget
 import com.juul.kable.uniffi.plugin.cargoBuild
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskContainer
@@ -19,7 +18,7 @@ internal fun TaskContainer.registerCopyDynamicLibraryResourcesTask(accessor: Uni
             .resolve("resources")
             .resolve(KOTLIN_SOURCE_SET)
 
-        val target = UniffiTarget.current
+        val target = accessor.target
         inputs.cargoBuild(target, accessor.optimized)
         from(target.buildDirectory(accessor.optimized)) {
             include { it.name.matches(target.os.library) }

--- a/uniffi-plugin/src/main/kotlin/tasks/UniffiBindgenTasks.kt
+++ b/uniffi-plugin/src/main/kotlin/tasks/UniffiBindgenTasks.kt
@@ -2,8 +2,6 @@ package com.juul.kable.uniffi.plugin.tasks
 
 import com.juul.kable.uniffi.plugin.UNIFFI_TASK_GROUP
 import com.juul.kable.uniffi.plugin.UniffiKotlinExtensionAccessor
-import com.juul.kable.uniffi.plugin.UniffiOs
-import com.juul.kable.uniffi.plugin.UniffiTarget
 import com.juul.kable.uniffi.plugin.cargoBuild
 import com.juul.kable.uniffi.plugin.uniffiBindgenProject
 import com.juul.kable.uniffi.plugin.uniffiOutputDirectory
@@ -82,7 +80,7 @@ internal fun TaskContainer.registerUniffiBindgenTasks(accessor: UniffiKotlinExte
 
         inputs.property("optimized", accessor.optimized)
 
-        inputs.cargoBuild(UniffiTarget.current, accessor.optimized)
+        inputs.cargoBuild(accessor.target, accessor.optimized)
         inputs.dir(project.uniffiBindgenProject)
         outputs.dir(project.uniffiOutputDirectory)
 
@@ -93,8 +91,9 @@ internal fun TaskContainer.registerUniffiBindgenTasks(accessor: UniffiKotlinExte
         args("--out-dir", project.uniffiOutputDirectory.absolutePath)
         args("--no-format")
         doFirst {
-            val directory = project.file(UniffiTarget.current.buildDirectory(accessor.optimized))
-            val file = directory.list().orEmpty().single { it.matches(UniffiOs.current.library) }
+            val target = accessor.target
+            val directory = project.file(target.buildDirectory(accessor.optimized))
+            val file = directory.list().orEmpty().single { it.matches(target.os.library) }
             args("--library", directory.resolve(file).absolutePath)
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves https://github.com/JuulLabs/kable/issues/990

## Problem

The Linux `kable-btleplug-ffi` dynamic libraries are built directly on GitHub's Ubuntu runners, so they link against the runner's glibc (2.38+). On distributions with an older glibc (e.g. Raspberry Pi OS, glibc ≤ 2.36), JNA fails to load the library and Sensortag scans crash immediately.

## Solution

As suggested in the issue, Linux builds now go through [`cross`](https://github.com/cross-rs/cross), using its CentOS 7 based images (`main-centos` tags, pinned via `kable-btleplug-ffi/Cross.toml`) so the produced `.so` files link against **glibc 2.17**.

> [!NOTE]
> The issue mentions cross's default toolchain being on glibc 2.31, but cross's default images have since moved to Ubuntu 24.04 (glibc 2.39), which would reproduce the original problem — hence the CentOS 7 images, which the issue also mentions as an option.

### `uniffi-plugin`

- New optional `cargoCommand` extension property: command used to build the dynamic library (defaults to `cargo`). CI sets it to `cross` for Linux builds via the `UNIFFI_CARGO` environment variable.
- New optional `target` extension property: Rust target triple to build the dynamic library for (defaults to the host's target). CI sets it via the `UNIFFI_TARGET` environment variable. This was needed because cross does not publish arm64 host images ([cross-rs/cross#751](https://github.com/cross-rs/cross/issues/751)), so the `aarch64-unknown-linux-gnu` library is now cross-compiled from the x86_64 runner instead of being built natively on `ubuntu-24.04-arm`.
- `generateKotlinBindings` still runs `uniffi-bindgen` with host `cargo`; only the `--library` it parses points at the (possibly cross-compiled) target library, which works since uniffi-bindgen reads metadata from the binary statically.

### Workflows (`ci.yml` / `publish.yml`)

- The `assemble-rust` matrix replaces the `ubuntu-24.04-arm` + `ubuntu-latest` runners with two `ubuntu-latest` entries (one per Linux target) that install cross (from git `main`, matching the pinned `main-centos` image tags) and export `UNIFFI_CARGO`/`UNIFFI_TARGET`.
- Linux artifact names are now keyed by target triple instead of runner name; macOS/Windows artifacts are unchanged.

Local (non-CI) builds are unaffected: without the environment variables set, the plugin behaves exactly as before (`cargo build --target <host triple>`).

## Verification

Performed locally (Docker + cross installed from git main, same as CI):

- `UNIFFI_CARGO=cross UNIFFI_TARGET=aarch64-unknown-linux-gnu ./gradlew :kable-btleplug-ffi:assemble` → jar contains `linux-aarch64/libbtleplug_ffi.so`, `objdump -T` shows max versioned symbol `GLIBC_2.17`.
- `UNIFFI_CARGO=cross ./gradlew :kable-btleplug-ffi:cargoBuild` (x86_64) → max versioned symbol `GLIBC_2.16`.
- Plain `./gradlew :kable-btleplug-ffi:assemble` (no env vars) → unchanged native host build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-135a7b9f-73bd-4501-aa03-803093507b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-135a7b9f-73bd-4501-aa03-803093507b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

