### PR TITLE
Disable automatic JVM toolchain download

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,9 +639,9 @@ android {
 
 # Development
 
-The Java version used to build this project is managed via [SDKMAN!], as declared in the
-[`.sdkmanrc`] file. With [SDKMAN!] installed, the appropriate JDK can be installed and
-activated from the repository root by running:
+The Java version used to build this project can optionally be managed via [SDKMAN!], as
+declared in the [`.sdkmanrc`] file. With [SDKMAN!] installed, the appropriate JDK can be
+installed and activated from the repository root by running:
 
 ```shell
 sdk env install
@@ -651,6 +651,10 @@ sdk env
 > [!TIP]
 > Have [SDKMAN!] automatically use the SDK defined in [`.sdkmanrc`] when changing directories by
 > running `sdk config` then setting `sdkman_auto_env=true`.
+
+> [!NOTE]
+> If not using [SDKMAN!], be sure the JDK version specified in [`.sdkmanrc`] is installed, as Gradle
+> toolchain automatic downloading is disabled for this project.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,26 @@ android {
 }
 ```
 
+# Development
+
+The Java version used to build this project is managed via [SDKMAN!], as declared in the
+[`.sdkmanrc`](.sdkmanrc) file. With SDKMAN! installed, the appropriate JDK can be installed and
+activated from the repository root by running:
+
+```shell
+sdk env install
+sdk env
+```
+
+Gradle is configured (via [`jvmToolchain`]) to compile against the JDK version declared in
+`.sdkmanrc`, but [automatic downloading of JDKs] by Gradle is disabled; the JDK is expected to be
+provisioned via SDKMAN! (or another locally installed JDK of the same version, which Gradle will
+auto-detect).
+
+> [!TIP]
+> Enabling the `sdkman_auto_env` setting in `~/.sdkman/etc/config` will switch to the correct Java
+> version automatically whenever you `cd` into the repository.
+
 # License
 
 ```
@@ -659,7 +679,10 @@ limitations under the License.
 [Bluetooth permissions]: https://developer.android.com/develop/connectivity/bluetooth/bt-permissions
 [Coroutine scope]: https://kotlinlang.org/docs/reference/coroutines/coroutine-context-and-dispatchers.html#coroutine-scope
 [Coroutines with multithread support for Kotlin/Native]: https://github.com/Kotlin/kotlinx.coroutines/issues/462
+[SDKMAN!]: https://sdkman.io/
 [SensorTag sample app]: samples/sensortag
+[`jvmToolchain`]: https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+[automatic downloading of JDKs]: https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
 [`Advertisement`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-advertisement/index.html
 [`Characteristic`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-characteristic/index.html
 [`Connected`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-state/-connected/index.html

--- a/README.md
+++ b/README.md
@@ -637,6 +637,21 @@ android {
 }
 ```
 
+# Development
+
+The Java version used to build this project is managed via [SDKMAN!], as declared in the
+[`.sdkmanrc`] file. With [SDKMAN!] installed, the appropriate JDK can be installed and
+activated from the repository root by running:
+
+```shell
+sdk env install
+sdk env
+```
+
+> [!TIP]
+> Have [SDKMAN!] automatically use the SDK defined in [`.sdkmanrc`] when changing directories by
+> running `sdk config` then setting `sdkman_auto_env=true`.
+
 # License
 
 ```
@@ -659,7 +674,9 @@ limitations under the License.
 [Bluetooth permissions]: https://developer.android.com/develop/connectivity/bluetooth/bt-permissions
 [Coroutine scope]: https://kotlinlang.org/docs/reference/coroutines/coroutine-context-and-dispatchers.html#coroutine-scope
 [Coroutines with multithread support for Kotlin/Native]: https://github.com/Kotlin/kotlinx.coroutines/issues/462
+[SDKMAN!]: https://sdkman.io/
 [SensorTag sample app]: samples/sensortag
+[`.sdkmanrc`]: .sdkmanrc
 [`Advertisement`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-advertisement/index.html
 [`Characteristic`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-characteristic/index.html
 [`Connected`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-state/-connected/index.html

--- a/README.md
+++ b/README.md
@@ -637,26 +637,6 @@ android {
 }
 ```
 
-# Development
-
-The Java version used to build this project is managed via [SDKMAN!], as declared in the
-[`.sdkmanrc`](.sdkmanrc) file. With SDKMAN! installed, the appropriate JDK can be installed and
-activated from the repository root by running:
-
-```shell
-sdk env install
-sdk env
-```
-
-Gradle is configured (via [`jvmToolchain`]) to compile against the JDK version declared in
-`.sdkmanrc`, but [automatic downloading of JDKs] by Gradle is disabled; the JDK is expected to be
-provisioned via SDKMAN! (or another locally installed JDK of the same version, which Gradle will
-auto-detect).
-
-> [!TIP]
-> Enabling the `sdkman_auto_env` setting in `~/.sdkman/etc/config` will switch to the correct Java
-> version automatically whenever you `cd` into the repository.
-
 # License
 
 ```
@@ -679,10 +659,7 @@ limitations under the License.
 [Bluetooth permissions]: https://developer.android.com/develop/connectivity/bluetooth/bt-permissions
 [Coroutine scope]: https://kotlinlang.org/docs/reference/coroutines/coroutine-context-and-dispatchers.html#coroutine-scope
 [Coroutines with multithread support for Kotlin/Native]: https://github.com/Kotlin/kotlinx.coroutines/issues/462
-[SDKMAN!]: https://sdkman.io/
 [SensorTag sample app]: samples/sensortag
-[`jvmToolchain`]: https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
-[automatic downloading of JDKs]: https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
 [`Advertisement`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-advertisement/index.html
 [`Characteristic`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-characteristic/index.html
 [`Connected`]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-state/-connected/index.html

--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ sdk env
 
 > [!NOTE]
 > If not using [SDKMAN!], be sure the JDK version specified in [`.sdkmanrc`] is installed, as Gradle
-> toolchain automatic downloading is disabled for this project.
+> [toolchain automatic downloading is disabled] for this project.
 
 # License
 
@@ -728,3 +728,4 @@ limitations under the License.
 [badge-watchos]: http://img.shields.io/badge/platform-watchos-C0C0C0.svg?style=flat
 [badge-windows]: http://img.shields.io/badge/platform-windows-4D76CD.svg?style=flat
 [connection-state]: https://juullabs.github.io/kable/kable-core/com.juul.kable/-state/index.html
+[toolchain automatic downloading is disabled]: https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ android {
 }
 ```
 
-# Development
+## Development
 
 The Java version used to build this project can optionally be managed via [SDKMAN!], as
 declared in the [`.sdkmanrc`] file. With [SDKMAN!] installed, the appropriate JDK can be

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,10 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# Java is managed via SDKMAN! (see `.sdkmanrc`); Gradle should never provision JDKs itself.
+# Locally installed JDKs (e.g. from SDKMAN!) are still auto-detected for toolchain resolution.
+# https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
+org.gradle.java.installations.auto-download=false
+
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 kotlin.js.webpack.major.version=5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,4 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
-# Java is managed via SDKMAN! (see `.sdkmanrc`); Gradle should never provision JDKs itself.
-# Locally installed JDKs (e.g. from SDKMAN!) are still auto-detected for toolchain resolution.
-# https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
 org.gradle.java.installations.auto-download=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.java.installations.auto-download=false
-
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 kotlin.js.webpack.major.version=5

--- a/kable-default-permissions/build.gradle.kts
+++ b/kable-default-permissions/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.maven.publish)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+}
+
 android {
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig {

--- a/samples/sensortag/android/build.gradle.kts
+++ b/samples/sensortag/android/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+}
+
 android {
     namespace = "com.juul.sensortag.android"
     compileSdk = libs.versions.android.compile.get().toInt()

--- a/samples/sensortag/gradle.properties
+++ b/samples/sensortag/gradle.properties
@@ -1,2 +1,8 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# Java is managed via SDKMAN! (see `.sdkmanrc` in the repository root); Gradle should never
+# provision JDKs itself. Locally installed JDKs (e.g. from SDKMAN!) are still auto-detected for
+# toolchain resolution.
+# https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
+org.gradle.java.installations.auto-download=false

--- a/samples/sensortag/gradle.properties
+++ b/samples/sensortag/gradle.properties
@@ -1,8 +1,3 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
-# Java is managed via SDKMAN! (see `.sdkmanrc` in the repository root); Gradle should never
-# provision JDKs itself. Locally installed JDKs (e.g. from SDKMAN!) are still auto-detected for
-# toolchain resolution.
-# https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
 org.gradle.java.installations.auto-download=false

--- a/samples/sensortag/settings.gradle.kts
+++ b/samples/sensortag/settings.gradle.kts
@@ -7,12 +7,6 @@ pluginManagement {
     }
 }
 
-plugins {
-    // Provides repositories for auto-downloading JVM toolchains.
-    // https://github.com/gradle/foojay-toolchains
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
-
 includeBuild("../..")
 
 include(


### PR DESCRIPTION
As mentioned in [Gradle toolchains are rarely a good idea](https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/) article, one of the downsides to toolchains is the [wasted disk space](https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/#wasted-disk-space):

> All those JDKs needlessly take up space in your home directory. Each JDK is a few hundred MiB. By default, Gradle will try to match an existing JDK when a toolchain is requested. Project owners can specify additional attributes such as the JDK vendor which might cause existing JDKs to not match. This means even though one project forced you to install Eclipse Temurin JDK 8, another might force Azul Zulu JDK 8. So not only do you now have a bunch of old JDKs, you have two or three copies of each. My JDK cache in `~/.gradle` is nearly 2 GiB.

This PR disables the automatic download. Gradle will then fail-fast if the expected JVM toolchain version is not found (as configured by SDKMAN!).

Updated readme can be viewed [here](https://github.com/JuulLabs/kable/blob/cursor/manage-java-via-sdkman-590c/README.md#development).