### PR TITLE
Include disconnect status in `NotConnectedException`

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -283,8 +283,9 @@ public final class com/juul/kable/ManufacturerData {
 
 public class com/juul/kable/NotConnectedException : java/io/IOException {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lcom/juul/kable/State$Disconnected$Status;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lcom/juul/kable/State$Disconnected$Status;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getStatus ()Lcom/juul/kable/State$Disconnected$Status;
 }
 
 public final class com/juul/kable/ObservationExceptionPeripheral {

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -237,8 +237,9 @@ public final class com/juul/kable/ManufacturerData {
 
 public class com/juul/kable/NotConnectedException : java/io/IOException {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lcom/juul/kable/State$Disconnected$Status;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lcom/juul/kable/State$Disconnected$Status;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getStatus ()Lcom/juul/kable/State$Disconnected$Status;
 }
 
 public final class com/juul/kable/ObservationExceptionPeripheral {

--- a/kable-core/src/androidHostTest/kotlin/com/juul/kable/gatt/CallbackTests.kt
+++ b/kable-core/src/androidHostTest/kotlin/com/juul/kable/gatt/CallbackTests.kt
@@ -1,0 +1,74 @@
+package com.juul.kable.gatt
+
+import android.bluetooth.BluetoothGatt.GATT_SUCCESS
+import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
+import android.os.Build
+import com.juul.kable.NotConnectedException
+import com.juul.kable.ObservationEvent
+import com.juul.kable.State
+import com.juul.kable.external.GATT_CONN_TIMEOUT
+import com.juul.kable.logs.Logging
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class CallbackTests {
+
+    @Test
+    fun onConnectionStateChange_disconnectWithTimeoutStatus_closesResponsesWithStatusInNotConnectedException() = runTest {
+        val callback = callback()
+
+        callback.onConnectionStateChange(mockk(), GATT_CONN_TIMEOUT, STATE_DISCONNECTED)
+
+        val exception = assertFailsWith<NotConnectedException> {
+            callback.onResponse.receive()
+        }
+        assertEquals(State.Disconnected.Status.Timeout, exception.status)
+    }
+
+    @Test
+    fun onConnectionStateChange_disconnectWithUnknownStatus_closesResponsesWithStatusInNotConnectedException() = runTest {
+        val callback = callback()
+        val gattInsufficientAuthentication = 5
+
+        callback.onConnectionStateChange(mockk(), gattInsufficientAuthentication, STATE_DISCONNECTED)
+
+        val exception = assertFailsWith<NotConnectedException> {
+            callback.onResponse.receive()
+        }
+        assertEquals(
+            State.Disconnected.Status.Unknown(gattInsufficientAuthentication),
+            exception.status,
+        )
+    }
+
+    @Test
+    fun onConnectionStateChange_disconnectWithSuccessStatus_closesResponsesWithoutStatusInNotConnectedException() = runTest {
+        val callback = callback()
+
+        callback.onConnectionStateChange(mockk(), GATT_SUCCESS, STATE_DISCONNECTED)
+
+        val exception = assertFailsWith<NotConnectedException> {
+            callback.onResponse.receive()
+        }
+        assertNull(exception.status)
+    }
+
+    private fun callback() = Callback(
+        state = MutableStateFlow(State.Connecting.Services),
+        mtu = MutableStateFlow(null),
+        onCharacteristicChanged = MutableSharedFlow<ObservationEvent<ByteArray>>(),
+        logging = Logging(),
+        macAddress = "00:11:22:AA:BB:CC",
+    )
+}

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -91,9 +91,13 @@ internal class BluetoothDeviceAndroidPeripheral(
     private val observers = Observers<ByteArray>(this, logging, false, observationExceptionHandler)
 
     private val connection = MutableStateFlow<Connection?>(null)
-    private fun connectionOrThrow() =
-        connection.value
-            ?: throw NotConnectedException("Connection not established, current state: ${state.value}")
+    private fun connectionOrThrow() = connection.value ?: run {
+        val currentState = state.value
+        throw NotConnectedException(
+            "Connection not established, current state: $currentState",
+            status = (currentState as? Disconnected)?.status,
+        )
+    }
 
     override val type: Type
         get() = typeFrom(bluetoothDevice.type)

--- a/kable-core/src/androidMain/kotlin/Connection.kt
+++ b/kable-core/src/androidMain/kotlin/Connection.kt
@@ -94,7 +94,7 @@ internal class Connection(
                 message = "Disconnect detected"
                 detail("state", state)
             }
-            dispose(NotConnectedException("Disconnect detected"))
+            dispose(NotConnectedException("Disconnect detected", status = it.status))
         }
     }
 

--- a/kable-core/src/androidMain/kotlin/gatt/Callback.kt
+++ b/kable-core/src/androidMain/kotlin/gatt/Callback.kt
@@ -113,7 +113,7 @@ internal class Callback(
         }
 
         if (newState == STATE_DISCONNECTING || newState == STATE_DISCONNECTED) {
-            onResponse.close(NotConnectedException())
+            onResponse.close(NotConnectedException(status = status.disconnectedConnectionStatus))
         }
     }
 

--- a/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -109,9 +109,13 @@ internal class CBPeripheralCoreBluetoothPeripheral(
     private fun servicesOrThrow() = services.value ?: error("Services have not been discovered")
 
     private val connection = MutableStateFlow<Connection?>(null)
-    private fun connectionOrThrow() =
-        connection.value
-            ?: throw NotConnectedException("Connection not established, current state: ${state.value}")
+    private fun connectionOrThrow() = connection.value ?: run {
+        val currentState = state.value
+        throw NotConnectedException(
+            "Connection not established, current state: $currentState",
+            status = (currentState as? State.Disconnected)?.status,
+        )
+    }
 
     @ExperimentalKableApi
     override val name: String?

--- a/kable-core/src/appleMain/kotlin/Connection.kt
+++ b/kable-core/src/appleMain/kotlin/Connection.kt
@@ -78,7 +78,7 @@ internal class Connection(
                 message = "Disconnect detected"
                 detail("state", state)
             }
-            dispose(NotConnectedException("Disconnect detected"))
+            dispose(NotConnectedException("Disconnect detected", status = it.status))
         }
     }
 

--- a/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -321,7 +321,8 @@ internal class PeripheralDelegate(
     }
 
     fun close(cause: Throwable?) {
-        _response.close(NotConnectedException(cause = cause))
+        val status = (cause as? NotConnectedException)?.status
+        _response.close(NotConnectedException(cause = cause, status = status))
         characteristicChanges.emitBlocking(ObservationEvent.Disconnected)
         canSendWriteWithoutResponse.value = true
     }

--- a/kable-core/src/commonMain/kotlin/NotConnectedException.kt
+++ b/kable-core/src/commonMain/kotlin/NotConnectedException.kt
@@ -5,4 +5,11 @@ import kotlinx.io.IOException
 public open class NotConnectedException(
     message: String? = null,
     cause: Throwable? = null,
+
+    /**
+     * The status (cause) of the disconnect that triggered this exception, or `null` if
+     * unavailable (e.g. disconnect was requested, or underlying platform did not provide a
+     * status).
+     */
+    public val status: State.Disconnected.Status? = null,
 ) : IOException(message, cause)

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -332,6 +332,6 @@ internal suspend inline fun <reified T : State> Peripheral.suspendUntilOrThrow()
         "Peripheral.suspendUntilOrThrow() throws on State.Disconnected, not intended for use with that State."
     }
     state
