### PR TITLE
Make `Advertisement` serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ val scanner = Scanner {
 _Scanning for nearby peripherals is supported, but only available on Chrome 79+ with "Experimental Web Platform
 features" enabled via:_ `chrome://flags/#enable-experimental-web-platform-features`
 
+### Serialization
+
+[`Advertisement`] objects are serializable (via [kotlinx.serialization]), allowing them to be used (for example) as
+navigation arguments with Compose Navigation:
+
+```kotlin
+@Serializable
+data class PeripheralDetails(val advertisement: Advertisement)
+```
+
+Serialization captures a snapshot of the advertisement data at the time of serialization; deserialization restores an
+[`Advertisement`] holding the previously captured data (deserialized advertisements are **not** "live"). Serialized
+advertisements are only guaranteed to deserialize on the same platform they were serialized on (the `identifier`
+property is a platform specific value that is not portable across platforms).
+
+> [!NOTE]
+> _On JavaScript, a [`Peripheral`] cannot be created from a deserialized [`Advertisement`] (Web Bluetooth requires a
+> `BluetoothDevice` object, which cannot be synchronously retrieved); use the `Peripheral(Identifier)` builder function
+> instead._
+
 ## Peripheral
 
 Once an [`Advertisement`] is obtained, it can be converted to a [`Peripheral`] via the `Peripheral` builder function:
@@ -660,6 +680,7 @@ limitations under the License.
 [Coroutine scope]: https://kotlinlang.org/docs/reference/coroutines/coroutine-context-and-dispatchers.html#coroutine-scope
 [Coroutines with multithread support for Kotlin/Native]: https://github.com/Kotlin/kotlinx.coroutines/issues/462
 [SensorTag sample app]: samples/sensortag
+[kotlinx.serialization]: https://github.com/Kotlin/kotlinx.serialization
 [`Advertisement`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-advertisement/index.html
 [`Characteristic`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-characteristic/index.html
 [`Connected`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-state/-connected/index.html

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ jna = "5.19.1"
 jvm-toolchain = "17"
 kotlin = "2.4.10"
 krayon = "0.24.0"
+serialization = "1.11.0"
 tuulbox = "8.1.0"
 voyager = "2.2.21-1.10.3"
 
@@ -41,7 +42,8 @@ krayon-selection = { module = "com.juul.krayon:selection", version.ref = "krayon
 krayon-shape = { module = "com.juul.krayon:shape", version.ref = "krayon" }
 mockk = { module = "io.mockk:mockk", version = "1.14.11" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.11.0" }
+serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version = "0.5.0" }
 tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }

--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -1,4 +1,5 @@
 public abstract interface class com/juul/kable/Advertisement {
+	public static final field Companion Lcom/juul/kable/Advertisement$Companion;
 	public abstract fun getIdentifier ()Ljava/lang/String;
 	public abstract fun getManufacturerData ()Lcom/juul/kable/ManufacturerData;
 	public abstract fun getName ()Ljava/lang/String;
@@ -9,6 +10,19 @@ public abstract interface class com/juul/kable/Advertisement {
 	public abstract fun isConnectable ()Ljava/lang/Boolean;
 	public abstract fun manufacturerData (I)[B
 	public abstract fun serviceData (Lkotlin/uuid/Uuid;)[B
+}
+
+public final class com/juul/kable/Advertisement$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/juul/kable/AdvertisementSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/juul/kable/AdvertisementSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/juul/kable/Advertisement;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/juul/kable/Advertisement;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
 public abstract interface class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
@@ -372,6 +386,7 @@ public final class com/juul/kable/Phy : java/lang/Enum {
 }
 
 public abstract interface class com/juul/kable/PlatformAdvertisement : android/os/Parcelable, com/juul/kable/Advertisement {
+	public static final field Companion Lcom/juul/kable/PlatformAdvertisement$Companion;
 	public abstract fun getAddress ()Ljava/lang/String;
 	public abstract fun getBondState ()Lcom/juul/kable/PlatformAdvertisement$BondState;
 	public abstract fun getBytes ()[B
@@ -384,6 +399,19 @@ public final class com/juul/kable/PlatformAdvertisement$BondState : java/lang/En
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/PlatformAdvertisement$BondState;
 	public static fun values ()[Lcom/juul/kable/PlatformAdvertisement$BondState;
+}
+
+public final class com/juul/kable/PlatformAdvertisement$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/juul/kable/PlatformAdvertisementSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/juul/kable/PlatformAdvertisementSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/juul/kable/PlatformAdvertisement;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/juul/kable/PlatformAdvertisement;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
 public final class com/juul/kable/PooledThreadingStrategy : com/juul/kable/ThreadingStrategy {

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -1,4 +1,5 @@
 public abstract interface class com/juul/kable/Advertisement {
+	public static final field Companion Lcom/juul/kable/Advertisement$Companion;
 	public abstract fun getIdentifier ()Lcom/juul/kable/Identifier;
 	public abstract fun getManufacturerData ()Lcom/juul/kable/ManufacturerData;
 	public abstract fun getName ()Ljava/lang/String;
@@ -9,6 +10,19 @@ public abstract interface class com/juul/kable/Advertisement {
 	public abstract fun isConnectable ()Ljava/lang/Boolean;
 	public abstract fun manufacturerData (I)[B
 	public abstract fun serviceData (Lkotlin/uuid/Uuid;)[B
+}
+
+public final class com/juul/kable/Advertisement$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/juul/kable/AdvertisementSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/juul/kable/AdvertisementSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/juul/kable/Advertisement;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/juul/kable/Advertisement;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
 public final class com/juul/kable/Bluetooth {
@@ -297,6 +311,20 @@ public final class com/juul/kable/Peripheral_deprecatedKt {
 }
 
 public abstract interface class com/juul/kable/PlatformAdvertisement : com/juul/kable/Advertisement {
+	public static final field Companion Lcom/juul/kable/PlatformAdvertisement$Companion;
+}
+
+public final class com/juul/kable/PlatformAdvertisement$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/juul/kable/PlatformAdvertisementSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/juul/kable/PlatformAdvertisementSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/juul/kable/PlatformAdvertisement;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/juul/kable/PlatformAdvertisement;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
 public final class com/juul/kable/ProfileKt {

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlinter)
+    alias(libs.plugins.serialization)
     id("kotlin-parcelize")
     kotlin("multiplatform")
 }
@@ -69,6 +70,7 @@ kotlin {
         commonMain.dependencies {
             api(libs.kotlinx.coroutines)
             api(libs.kotlinx.io)
+            api(libs.serialization)
             implementation(libs.atomicfu)
         }
 
@@ -77,6 +79,7 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.khronicle)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.serialization.json)
         }
 
         androidMain.dependencies {

--- a/kable-core/src/androidHostTest/kotlin/com/juul/kable/AdvertisementSerializationTests.kt
+++ b/kable-core/src/androidHostTest/kotlin/com/juul/kable/AdvertisementSerializationTests.kt
@@ -1,0 +1,125 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.le.ScanRecord
+import android.bluetooth.le.ScanResult
+import android.os.Build
+import android.os.Parcel
+import android.os.ParcelUuid
+import android.os.Parcelable
+import android.util.SparseArray
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+import kotlin.uuid.toJavaUuid
+
+private const val MANUFACTURER_CODE = 0x004C
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class AdvertisementSerializationTests {
+
+    private val serviceUuid = Uuid.parse("0000180a-0000-1000-8000-00805f9b34fb")
+
+    private fun scanResultAdvertisement(): PlatformAdvertisement {
+        val bluetoothDevice = mockk<BluetoothDevice> {
+            every { address } returns "00:11:22:AA:BB:CC"
+            every { name } returns "Example (cached)"
+        }
+        val record = mockk<ScanRecord> {
+            every { deviceName } returns "Example"
+            every { bytes } returns byteArrayOf(0x0F, 0x09)
+            every { txPowerLevel } returns 8
+            every { serviceUuids } returns listOf(ParcelUuid(serviceUuid.toJavaUuid()))
+            every { serviceData } returns
+                mapOf(ParcelUuid(serviceUuid.toJavaUuid()) to byteArrayOf(0x01, 0x02, 0x03))
+            every { getManufacturerSpecificData(MANUFACTURER_CODE) } returns byteArrayOf(0x02, 0x15)
+            every { manufacturerSpecificData } returns
+                SparseArray<ByteArray>().apply { put(MANUFACTURER_CODE, byteArrayOf(0x02, 0x15)) }
+        }
+        val scanResult = mockk<ScanResult> {
+            every { device } returns bluetoothDevice
+            every { rssi } returns -42
+            every { isConnectable } returns true
+            every { scanRecord } returns record
+        }
+        return ScanResultAndroidAdvertisement(scanResult)
+    }
+
+    @Test
+    fun jsonRoundTrip_retainsAdvertisementData() {
+        val advertisement = scanResultAdvertisement()
+
+        val json = Json.encodeToString(PlatformAdvertisementSerializer, advertisement)
+        val restored = Json.decodeFromString(PlatformAdvertisementSerializer, json)
+
+        assertEquals(advertisement.name, restored.name)
+        assertEquals(advertisement.peripheralName, restored.peripheralName)
+        assertEquals(advertisement.address, restored.address)
+        assertEquals(advertisement.identifier, restored.identifier)
+        assertEquals(advertisement.isConnectable, restored.isConnectable)
+        assertEquals(advertisement.rssi, restored.rssi)
+        assertEquals(advertisement.txPower, restored.txPower)
+        assertEquals(advertisement.uuids, restored.uuids)
+        assertContentEquals(advertisement.bytes, restored.bytes)
+        assertContentEquals(advertisement.serviceData(serviceUuid), restored.serviceData(serviceUuid))
+        assertContentEquals(
+            advertisement.manufacturerData(MANUFACTURER_CODE),
+            restored.manufacturerData(MANUFACTURER_CODE),
+        )
+        assertEquals(advertisement.manufacturerData?.code, restored.manufacturerData?.code)
+        assertContentEquals(advertisement.manufacturerData?.data, restored.manufacturerData?.data)
+    }
+
+    @Test
+    fun jsonRoundTrip_ofRestoredAdvertisement_isEqual() {
+        val advertisement = scanResultAdvertisement()
+        val json = Json.encodeToString(PlatformAdvertisementSerializer, advertisement)
+        val restored = Json.decodeFromString(PlatformAdvertisementSerializer, json)
+
+        val jsonOfRestored = Json.encodeToString(PlatformAdvertisementSerializer, restored)
+        val restoredAgain = Json.decodeFromString(PlatformAdvertisementSerializer, jsonOfRestored)
+
+        assertEquals(json, jsonOfRestored)
+        assertEquals(restored, restoredAgain)
+    }
+
+    @Test
+    fun serializesViaAdvertisementSerializer_matchesPlatformAdvertisementSerializer() {
+        val advertisement = scanResultAdvertisement()
+
+        val json = Json.encodeToString(AdvertisementSerializer, advertisement)
+
+        assertEquals(Json.encodeToString(PlatformAdvertisementSerializer, advertisement), json)
+    }
+
+    @Test
+    fun parcelRoundTrip_ofRestoredAdvertisement_isEqual() {
+        val advertisement = scanResultAdvertisement()
+        val json = Json.encodeToString(PlatformAdvertisementSerializer, advertisement)
+        val restored = Json.decodeFromString(PlatformAdvertisementSerializer, json)
+            as CapturedAndroidAdvertisement
+
+        val parcel = Parcel.obtain()
+        try {
+            restored.writeToParcel(parcel, 0)
+            parcel.setDataPosition(0)
+            @Suppress("UNCHECKED_CAST")
+            val creator = CapturedAndroidAdvertisement::class.java
+                .getField("CREATOR")
+                .get(null) as Parcelable.Creator<CapturedAndroidAdvertisement>
+            val fromParcel = creator.createFromParcel(parcel)
+
+            assertEquals(restored, fromParcel)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}

--- a/kable-core/src/androidMain/kotlin/AdvertisementCapture.android.kt
+++ b/kable-core/src/androidMain/kotlin/AdvertisementCapture.android.kt
@@ -1,0 +1,22 @@
+package com.juul.kable
+
+internal actual fun PlatformAdvertisement.capture(): AdvertisementCapture = when (this) {
+    is ScanResultAndroidAdvertisement -> capture()
+    is CapturedAndroidAdvertisement -> capture
+    else -> AdvertisementCapture(
+        name = name,
+        peripheralName = peripheralName,
+        identifier = address,
+        isConnectable = isConnectable,
+        rssi = rssi,
+        txPower = txPower,
+        uuids = uuids,
+        // `PlatformAdvertisement` does not provide enumeration of service data.
+        serviceData = emptyMap(),
+        manufacturerData = manufacturerData?.let { mapOf(it.code to it.data) }.orEmpty(),
+        bytes = bytes,
+    )
+}
+
+internal actual fun AdvertisementCapture.restore(): PlatformAdvertisement =
+    CapturedAndroidAdvertisement(this)

--- a/kable-core/src/androidMain/kotlin/BondState.kt
+++ b/kable-core/src/androidMain/kotlin/BondState.kt
@@ -1,0 +1,14 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothDevice.BOND_BONDED
+import android.bluetooth.BluetoothDevice.BOND_BONDING
+import android.bluetooth.BluetoothDevice.BOND_NONE
+import com.juul.kable.PlatformAdvertisement.BondState
+
+internal fun BluetoothDevice.toBondState(): BondState = when (bondState) {
+    BOND_NONE -> BondState.None
+    BOND_BONDING -> BondState.Bonding
+    BOND_BONDED -> BondState.Bonded
+    else -> error("Unknown bond state: $bondState")
+}

--- a/kable-core/src/androidMain/kotlin/CapturedAndroidAdvertisement.kt
+++ b/kable-core/src/androidMain/kotlin/CapturedAndroidAdvertisement.kt
@@ -1,0 +1,119 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothDevice
+import android.os.Parcel
+import com.juul.kable.PlatformAdvertisement.BondState
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
+import kotlin.uuid.Uuid
+
+/**
+ * [PlatformAdvertisement] restored from previously captured advertisement data (i.e. produced by
+ * deserializing a serialized [PlatformAdvertisement]).
+ *
+ * Most properties reflect the advertisement at the time it was captured, with the following
+ * exceptions (which are retrieved, on demand, from the local Bluetooth adapter):
+ * - [bondState]
+ * - [bluetoothDevice]
+ */
+@Parcelize
+@TypeParceler<AdvertisementCapture, AdvertisementCaptureParceler>()
+internal class CapturedAndroidAdvertisement(
+    internal val capture: AdvertisementCapture,
+) : PlatformAdvertisement {
+
+    /** @throws IllegalStateException If bluetooth is not supported. */
+    @InternalKableApi
+    override val bluetoothDevice: BluetoothDevice
+        get() = getBluetoothAdapter().getRemoteDevice(address.uppercase())
+
+    override val name: String?
+        get() = capture.name
+
+    override val peripheralName: String?
+        get() = capture.peripheralName
+
+    override val address: String
+        get() = capture.identifier
+
+    override val identifier: Identifier
+        get() = capture.identifier
+
+    /** @throws IllegalStateException If bluetooth is not supported. */
+    override val bondState: BondState
+        get() = bluetoothDevice.toBondState()
+
+    override val isConnectable: Boolean?
+        get() = capture.isConnectable
+
+    override val bytes: ByteArray?
+        get() = capture.bytes
+
+    override val rssi: Int
+        get() = capture.rssi
+
+    override val txPower: Int?
+        get() = capture.txPower
+
+    override val uuids: List<Uuid>
+        get() = capture.uuids
+
+    override fun serviceData(uuid: Uuid): ByteArray? = capture.serviceData[uuid]
+
+    override fun manufacturerData(companyIdentifierCode: Int): ByteArray? =
+        capture.manufacturerData[companyIdentifierCode]
+
+    override val manufacturerData: ManufacturerData?
+        get() = capture.manufacturerData.entries.firstOrNull()
+            ?.let { (code, data) -> ManufacturerData(code, data) }
+
+    override fun equals(other: Any?): Boolean =
+        other is CapturedAndroidAdvertisement && capture == other.capture
+
+    override fun hashCode(): Int = capture.hashCode()
+
+    override fun toString(): String = capture.toString()
+}
+
+internal object AdvertisementCaptureParceler : Parceler<AdvertisementCapture> {
+
+    override fun create(parcel: Parcel): AdvertisementCapture = AdvertisementCapture(
+        name = parcel.readString(),
+        peripheralName = parcel.readString(),
+        identifier = parcel.readString()!!,
+        isConnectable = parcel.readValue(Boolean::class.java.classLoader) as Boolean?,
+        rssi = parcel.readInt(),
+        txPower = parcel.readValue(Int::class.java.classLoader) as Int?,
+        uuids = List(parcel.readInt()) { Uuid.parse(parcel.readString()!!) },
+        serviceData = List(parcel.readInt()) {
+            Uuid.parse(parcel.readString()!!) to parcel.createByteArray()!!
+        }.toMap(),
+        manufacturerData = List(parcel.readInt()) {
+            parcel.readInt() to parcel.createByteArray()!!
+        }.toMap(),
+        bytes = parcel.createByteArray(),
+    )
+
+    override fun AdvertisementCapture.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+        parcel.writeString(peripheralName)
+        parcel.writeString(identifier)
+        parcel.writeValue(isConnectable)
+        parcel.writeInt(rssi)
+        parcel.writeValue(txPower)
+        parcel.writeInt(uuids.size)
+        uuids.forEach { uuid -> parcel.writeString(uuid.toString()) }
+        parcel.writeInt(serviceData.size)
+        serviceData.forEach { (uuid, data) ->
+            parcel.writeString(uuid.toString())
+            parcel.writeByteArray(data)
+        }
+        parcel.writeInt(manufacturerData.size)
+        manufacturerData.forEach { (code, data) ->
+            parcel.writeInt(code)
+            parcel.writeByteArray(data)
+        }
+        parcel.writeByteArray(bytes)
+    }
+}

--- a/kable-core/src/androidMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/androidMain/kotlin/PlatformAdvertisement.kt
@@ -2,7 +2,9 @@ package com.juul.kable
 
 import android.bluetooth.BluetoothDevice
 import android.os.Parcelable
+import kotlinx.serialization.Serializable
 
+@Serializable(with = PlatformAdvertisementSerializer::class)
 public actual interface PlatformAdvertisement : Advertisement, Parcelable {
 
     public enum class BondState {

--- a/kable-core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
+++ b/kable-core/src/androidMain/kotlin/ScanResultAndroidAdvertisement.kt
@@ -1,14 +1,13 @@
 package com.juul.kable
 
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothDevice.BOND_BONDED
-import android.bluetooth.BluetoothDevice.BOND_BONDING
-import android.bluetooth.BluetoothDevice.BOND_NONE
 import android.bluetooth.le.ScanRecord
 import android.bluetooth.le.ScanResult
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.ParcelUuid
+import android.util.SparseArray
+import androidx.core.util.forEach
 import androidx.core.util.isNotEmpty
 import com.juul.kable.PlatformAdvertisement.BondState
 import kotlinx.parcelize.Parcelize
@@ -51,12 +50,7 @@ internal class ScanResultAndroidAdvertisement(
         get() = bluetoothDevice.address
 
     override val bondState: BondState
-        get() = when (bluetoothDevice.bondState) {
-            BOND_NONE -> BondState.None
-            BOND_BONDING -> BondState.Bonding
-            BOND_BONDED -> BondState.Bonded
-            else -> error("Unknown bond state: ${bluetoothDevice.bondState}")
-        }
+        get() = bluetoothDevice.toBondState()
 
     /** Returns raw bytes of the underlying scan record. */
     override val bytes: ByteArray?
@@ -88,6 +82,22 @@ internal class ScanResultAndroidAdvertisement(
             )
         }
 
+    internal fun capture(): AdvertisementCapture = AdvertisementCapture(
+        name = name,
+        peripheralName = peripheralName,
+        identifier = address,
+        isConnectable = isConnectable,
+        rssi = rssi,
+        txPower = txPower,
+        uuids = uuids,
+        serviceData = serviceData
+            ?.entries
+            ?.associate { (uuid, data) -> uuid.uuid.toKotlinUuid() to data }
+            .orEmpty(),
+        manufacturerData = scanResult.scanRecord?.manufacturerSpecificData?.toMap().orEmpty(),
+        bytes = bytes,
+    )
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ScanResultAndroidAdvertisement) return false
@@ -99,3 +109,6 @@ internal class ScanResultAndroidAdvertisement(
     override fun toString(): String =
         "Advertisement(address=$address, name=$name, rssi=$rssi, txPower=$txPower)"
 }
+
+private fun SparseArray<ByteArray>.toMap(): Map<Int, ByteArray> =
+    buildMap { this@toMap.forEach { key, value -> put(key, value) } }

--- a/kable-core/src/appleMain/kotlin/AdvertisementCapture.apple.kt
+++ b/kable-core/src/appleMain/kotlin/AdvertisementCapture.apple.kt
@@ -1,0 +1,10 @@
+package com.juul.kable
+
+internal actual fun PlatformAdvertisement.capture(): AdvertisementCapture = when (this) {
+    is CBPeripheralCoreBluetoothAdvertisement -> capture()
+    is CapturedCoreBluetoothAdvertisement -> capture
+    else -> captureCommon()
+}
+
+internal actual fun AdvertisementCapture.restore(): PlatformAdvertisement =
+    CapturedCoreBluetoothAdvertisement(this)

--- a/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
+++ b/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothAdvertisement.kt
@@ -67,6 +67,21 @@ internal class CBPeripheralCoreBluetoothAdvertisement(
     override val manufacturerDataAsNSData: NSData?
         get() = data[CBAdvertisementDataManufacturerDataKey] as? NSData
 
+    internal fun capture(): AdvertisementCapture = AdvertisementCapture(
+        name = name,
+        peripheralName = peripheralName,
+        identifier = identifier.toString(),
+        isConnectable = isConnectable,
+        rssi = rssi,
+        txPower = txPower,
+        uuids = uuids,
+        serviceData = (data[CBAdvertisementDataServiceDataKey] as? Map<CBUUID, NSData>)
+            ?.entries
+            ?.associate { (uuid, data) -> uuid.toUuid() to data.toByteArray() }
+            .orEmpty(),
+        manufacturerData = manufacturerData?.let { mapOf(it.code to it.data) }.orEmpty(),
+    )
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is CBPeripheralCoreBluetoothAdvertisement) return false

--- a/kable-core/src/appleMain/kotlin/CapturedCoreBluetoothAdvertisement.kt
+++ b/kable-core/src/appleMain/kotlin/CapturedCoreBluetoothAdvertisement.kt
@@ -1,0 +1,75 @@
+package com.juul.kable
+
+import platform.CoreBluetooth.CBPeripheral
+import platform.Foundation.NSData
+import kotlin.uuid.Uuid
+
+/**
+ * [PlatformAdvertisement] restored from previously captured advertisement data (i.e. produced by
+ * deserializing a serialized [PlatformAdvertisement]).
+ *
+ * All properties reflect the advertisement at the time it was captured, except [cbPeripheral],
+ * which is retrieved (on demand) from the system.
+ */
+internal class CapturedCoreBluetoothAdvertisement(
+    internal val capture: AdvertisementCapture,
+) : PlatformAdvertisement {
+
+    override val identifier: Identifier = Uuid.parse(capture.identifier)
+
+    /** @throws NoSuchElementException If the system has no knowledge of a peripheral with [identifier]. */
+    @InternalKableApi
+    override val cbPeripheral: CBPeripheral
+        get() = CentralManager.Default.retrievePeripheral(identifier)
+            ?: throw NoSuchElementException("Peripheral with UUID $identifier not found")
+
+    override val name: String?
+        get() = capture.name
+
+    override val peripheralName: String?
+        get() = capture.peripheralName
+
+    override val isConnectable: Boolean?
+        get() = capture.isConnectable
+
+    override val rssi: Int
+        get() = capture.rssi
+
+    override val txPower: Int?
+        get() = capture.txPower
+
+    override val uuids: List<Uuid>
+        get() = capture.uuids
+
+    override fun serviceData(uuid: Uuid): ByteArray? = capture.serviceData[uuid]
+
+    override fun serviceDataAsNSData(uuid: Uuid): NSData? = capture.serviceData[uuid]?.toNSData()
+
+    override fun manufacturerData(companyIdentifierCode: Int): ByteArray? =
+        capture.manufacturerData[companyIdentifierCode]
+
+    override fun manufacturerDataAsNSData(companyIdentifierCode: Int): NSData? =
+        manufacturerData(companyIdentifierCode)?.toNSData()
+
+    override val manufacturerData: ManufacturerData?
+        get() = capture.manufacturerData.entries.firstOrNull()
+            ?.let { (code, data) -> ManufacturerData(code, data) }
+
+    override val manufacturerDataAsNSData: NSData?
+        get() = capture.manufacturerData.entries.firstOrNull()
+            ?.let { (code, data) ->
+                // Reconstructs the Manufacturer Specific Data layout (two octet little-endian
+                // Company Identifier Code, followed by the manufacturer data).
+                byteArrayOf(
+                    (code and 0xFF).toByte(),
+                    ((code shr 8) and 0xFF).toByte(),
+                ).plus(data).toNSData()
+            }
+
+    override fun equals(other: Any?): Boolean =
+        other is CapturedCoreBluetoothAdvertisement && capture == other.capture
+
+    override fun hashCode(): Int = capture.hashCode()
+
+    override fun toString(): String = capture.toString()
+}

--- a/kable-core/src/appleMain/kotlin/Peripheral.kt
+++ b/kable-core/src/appleMain/kotlin/Peripheral.kt
@@ -6,7 +6,7 @@ public actual fun Peripheral(
     advertisement: Advertisement,
     builderAction: PeripheralBuilderAction,
 ): Peripheral {
-    advertisement as CBPeripheralCoreBluetoothAdvertisement
+    advertisement as PlatformAdvertisement
     return Peripheral(advertisement.cbPeripheral, builderAction)
 }
 

--- a/kable-core/src/appleMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/appleMain/kotlin/PlatformAdvertisement.kt
@@ -1,9 +1,11 @@
 package com.juul.kable
 
+import kotlinx.serialization.Serializable
 import platform.CoreBluetooth.CBPeripheral
 import platform.Foundation.NSData
 import kotlin.uuid.Uuid
 
+@Serializable(with = PlatformAdvertisementSerializer::class)
 public actual interface PlatformAdvertisement : Advertisement {
     public fun serviceDataAsNSData(uuid: Uuid): NSData?
     public val manufacturerDataAsNSData: NSData?

--- a/kable-core/src/commonMain/kotlin/Advertisement.kt
+++ b/kable-core/src/commonMain/kotlin/Advertisement.kt
@@ -1,7 +1,14 @@
 package com.juul.kable
 
+import kotlinx.serialization.Serializable
 import kotlin.uuid.Uuid
 
+/**
+ * [Advertisement] is serializable (e.g. usable as a Compose Navigation argument): serialization
+ * captures a snapshot of the advertisement data, and deserialization restores an advertisement
+ * holding the captured data. See [AdvertisementSerializer] for caveats.
+ */
+@Serializable(with = AdvertisementSerializer::class)
 public interface Advertisement {
 
     /**

--- a/kable-core/src/commonMain/kotlin/AdvertisementCapture.kt
+++ b/kable-core/src/commonMain/kotlin/AdvertisementCapture.kt
@@ -1,0 +1,89 @@
+package com.juul.kable
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * Snapshot of the data carried by an [Advertisement], used as the serial (wire) representation of
+ * [Advertisement] and [PlatformAdvertisement].
+ *
+ * [identifier] is retained as its [String] representation ([Identifier] is a platform specific
+ * type). Serialized advertisements are only meant to be deserialized on the same platform (an
+ * [Identifier] is not portable across platforms).
+ */
+@Serializable
+@SerialName("com.juul.kable.Advertisement")
+internal class AdvertisementCapture(
+    val name: String?,
+    val peripheralName: String?,
+    val identifier: String,
+    val isConnectable: Boolean?,
+    val rssi: Int,
+    val txPower: Int?,
+    val uuids: List<Uuid>,
+    val serviceData: Map<Uuid, ByteArray>,
+    val manufacturerData: Map<Int, ByteArray>,
+    /** Raw bytes of the underlying scan record. Only available on Android. */
+    val bytes: ByteArray? = null,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AdvertisementCapture) return false
+        return name == other.name &&
+            peripheralName == other.peripheralName &&
+            identifier == other.identifier &&
+            isConnectable == other.isConnectable &&
+            rssi == other.rssi &&
+            txPower == other.txPower &&
+            uuids == other.uuids &&
+            serviceData.contentEquals(other.serviceData) &&
+            manufacturerData.contentEquals(other.manufacturerData) &&
+            bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + peripheralName.hashCode()
+        result = 31 * result + identifier.hashCode()
+        result = 31 * result + isConnectable.hashCode()
+        result = 31 * result + rssi
+        result = 31 * result + txPower.hashCode()
+        result = 31 * result + uuids.hashCode()
+        result = 31 * result + serviceData.contentHashCode()
+        result = 31 * result + manufacturerData.contentHashCode()
+        result = 31 * result + (bytes?.contentHashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "Advertisement(identifier=$identifier, name=$name, rssi=$rssi, txPower=$txPower)"
+}
+
+/** Captures the data of an [Advertisement] that is visible via the common [Advertisement] API. */
+internal fun Advertisement.captureCommon(): AdvertisementCapture = AdvertisementCapture(
+    name = name,
+    peripheralName = peripheralName,
+    identifier = identifier.toString(),
+    isConnectable = isConnectable,
+    rssi = rssi,
+    txPower = txPower,
+    uuids = uuids,
+    // Common `Advertisement` API does not provide enumeration of service data.
+    serviceData = emptyMap(),
+    manufacturerData = manufacturerData?.let { mapOf(it.code to it.data) }.orEmpty(),
+)
+
+/** Captures the data of this [PlatformAdvertisement] (including platform specific data). */
+internal expect fun PlatformAdvertisement.capture(): AdvertisementCapture
+
+/** Restores a previously [captured][capture] advertisement as a [PlatformAdvertisement]. */
+internal expect fun AdvertisementCapture.restore(): PlatformAdvertisement
+
+private fun <K> Map<K, ByteArray>.contentEquals(other: Map<K, ByteArray>): Boolean =
+    size == other.size && all { (key, value) -> other[key]?.contentEquals(value) == true }
+
+// Sum of entry hashes (order independent, in line with `Map.hashCode` contract).
+private fun Map<*, ByteArray>.contentHashCode(): Int =
+    entries.sumOf { (key, value) -> key.hashCode() xor value.contentHashCode() }

--- a/kable-core/src/commonMain/kotlin/AdvertisementSerializer.kt
+++ b/kable-core/src/commonMain/kotlin/AdvertisementSerializer.kt
@@ -1,0 +1,65 @@
+package com.juul.kable
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Serializes an [Advertisement] as a snapshot of its data (rather than the platform specific
+ * objects it wraps), making it usable (for example) as a navigation argument in Compose Navigation.
+ *
+ * Serialization captures the data of the [Advertisement] at the time of serialization.
+ * Deserialization produces a [PlatformAdvertisement] that holds the previously captured data
+ * (deserialized advertisements are not "live" — properties reflect the advertisement at the time
+ * it was serialized).
+ *
+ * Serialized advertisements are only guaranteed to deserialize on the same platform they were
+ * serialized on ([Advertisement.identifier] is a platform specific value that is not portable
+ * across platforms).
+ *
+ * This serializer is applied by default (via `@Serializable(with = ...)` on [Advertisement]), so
+ * [Advertisement] properties may be used in serializable classes without additional configuration.
+ */
+public object AdvertisementSerializer : KSerializer<Advertisement> {
+
+    override val descriptor: SerialDescriptor = AdvertisementCapture.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: Advertisement) {
+        val capture = (value as? PlatformAdvertisement)?.capture() ?: value.captureCommon()
+        encoder.encodeSerializableValue(AdvertisementCapture.serializer(), capture)
+    }
+
+    override fun deserialize(decoder: Decoder): Advertisement =
+        decoder.decodeSerializableValue(AdvertisementCapture.serializer()).restore()
+}
+
+/**
+ * Serializes a [PlatformAdvertisement] as a snapshot of its data (rather than the platform
+ * specific objects it wraps), making it usable (for example) as a navigation argument in Compose
+ * Navigation.
+ *
+ * Serialization captures the data of the [PlatformAdvertisement] at the time of serialization.
+ * Deserialization produces a [PlatformAdvertisement] that holds the previously captured data
+ * (deserialized advertisements are not "live" — properties reflect the advertisement at the time
+ * it was serialized).
+ *
+ * Serialized advertisements are only guaranteed to deserialize on the same platform they were
+ * serialized on ([Advertisement.identifier] is a platform specific value that is not portable
+ * across platforms).
+ *
+ * This serializer is applied by default (via `@Serializable(with = ...)` on
+ * [PlatformAdvertisement]), so [PlatformAdvertisement] properties may be used in serializable
+ * classes without additional configuration.
+ */
+public object PlatformAdvertisementSerializer : KSerializer<PlatformAdvertisement> {
+
+    override val descriptor: SerialDescriptor = AdvertisementCapture.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: PlatformAdvertisement) {
+        encoder.encodeSerializableValue(AdvertisementCapture.serializer(), value.capture())
+    }
+
+    override fun deserialize(decoder: Decoder): PlatformAdvertisement =
+        decoder.decodeSerializableValue(AdvertisementCapture.serializer()).restore()
+}

--- a/kable-core/src/commonMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/commonMain/kotlin/PlatformAdvertisement.kt
@@ -1,3 +1,11 @@
 package com.juul.kable
 
+import kotlinx.serialization.Serializable
+
+/**
+ * [PlatformAdvertisement] is serializable (e.g. usable as a Compose Navigation argument):
+ * serialization captures a snapshot of the advertisement data, and deserialization restores an
+ * advertisement holding the captured data. See [PlatformAdvertisementSerializer] for caveats.
+ */
+@Serializable(with = PlatformAdvertisementSerializer::class)
 public expect interface PlatformAdvertisement : Advertisement

--- a/kable-core/src/commonTest/kotlin/AdvertisementCaptureTests.kt
+++ b/kable-core/src/commonTest/kotlin/AdvertisementCaptureTests.kt
@@ -1,0 +1,39 @@
+package com.juul.kable
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.uuid.Uuid
+
+class AdvertisementCaptureTests {
+
+    private val serviceUuid = Uuid.parse("0000180a-0000-1000-8000-00805f9b34fb")
+
+    private fun capture(rssi: Int = -42) = AdvertisementCapture(
+        name = "Example",
+        peripheralName = "Example (cached)",
+        identifier = "00:11:22:AA:BB:CC",
+        isConnectable = true,
+        rssi = rssi,
+        txPower = 8,
+        uuids = listOf(serviceUuid),
+        serviceData = mapOf(serviceUuid to byteArrayOf(0x01, 0x02, 0x03)),
+        manufacturerData = mapOf(0x004C to byteArrayOf(0x02, 0x15)),
+        bytes = byteArrayOf(0x0F, 0x09),
+    )
+
+    @Test
+    fun jsonRoundTrip_isEqualToOriginal() {
+        val capture = capture()
+        val json = Json.encodeToString(AdvertisementCapture.serializer(), capture)
+        val decoded = Json.decodeFromString(AdvertisementCapture.serializer(), json)
+        assertEquals(capture, decoded)
+        assertEquals(capture.hashCode(), decoded.hashCode())
+    }
+
+    @Test
+    fun equals_capturesWithDifferentData_areNotEqual() {
+        assertNotEquals(capture(rssi = -42), capture(rssi = -43))
+    }
+}

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/AdvertisementCapture.jvm.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/AdvertisementCapture.jvm.kt
@@ -1,0 +1,21 @@
+package com.juul.kable
+
+import com.juul.kable.btleplug.BtleplugAdvertisement
+import kotlinx.io.bytestring.ByteString
+
+internal actual fun PlatformAdvertisement.capture(): AdvertisementCapture = when (this) {
+    is BtleplugAdvertisement -> capture()
+    else -> captureCommon()
+}
+
+internal actual fun AdvertisementCapture.restore(): PlatformAdvertisement = BtleplugAdvertisement(
+    manufacturerDataMap = manufacturerData.entries
+        .associate { (code, data) -> code.toUShort() to ByteString(data) },
+    serviceData = serviceData.mapValues { (_, data) -> ByteString(data) },
+    name = name,
+    peripheralName = peripheralName,
+    identifier = identifier.toIdentifier(),
+    rssi = rssi,
+    txPower = txPower,
+    uuids = uuids,
+)

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/PlatformAdvertisement.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/PlatformAdvertisement.kt
@@ -1,3 +1,6 @@
 package com.juul.kable
 
+import kotlinx.serialization.Serializable
+
+@Serializable(with = PlatformAdvertisementSerializer::class)
 public actual interface PlatformAdvertisement : Advertisement

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugAdvertisement.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/btleplug/BtleplugAdvertisement.kt
@@ -1,5 +1,6 @@
 package com.juul.kable.btleplug
 
+import com.juul.kable.AdvertisementCapture
 import com.juul.kable.Identifier
 import com.juul.kable.ManufacturerData
 import com.juul.kable.PlatformAdvertisement
@@ -45,4 +46,17 @@ internal data class BtleplugAdvertisement(
 
     override fun manufacturerData(companyIdentifierCode: Int): ByteArray? =
         manufacturerDataMap[companyIdentifierCode.toUShort()]?.toByteArray()
+
+    internal fun capture(): AdvertisementCapture = AdvertisementCapture(
+        name = name,
+        peripheralName = peripheralName,
+        identifier = identifier.toString(),
+        isConnectable = isConnectable,
+        rssi = rssi,
+        txPower = txPower,
+        uuids = uuids,
+        serviceData = serviceData.mapValues { (_, data) -> data.toByteArray() },
+        manufacturerData = manufacturerDataMap.entries
+            .associate { (code, data) -> code.toInt() to data.toByteArray() },
+    )
 }

--- a/kable-core/src/webMain/kotlin/AdvertisementCapture.web.kt
+++ b/kable-core/src/webMain/kotlin/AdvertisementCapture.web.kt
@@ -1,0 +1,10 @@
+package com.juul.kable
+
+internal actual fun PlatformAdvertisement.capture(): AdvertisementCapture = when (this) {
+    is BluetoothAdvertisingEventWebBluetoothAdvertisement -> capture()
+    is CapturedWebBluetoothAdvertisement -> capture
+    else -> captureCommon()
+}
+
+internal actual fun AdvertisementCapture.restore(): PlatformAdvertisement =
+    CapturedWebBluetoothAdvertisement(this)

--- a/kable-core/src/webMain/kotlin/BluetoothAdvertisingEventWebBluetoothAdvertisement.kt
+++ b/kable-core/src/webMain/kotlin/BluetoothAdvertisingEventWebBluetoothAdvertisement.kt
@@ -57,6 +57,20 @@ internal class BluetoothAdvertisingEventWebBluetoothAdvertisement(
             ManufacturerData(key.toInt(), value.buffer.toByteArray())
         }
 
+    internal fun capture(): AdvertisementCapture = AdvertisementCapture(
+        name = name,
+        peripheralName = peripheralName,
+        identifier = identifier,
+        isConnectable = isConnectable,
+        rssi = rssi,
+        txPower = txPower,
+        uuids = uuids,
+        serviceData = Iterable { advertisement.serviceData.entries().iterator() }
+            .associate { (uuid, data) -> uuid.toString().toUuid() to data.buffer.toByteArray() },
+        manufacturerData = Iterable { advertisement.manufacturerData.entries().iterator() }
+            .associate { (code, data) -> code.toInt() to data.buffer.toByteArray() },
+    )
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/kable-core/src/webMain/kotlin/CapturedWebBluetoothAdvertisement.kt
+++ b/kable-core/src/webMain/kotlin/CapturedWebBluetoothAdvertisement.kt
@@ -1,0 +1,65 @@
+package com.juul.kable
+
+import org.khronos.webgl.DataView
+import org.khronos.webgl.toInt8Array
+import kotlin.uuid.Uuid
+
+/**
+ * [PlatformAdvertisement] restored from previously captured advertisement data (i.e. produced by
+ * deserializing a serialized [PlatformAdvertisement]).
+ *
+ * All properties reflect the advertisement at the time it was captured.
+ *
+ * A [Peripheral] cannot be created from a restored advertisement (Web Bluetooth requires a
+ * `BluetoothDevice`, which cannot be synchronously retrieved); use the `Peripheral(Identifier)`
+ * builder function instead.
+ */
+internal class CapturedWebBluetoothAdvertisement(
+    internal val capture: AdvertisementCapture,
+) : PlatformAdvertisement {
+
+    override val identifier: Identifier
+        get() = capture.identifier
+
+    override val name: String?
+        get() = capture.name
+
+    override val peripheralName: String?
+        get() = capture.peripheralName
+
+    override val isConnectable: Boolean?
+        get() = capture.isConnectable
+
+    override val rssi: Int
+        get() = capture.rssi
+
+    override val txPower: Int?
+        get() = capture.txPower
+
+    override val uuids: List<Uuid>
+        get() = capture.uuids
+
+    override fun serviceData(uuid: Uuid): ByteArray? = capture.serviceData[uuid]
+
+    override fun serviceDataAsDataView(uuid: Uuid): DataView? =
+        capture.serviceData[uuid]?.toDataView()
+
+    override fun manufacturerData(companyIdentifierCode: Int): ByteArray? =
+        capture.manufacturerData[companyIdentifierCode]
+
+    override fun manufacturerDataAsDataView(companyIdentifierCode: Int): DataView? =
+        capture.manufacturerData[companyIdentifierCode]?.toDataView()
+
+    override val manufacturerData: ManufacturerData?
+        get() = capture.manufacturerData.entries.firstOrNull()
+            ?.let { (code, data) -> ManufacturerData(code, data) }
+
+    override fun equals(other: Any?): Boolean =
+        other is CapturedWebBluetoothAdvertisement && capture == other.capture
+
+    override fun hashCode(): Int = capture.hashCode()
+
+    override fun toString(): String = capture.toString()
+}
+
+private fun ByteArray.toDataView(): DataView = DataView(toInt8Array().buffer)

--- a/kable-core/src/webMain/kotlin/Peripheral.kt
+++ b/kable-core/src/webMain/kotlin/Peripheral.kt
@@ -14,7 +14,12 @@ public actual fun Peripheral(
     advertisement: Advertisement,
     builderAction: PeripheralBuilderAction,
 ): Peripheral {
-    advertisement as BluetoothAdvertisingEventWebBluetoothAdvertisement
+    require(advertisement is BluetoothAdvertisingEventWebBluetoothAdvertisement) {
+        "Unable to create Peripheral from ${advertisement::class.simpleName}. " +
+            "On JavaScript, a Peripheral can only be created from an Advertisement that was " +
+            "obtained from a Scanner (e.g. deserialized advertisements are not supported); " +
+            "use the `Peripheral(Identifier)` builder function instead."
+    }
     return Peripheral(advertisement.bluetoothDevice, builderAction)
 }
 

--- a/kable-core/src/webMain/kotlin/PlatformAdvertisement.kt
+++ b/kable-core/src/webMain/kotlin/PlatformAdvertisement.kt
@@ -1,8 +1,10 @@
 package com.juul.kable
 
+import kotlinx.serialization.Serializable
 import org.khronos.webgl.DataView
 import kotlin.uuid.Uuid
 
+@Serializable(with = PlatformAdvertisementSerializer::class)
 public actual interface PlatformAdvertisement : Advertisement {
     public fun serviceDataAsDataView(uuid: Uuid): DataView?
     public fun manufacturerDataAsDataView(companyIdentifierCode: Int): DataView?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #861

Adds [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) support to `Advertisement` and `PlatformAdvertisement`, so they can be used (for example) as navigation arguments with Compose Navigation (per the request in #861 / discussion #788):

```kotlin
@Serializable
data class PeripheralDetails(val advertisement: Advertisement)
```

## Design

The platform advertisement implementations wrap live platform objects (`ScanResult`, `CBPeripheral` + advertisement dictionary, `BluetoothAdvertisingEvent`), which cannot themselves be serialized. Instead:

- **Serialization** captures a snapshot of the advertisement data into an internal `AdvertisementCapture` (the wire representation): `name`, `peripheralName`, `identifier` (as `String`), `isConnectable`, `rssi`, `txPower`, `uuids`, full service data and manufacturer data maps, and (Android only) the raw scan record `bytes`.
- **Deserialization** restores a `PlatformAdvertisement` holding the captured data. Restored advertisements are *not* "live" — properties reflect the advertisement at the time it was serialized.
- `Advertisement` and `PlatformAdvertisement` are annotated with `@Serializable(with = ...)` (`AdvertisementSerializer` / `PlatformAdvertisementSerializer`), so no additional configuration (contextual serializers, etc.) is needed at usage sites.

Serialized advertisements are only guaranteed to deserialize on the same platform they were serialized on (`identifier` is a platform specific value that is not portable across platforms).

## Platform notes

| Platform | Restored implementation | Notes |
|---|---|---|
| Android | `CapturedAndroidAdvertisement` | Also `Parcelable` (via custom `Parceler`). `bondState`/`bluetoothDevice` are retrieved on-demand from the local adapter, so `Peripheral(advertisement)` works with restored advertisements. |
| Apple | `CapturedCoreBluetoothAdvertisement` | `cbPeripheral` is retrieved on-demand via `retrievePeripheralsWithIdentifiers` (throws `NoSuchElementException` if unknown to the system, mirroring `Peripheral(Identifier)`). |
| JS / WasmJS | `CapturedWebBluetoothAdvertisement` | Web Bluetooth provides no synchronous way to recover a `BluetoothDevice`, so `Peripheral(advertisement)` now fails with a descriptive `IllegalArgumentException` for restored advertisements (directing users to `Peripheral(Identifier)`). |
| JVM (btleplug) | `BtleplugAdvertisement` | Already a plain data holder; restored directly (identifier reconstructed via `String.toIdentifier()`). |

Other changes:

- `kable-core` now applies the `org.jetbrains.kotlin.plugin.serialization` plugin and exposes `kotlinx-serialization-core` as an `api` dependency.
- Extracted `BluetoothDevice.toBondState()` (previously inlined in `ScanResultAndroidAdvertisement`) for reuse by the restored implementation.
- `Peripheral(Advertisement)` on Apple now accepts any `PlatformAdvertisement` (previously hard-cast to `CBPeripheralCoreBluetoothAdvertisement`).
- README: new "Serialization" section under Scanning.
- API dumps updated (`Companion.serializer()` on the interfaces, plus the two public serializer objects).

## Testing

- `commonTest`: JSON round-trip of the capture (runs on JVM, Android host, JS, and WasmJS).
- `androidHostTest` (Robolectric): JSON round-trip of a `ScanResult`-backed advertisement via `PlatformAdvertisementSerializer` (verifies all data retained), stability of re-serialization, `AdvertisementSerializer`/`PlatformAdvertisementSerializer` equivalence, and `Parcel` round-trip of a restored advertisement.
- Verified locally (Linux): `compileKotlinJvm`, `compileKotlinJs`, `compileKotlinWasmJs`, `assembleAndroidMain`, `jvmTest`, `testAndroidHostTest`, `jsTest`/`wasmJsTest` (only pre-existing environment-dependent Web Bluetooth availability tests fail in headless CI-less Chrome), `lintKotlin`, `apiCheck`, and `apiDump`. Apple targets could not be compiled locally (macOS-only) and rely on CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b50534f-3665-4528-b75e-16e32122d99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b50534f-3665-4528-b75e-16e32122d99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