-        .onEach { if (it is State.Disconnected) throw NotConnectedException() }
+        .onEach { if (it is State.Disconnected) throw NotConnectedException(status = it.status) }
         .first { it is T }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1154

## Summary

Adds a `status: State.Disconnected.Status?` property to `NotConnectedException`, so clients can examine the underlying cause of a connection failure (e.g. Android GATT status) directly from the exception, rather than having to separately monitor `State.Disconnected` (which can be racy, or masked by a downstream symptom such as a `GattStatusException` from a failed `requestMtu`, as described in #1154).

```kotlin
public open class NotConnectedException(
    message: String? = null,
    cause: Throwable? = null,
    public val status: State.Disconnected.Status? = null,
) : IOException(message, cause)
```

`status` is `null` when unavailable (e.g. disconnect was requested, or the underlying platform did not provide a status).

## Where `status` is populated

- **Android**
  - `Callback.onConnectionStateChange`: the GATT status (translated via the existing `disconnectedConnectionStatus` mapping) is included in the `NotConnectedException` used to close the response channel — this is the location referenced in #1154.
  - `Connection`: "Disconnect detected" disposal includes `State.Disconnected.status`.
  - `BluetoothDeviceAndroidPeripheral.connectionOrThrow`: includes the status of the current `Disconnected` state (if applicable).
- **Apple**
  - `Connection`: "Disconnect detected" disposal includes `State.Disconnected.status` (translated from `CBError` via the existing `NSError.toStatus()` mapping).
  - `PeripheralDelegate.close`: propagates the status from the causing `NotConnectedException` (if any) when closing the response channel.
  - `CBPeripheralCoreBluetoothPeripheral.connectionOrThrow`: includes the status of the current `Disconnected` state (if applicable).
- **Common**
  - `Peripheral.suspendUntilOrThrow`: includes `State.Disconnected.status` (e.g. connection dropped while establishing a connection).

JavaScript/Web is unchanged, as `State.Disconnected.status` is always `null` on that platform. JVM (btleplug) is unchanged, as no disconnect status is available from the underlying callback.

## API / binary compatibility

Since the new constructor parameter has a default value, this change is **source compatible** but **not binary compatible** (the two-arg `<init>(String, Throwable)` JVM constructor is replaced by a three-arg constructor). The `api/jvm` and `api/android` dumps have been updated accordingly.

> [!NOTE]
> `./gradlew :kable-core:apiDump` only regenerated the `api/jvm` dump on my machine (no BCV dump task appears to be registered for the `android` target under AGP 9.3 / BCV 0.18.1 — possibly related: `api/android/kable-core.api` was left untouched by #1197 and still lags the JVM dump), so the `api/android` dump portion of this change was updated manually to match.

## Testing

- Added `CallbackTests` (Robolectric, `androidHostTest`) verifying that `onConnectionStateChange` closes the response channel with a `NotConnectedException` carrying:
  - a translated status (`Timeout` for `GATT_CONN_TIMEOUT`),
  - an `Unknown(5)` status for statuses without a dedicated mapping (e.g. `GATT_INSUFFICIENT_AUTHENTICATION`, the scenario from #1154), and
  - `null` for `GATT_SUCCESS`.
- `./gradlew :kable-core:apiCheck :kable-core:lintKotlin :kable-core:jvmTest :kable-core:testAndroidHostTest` passes locally (Linux; Apple targets compile-verified by CI only, as they are excluded from non-macOS builds).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dbc46e2-ba73-4e0b-8c46-7438a7221e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dbc46e2-ba73-4e0b-8c46-7438a7221e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

