### PR TITLE
Add L2CAP channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,27 +548,21 @@ On Apple platforms:
 val socket = (peripheral as CoreBluetoothPeripheral).openL2CapChannel(psm = 0x0080)
 ```
 
-The returned `L2CapSocket` is already open. Read chunks of incoming bytes, and write whole packets:
+The returned `L2CapSocket` is already open. Incoming bytes arrive as a `Flow` of chunks that completes at
+end of stream, and packets are written whole:
 
 ```kotlin
-val chunk = socket.read() // suspends until data arrives; returns null at end-of-stream
+socket.incoming.collect { chunk ->
+    // Process chunk.
+}
 
 socket.write(byteArrayOf(1, 2, 3))
 
 socket.close()
 ```
 
-Incoming data is also available as a cold `Flow`, which completes at end-of-stream:
-
-```kotlin
-socket.incoming().collect { chunk ->
-    // Process chunk.
-}
-```
-
 > [!NOTE]
-> _Opening a channel throws `L2CapException` on failure. `read` should be called from a single coroutine
-> at a time; `write` may run concurrently with it._
+> _A failure while opening, reading or writing throws `L2CapException`._
 
 ### Observation
 

--- a/README.md
+++ b/README.md
@@ -548,15 +548,22 @@ On Apple platforms:
 val socket = (peripheral as CoreBluetoothPeripheral).openL2CapChannel(psm = 0x0080)
 ```
 
-The returned `L2CapSocket` is already open. Read into a caller-provided buffer, and write whole packets:
+The returned `L2CapSocket` is already open. Read chunks of incoming bytes, and write whole packets:
 
 ```kotlin
-val buffer = ByteArray(1024)
-val count = socket.read(buffer) // suspends until data arrives; returns -1 at end-of-stream
+val chunk = socket.read() // suspends until data arrives; returns null at end-of-stream
 
 socket.write(byteArrayOf(1, 2, 3))
 
 socket.close()
+```
+
+Incoming data is also available as a cold `Flow`, which completes at end-of-stream:
+
+```kotlin
+socket.incoming().collect { chunk ->
+    // Process chunk.
+}
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -527,6 +527,42 @@ When a write type is not specified, [`WithoutResponse`] is used.
 > [!NOTE]
 > _Write type only applies to characteristic writes (descriptor writes are always acknowledged by the peripheral)._
 
+### L2CAP
+
+In addition to GATT, a connected peripheral can open an L2CAP connection-oriented channel (CoC) on a PSM
+(protocol/service multiplexer). Unlike GATT's message-based characteristics, a channel is a bidirectional
+byte stream, so callers are responsible for framing their own protocol. L2CAP is available on Android and
+Apple platforms (it has no Web Bluetooth equivalent), so a channel is opened from the platform-specific
+peripheral.
+
+On Android (requires API level 29 or higher):
+
+```kotlin
+val socket = (peripheral as AndroidPeripheral).openL2CapChannel(psm = 0x0080)
+// or `openInsecureL2CapChannel(...)` for a channel without authentication/encryption
+```
+
+On Apple platforms:
+
+```kotlin
+val socket = (peripheral as CoreBluetoothPeripheral).openL2CapChannel(psm = 0x0080)
+```
+
+The returned `L2CapSocket` is already open. Read into a caller-provided buffer, and write whole packets:
+
+```kotlin
+val buffer = ByteArray(1024)
+val count = socket.read(buffer) // suspends until data arrives; returns -1 at end-of-stream
+
+socket.write(byteArrayOf(1, 2, 3))
+
+socket.close()
+```
+
+> [!NOTE]
+> _Opening a channel throws `L2CapException` on failure. `read` should be called from a single coroutine
+> at a time; `write` may run concurrently with it._
+
 ### Observation
 
 Bluetooth Low Energy provides the capability of subscribing to characteristic changes by means of notifications and/or

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -202,6 +202,20 @@ public final class com/juul/kable/InternalError : java/lang/Error {
 public abstract interface annotation class com/juul/kable/InternalKableApi : java/lang/annotation/Annotation {
 }
 
+public final class com/juul/kable/L2CapException : java/io/IOException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCode ()J
+}
+
+public abstract interface class com/juul/kable/L2CapSocket {
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getHasReachedEof ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isConnected ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun read ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun write ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/juul/kable/LazyCharacteristic : com/juul/kable/Characteristic {
 	public final fun component1 ()Lkotlin/uuid/Uuid;
 	public final fun component2 ()Lkotlin/uuid/Uuid;

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -203,20 +203,17 @@ public abstract interface annotation class com/juul/kable/InternalKableApi : jav
 }
 
 public final class com/juul/kable/L2CapException : java/io/IOException {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;J)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCode ()J
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCode ()Ljava/lang/Long;
 }
 
 public abstract interface class com/juul/kable/L2CapSocket {
 	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getIncoming ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun isConnected ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun write ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/juul/kable/L2CapSocketKt {
-	public static final fun incoming (Lcom/juul/kable/L2CapSocket;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/juul/kable/LazyCharacteristic : com/juul/kable/Characteristic {

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -210,10 +210,13 @@ public final class com/juul/kable/L2CapException : java/io/IOException {
 
 public abstract interface class com/juul/kable/L2CapSocket {
 	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getHasReachedEof ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun isConnected ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun read ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun write ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/juul/kable/L2CapSocketKt {
+	public static final fun incoming (Lcom/juul/kable/L2CapSocket;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/juul/kable/LazyCharacteristic : com/juul/kable/Characteristic {

--- a/kable-core/src/androidHostTest/kotlin/com/juul/kable/AndroidL2CapSocketTests.kt
+++ b/kable-core/src/androidHostTest/kotlin/com/juul/kable/AndroidL2CapSocketTests.kt
@@ -6,10 +6,11 @@ import android.os.Build
 import com.juul.kable.logs.Logging
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -25,14 +26,8 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-// Scriptable stand-in for BluetoothSocket's InputStream: read(bytes) blocks until the test feeds
-// data, end-of-stream, or a failure — mirroring the non-interruptible blocking read of the real
-// socket. [readEntered] lets a test wait until a read is genuinely in flight, and [readsStarted]
-// counts reads handed to the "OS" so tests can pin how far the socket drained.
 private class ScriptedInputStream : InputStream() {
 
     private sealed interface Outcome {
@@ -62,7 +57,6 @@ private class ScriptedInputStream : InputStream() {
     }
 
     override fun close() {
-        // The real stream makes a blocked read throw once the socket closes underneath it.
         outcomes.put(Outcome.Failure(IOException("Socket closed")))
     }
 
@@ -81,7 +75,7 @@ class AndroidL2CapSocketTests {
 
     private val input = ScriptedInputStream()
 
-    private fun socket(): AndroidL2CapSocket {
+    private fun TestScope.socket(): AndroidL2CapSocket {
         val bluetoothSocket = mockk<BluetoothSocket> {
             every { remoteDevice } returns mockk<BluetoothDevice> {
                 every { address } returns "00:11:22:AA:BB:CC"
@@ -92,83 +86,71 @@ class AndroidL2CapSocketTests {
             every { outputStream } returns mockk<OutputStream>()
             every { close() } answers { input.close() }
         }
-        return AndroidL2CapSocket(bluetoothSocket, Logging())
+        return AndroidL2CapSocket(bluetoothSocket, backgroundScope, Logging())
     }
 
-    // The contract under test: cancelling read() never loses data. The blocking read a cancelled
-    // read() leaves in flight is awaited by the next read() — not abandoned, and not doubled up
-    // with a second OS read.
     @Test
-    fun cancelledRead_dataIsReturnedByNextRead() = runBlocking {
+    fun incoming_deliversChunksThenCompletesAtEndOfStream() = runTest(timeout = 5.seconds) {
         val socket = socket()
-        // UNDISPATCHED so the reader reaches its suspension point before this thread — the only
-        // one in runBlocking — blocks in awaitReadInFlight.
-        val reader = launch(start = UNDISPATCHED) { socket.read() }
-        input.awaitReadInFlight()
-        reader.cancel()
-        reader.join()
+        input.feed(byteArrayOf(1, 2))
+        input.feed(byteArrayOf(3))
+        input.endOfStream()
 
-        val sent = byteArrayOf(4, 5, 6)
-        input.feed(sent)
-        assertContentEquals(sent, withTimeout(5.seconds) { socket.read() })
-        assertEquals(1, input.readsStarted.get(), "Expected the pending read to be reused")
+        val chunks = socket.incoming.toList()
+        assertEquals(2, chunks.size)
+        assertContentEquals(byteArrayOf(1, 2, 3), chunks.reduce(ByteArray::plus))
+        assertFalse(socket.isConnected.value)
         socket.close()
     }
 
-    // A slow consumer must throttle the peer via L2CAP flow control: the socket reads from the OS
-    // only on demand, never draining ahead of read() calls.
     @Test
-    fun read_doesNotDrainAheadOfConsumer() = runBlocking {
+    fun incoming_collectedAgain_continuesWhereItLeftOff() = runTest(timeout = 5.seconds) {
         val socket = socket()
         input.feed(byteArrayOf(1))
         input.feed(byteArrayOf(2))
 
-        assertContentEquals(byteArrayOf(1), withTimeout(5.seconds) { socket.read() })
-        assertEquals(1, input.readsStarted.get(), "Read ahead of the consumer")
-
-        assertContentEquals(byteArrayOf(2), withTimeout(5.seconds) { socket.read() })
-        assertEquals(2, input.readsStarted.get())
+        assertContentEquals(byteArrayOf(1), socket.incoming.first())
+        assertContentEquals(byteArrayOf(2), socket.incoming.first())
         socket.close()
     }
 
     @Test
-    fun read_afterEndOfStream_returnsNullAndStaysNull() = runBlocking {
+    fun socket_doesNotReadAheadOfCollector() = runTest(timeout = 5.seconds) {
         val socket = socket()
-        input.feed(byteArrayOf(7))
-        input.endOfStream()
+        input.feed(byteArrayOf(1))
+        input.feed(byteArrayOf(2))
+        input.awaitReadInFlight()
 
-        assertContentEquals(byteArrayOf(7), withTimeout(5.seconds) { socket.read() })
-        assertNull(withTimeout(5.seconds) { socket.read() })
-        assertFalse(socket.isConnected.value)
-        // End-of-stream is terminal: no further OS reads on a dead socket.
-        assertNull(withTimeout(5.seconds) { socket.read() })
-        assertEquals(2, input.readsStarted.get())
+        assertEquals(1, input.readsStarted.get())
+        assertContentEquals(byteArrayOf(1), socket.incoming.first())
         socket.close()
     }
 
     @Test
-    fun readFailure_throwsAndSubsequentReadsObserveSameFailure() = runBlocking {
+    fun incoming_failure_throwsL2CapException() = runTest(timeout = 5.seconds) {
         val socket = socket()
         input.failWith(IOException("peer vanished"))
 
-        assertFailsWith<L2CapException> { withTimeout(5.seconds) { socket.read() } }
+        assertFailsWith<L2CapException> { socket.incoming.toList() }
         assertFalse(socket.isConnected.value)
-        // Failure is terminal: rethrown without starting another read on a dead socket.
-        assertFailsWith<L2CapException> { withTimeout(5.seconds) { socket.read() } }
-        assertEquals(1, input.readsStarted.get())
         socket.close()
     }
 
     @Test
-    fun close_whileReadBlocked_completesReadWithNull() = runBlocking {
+    fun close_whileReadBlocked_completesIncoming() = runTest(timeout = 5.seconds) {
         val socket = socket()
-        val reader = launch(start = UNDISPATCHED) {
-            assertNull(socket.read())
-        }
+        val collector = launch { socket.incoming.toList() }
         input.awaitReadInFlight()
-        withTimeout(5.seconds) { socket.close() }
-        withTimeout(5.seconds) { reader.join() }
-        assertTrue(reader.isCompleted)
+
+        socket.close()
+        collector.join()
         assertFalse(socket.isConnected.value)
+    }
+
+    @Test
+    fun write_emptyPacket_throwsIllegalArgumentException() = runTest(timeout = 5.seconds) {
+        val socket = socket()
+        assertFailsWith<IllegalArgumentException> { socket.write(byteArrayOf()) }
+        socket.close()
     }
 }

--- a/kable-core/src/androidHostTest/kotlin/com/juul/kable/AndroidL2CapSocketTests.kt
+++ b/kable-core/src/androidHostTest/kotlin/com/juul/kable/AndroidL2CapSocketTests.kt
@@ -1,0 +1,174 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothSocket
+import android.os.Build
+import com.juul.kable.logs.Logging
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+// Scriptable stand-in for BluetoothSocket's InputStream: read(bytes) blocks until the test feeds
+// data, end-of-stream, or a failure — mirroring the non-interruptible blocking read of the real
+// socket. [readEntered] lets a test wait until a read is genuinely in flight, and [readsStarted]
+// counts reads handed to the "OS" so tests can pin how far the socket drained.
+private class ScriptedInputStream : InputStream() {
+
+    private sealed interface Outcome {
+        data class Data(val bytes: ByteArray) : Outcome
+        object Eof : Outcome
+        data class Failure(val exception: IOException) : Outcome
+    }
+
+    private val outcomes = LinkedBlockingQueue<Outcome>()
+    private val readEntered = Semaphore(0)
+    val readsStarted = AtomicInteger()
+
+    override fun read(): Int = error("Single-byte read not expected")
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+        readsStarted.incrementAndGet()
+        readEntered.release()
+        return when (val outcome = outcomes.take()) {
+            is Outcome.Data -> {
+                check(outcome.bytes.size <= length) { "Fed chunk larger than read buffer" }
+                outcome.bytes.copyInto(bytes, offset)
+                outcome.bytes.size
+            }
+            Outcome.Eof -> -1
+            is Outcome.Failure -> throw outcome.exception
+        }
+    }
+
+    override fun close() {
+        // The real stream makes a blocked read throw once the socket closes underneath it.
+        outcomes.put(Outcome.Failure(IOException("Socket closed")))
+    }
+
+    fun feed(bytes: ByteArray) = outcomes.put(Outcome.Data(bytes))
+    fun endOfStream() = outcomes.put(Outcome.Eof)
+    fun failWith(exception: IOException) = outcomes.put(Outcome.Failure(exception))
+
+    fun awaitReadInFlight() {
+        check(readEntered.tryAcquire(5, SECONDS)) { "Timed out waiting for a read to start" }
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class AndroidL2CapSocketTests {
+
+    private val input = ScriptedInputStream()
+
+    private fun socket(): AndroidL2CapSocket {
+        val bluetoothSocket = mockk<BluetoothSocket> {
+            every { remoteDevice } returns mockk<BluetoothDevice> {
+                every { address } returns "00:11:22:AA:BB:CC"
+            }
+            every { maxTransmitPacketSize } returns 512
+            every { maxReceivePacketSize } returns 512
+            every { inputStream } returns input
+            every { outputStream } returns mockk<OutputStream>()
+            every { close() } answers { input.close() }
+        }
+        return AndroidL2CapSocket(bluetoothSocket, Logging())
+    }
+
+    // The contract under test: cancelling read() never loses data. The blocking read a cancelled
+    // read() leaves in flight is awaited by the next read() — not abandoned, and not doubled up
+    // with a second OS read.
+    @Test
+    fun cancelledRead_dataIsReturnedByNextRead() = runBlocking {
+        val socket = socket()
+        // UNDISPATCHED so the reader reaches its suspension point before this thread — the only
+        // one in runBlocking — blocks in awaitReadInFlight.
+        val reader = launch(start = UNDISPATCHED) { socket.read() }
+        input.awaitReadInFlight()
+        reader.cancel()
+        reader.join()
+
+        val sent = byteArrayOf(4, 5, 6)
+        input.feed(sent)
+        assertContentEquals(sent, withTimeout(5.seconds) { socket.read() })
+        assertEquals(1, input.readsStarted.get(), "Expected the pending read to be reused")
+        socket.close()
+    }
+
+    // A slow consumer must throttle the peer via L2CAP flow control: the socket reads from the OS
+    // only on demand, never draining ahead of read() calls.
+    @Test
+    fun read_doesNotDrainAheadOfConsumer() = runBlocking {
+        val socket = socket()
+        input.feed(byteArrayOf(1))
+        input.feed(byteArrayOf(2))
+
+        assertContentEquals(byteArrayOf(1), withTimeout(5.seconds) { socket.read() })
+        assertEquals(1, input.readsStarted.get(), "Read ahead of the consumer")
+
+        assertContentEquals(byteArrayOf(2), withTimeout(5.seconds) { socket.read() })
+        assertEquals(2, input.readsStarted.get())
+        socket.close()
+    }
+
+    @Test
+    fun read_afterEndOfStream_returnsNullAndStaysNull() = runBlocking {
+        val socket = socket()
+        input.feed(byteArrayOf(7))
+        input.endOfStream()
+
+        assertContentEquals(byteArrayOf(7), withTimeout(5.seconds) { socket.read() })
+        assertNull(withTimeout(5.seconds) { socket.read() })
+        assertFalse(socket.isConnected.value)
+        // End-of-stream is terminal: no further OS reads on a dead socket.
+        assertNull(withTimeout(5.seconds) { socket.read() })
+        assertEquals(2, input.readsStarted.get())
+        socket.close()
+    }
+
+    @Test
+    fun readFailure_throwsAndSubsequentReadsObserveSameFailure() = runBlocking {
+        val socket = socket()
+        input.failWith(IOException("peer vanished"))
+
+        assertFailsWith<L2CapException> { withTimeout(5.seconds) { socket.read() } }
+        assertFalse(socket.isConnected.value)
+        // Failure is terminal: rethrown without starting another read on a dead socket.
+        assertFailsWith<L2CapException> { withTimeout(5.seconds) { socket.read() } }
+        assertEquals(1, input.readsStarted.get())
+        socket.close()
+    }
+
+    @Test
+    fun close_whileReadBlocked_completesReadWithNull() = runBlocking {
+        val socket = socket()
+        val reader = launch(start = UNDISPATCHED) {
+            assertNull(socket.read())
+        }
+        input.awaitReadInFlight()
+        withTimeout(5.seconds) { socket.close() }
+        withTimeout(5.seconds) { reader.join() }
+        assertTrue(reader.isCompleted)
+        assertFalse(socket.isConnected.value)
+    }
+}

--- a/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
@@ -1,0 +1,83 @@
+package com.juul.kable
+
+import android.bluetooth.BluetoothSocket
+import android.bluetooth.BluetoothSocketException
+import android.os.Build
+import com.juul.kable.logs.Logger
+import com.juul.kable.logs.Logging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
+
+internal class AndroidL2CapSocket(
+    private val socket: BluetoothSocket,
+    logging: Logging,
+) : L2CapSocket {
+
+    private val logger = Logger(logging, "Kable/L2CapSocket", socket.remoteDevice.address)
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            logger.info {
+                message = "L2CAP MTU tx=${socket.maxTransmitPacketSize}, rx=${socket.maxReceivePacketSize}"
+            }
+        }
+    }
+
+    private val inputStream = socket.inputStream
+    private val outputStream = socket.outputStream
+
+    private val _isConnected = MutableStateFlow(true)
+    override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _hasReachedEof = MutableStateFlow(false)
+    override val hasReachedEof: StateFlow<Boolean> = _hasReachedEof.asStateFlow()
+
+    override suspend fun read(buffer: ByteArray): Int {
+        try {
+            val count = withContext(Dispatchers.IO) {
+                inputStream.read(buffer)
+            }
+            if (count < 0) {
+                _hasReachedEof.value = true
+                _isConnected.value = false
+            }
+            return count
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            _isConnected.value = false
+            logger.error(e) { message = "Failed to read bytes" }
+            throw e.toL2CapException()
+        }
+    }
+
+    override suspend fun write(packet: ByteArray) {
+        try {
+            withContext(Dispatchers.IO) {
+                outputStream.write(packet)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            _isConnected.value = false
+            logger.error(e) { message = "Failed to write packet" }
+            throw e.toL2CapException()
+        }
+    }
+
+    override suspend fun close() {
+        _isConnected.value = false
+        socket.close()
+    }
+}
+
+internal fun Exception.toL2CapException(): L2CapException =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && this is BluetoothSocketException) {
+        L2CapException(message, this, errorCode.toLong())
+    } else {
+        L2CapException(message, this, 0)
+    }

--- a/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
@@ -6,25 +6,24 @@ import android.os.Build
 import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.job
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.cancellation.CancellationException
+import java.io.IOException
 
 private const val READ_CHUNK_SIZE = 8192
 
 internal class AndroidL2CapSocket(
     private val socket: BluetoothSocket,
+    scope: CoroutineScope,
     logging: Logging,
 ) : L2CapSocket {
 
@@ -38,90 +37,59 @@ internal class AndroidL2CapSocket(
         }
     }
 
-    private val inputStream = socket.inputStream
-    private val outputStream = socket.outputStream
-
     private val _isConnected = MutableStateFlow(true)
     override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
-    // Lets the read path report the exception from a deliberate socket.close() as end-of-stream.
     @Volatile
-    private var closeRequested = false
+    private var closed = false
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // Unbuffered, so the socket is only read as fast as `incoming` is collected.
+    private val chunks = Channel<ByteArray>()
+    override val incoming: Flow<ByteArray> = chunks.receiveAsFlow()
 
-    // The in-flight blocking read. It survives a cancelled read() — data the OS may already have handed
-    // over must not be lost — so the next read() awaits it instead of starting another. Only touched by
-    // read(), which the interface limits to a single coroutine at a time.
-    private var pending: Deferred<ByteArray?>? = null
-
-    override suspend fun read(): ByteArray? {
-        val chunk = pending ?: scope.async { readChunk() }.also { pending = it }
+    private val reader = scope.launch(Dispatchers.IO) {
+        val buffer = ByteArray(READ_CHUNK_SIZE)
         try {
-            val result = chunk.await()
-            // End-of-stream and failure are terminal: they stay in pending so every later read()
-            // observes the same outcome instead of starting another read on a dead socket.
-            if (result != null) pending = null
-            return result
-        } catch (e: CancellationException) {
-            // Rethrows when read() itself was cancelled (pending is kept for the next read());
-            // otherwise close() cancelled the scope, which is end-of-stream.
-            currentCoroutineContext().ensureActive()
-            return null
-        }
-    }
-
-    // Blocking read into a socket-owned array, so a cancelled read() never leaves the OS writing into a
-    // caller's buffer. Terminal state is recorded here so it is observed even when no read() is awaiting.
-    private fun readChunk(): ByteArray? {
-        val scratch = ByteArray(READ_CHUNK_SIZE)
-        val count = try {
-            inputStream.read(scratch)
-        } catch (e: Exception) {
+            while (true) {
+                val count = socket.inputStream.read(buffer)
+                if (count < 0) break
+                chunks.send(buffer.copyOf(count))
+            }
+        } catch (e: IOException) {
+            if (!closed) chunks.close(e.wrapInL2CapException())
+        } finally {
             _isConnected.value = false
-            if (closeRequested) return null
-            logger.error(e) { message = "Failed to read bytes" }
-            throw e.toL2CapException()
+            chunks.close()
         }
-        if (count < 0 || closeRequested) {
-            _isConnected.value = false
-            return null
-        }
-        return if (count == scratch.size) scratch else scratch.copyOf(count)
     }
 
     override suspend fun write(packet: ByteArray) {
-        if (packet.isEmpty()) return
+        require(packet.isNotEmpty()) { "Packet must not be empty" }
         try {
             withContext(Dispatchers.IO) {
-                outputStream.write(packet)
+                socket.outputStream.write(packet)
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
+        } catch (e: IOException) {
             _isConnected.value = false
-            logger.error(e) { message = "Failed to write packet" }
-            throw e.toL2CapException()
+            throw e.wrapInL2CapException()
         }
     }
 
     override suspend fun close() {
-        closeRequested = true
+        closed = true
         _isConnected.value = false
-        scope.cancel() // Completes any awaiting read() with null, even if socket.close() below throws.
         withContext(NonCancellable + Dispatchers.IO) {
-            try {
-                socket.close() // Unblocks an in-flight readChunk.
-            } finally {
-                scope.coroutineContext.job.join()
-            }
+            socket.close()
+            reader.cancelAndJoin()
         }
     }
 }
 
-internal fun Exception.toL2CapException(): L2CapException =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && this is BluetoothSocketException) {
-        L2CapException(message, this, errorCode.toLong())
+internal fun IOException.wrapInL2CapException(): L2CapException {
+    val code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && this is BluetoothSocketException) {
+        errorCode.toLong()
     } else {
-        L2CapException(message, this, 0)
+        null
     }
+    return L2CapException(message, this, code)
+}

--- a/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidL2CapSocket.kt
@@ -5,12 +5,23 @@ import android.bluetooth.BluetoothSocketException
 import android.os.Build
 import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
+
+private const val READ_CHUNK_SIZE = 8192
 
 internal class AndroidL2CapSocket(
     private val socket: BluetoothSocket,
@@ -33,29 +44,54 @@ internal class AndroidL2CapSocket(
     private val _isConnected = MutableStateFlow(true)
     override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
-    private val _hasReachedEof = MutableStateFlow(false)
-    override val hasReachedEof: StateFlow<Boolean> = _hasReachedEof.asStateFlow()
+    // Lets the read path report the exception from a deliberate socket.close() as end-of-stream.
+    @Volatile
+    private var closeRequested = false
 
-    override suspend fun read(buffer: ByteArray): Int {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // The in-flight blocking read. It survives a cancelled read() — data the OS may already have handed
+    // over must not be lost — so the next read() awaits it instead of starting another. Only touched by
+    // read(), which the interface limits to a single coroutine at a time.
+    private var pending: Deferred<ByteArray?>? = null
+
+    override suspend fun read(): ByteArray? {
+        val chunk = pending ?: scope.async { readChunk() }.also { pending = it }
         try {
-            val count = withContext(Dispatchers.IO) {
-                inputStream.read(buffer)
-            }
-            if (count < 0) {
-                _hasReachedEof.value = true
-                _isConnected.value = false
-            }
-            return count
+            val result = chunk.await()
+            // End-of-stream and failure are terminal: they stay in pending so every later read()
+            // observes the same outcome instead of starting another read on a dead socket.
+            if (result != null) pending = null
+            return result
         } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            _isConnected.value = false
-            logger.error(e) { message = "Failed to read bytes" }
-            throw e.toL2CapException()
+            // Rethrows when read() itself was cancelled (pending is kept for the next read());
+            // otherwise close() cancelled the scope, which is end-of-stream.
+            currentCoroutineContext().ensureActive()
+            return null
         }
     }
 
+    // Blocking read into a socket-owned array, so a cancelled read() never leaves the OS writing into a
+    // caller's buffer. Terminal state is recorded here so it is observed even when no read() is awaiting.
+    private fun readChunk(): ByteArray? {
+        val scratch = ByteArray(READ_CHUNK_SIZE)
+        val count = try {
+            inputStream.read(scratch)
+        } catch (e: Exception) {
+            _isConnected.value = false
+            if (closeRequested) return null
+            logger.error(e) { message = "Failed to read bytes" }
+            throw e.toL2CapException()
+        }
+        if (count < 0 || closeRequested) {
+            _isConnected.value = false
+            return null
+        }
+        return if (count == scratch.size) scratch else scratch.copyOf(count)
+    }
+
     override suspend fun write(packet: ByteArray) {
+        if (packet.isEmpty()) return
         try {
             withContext(Dispatchers.IO) {
                 outputStream.write(packet)
@@ -70,8 +106,16 @@ internal class AndroidL2CapSocket(
     }
 
     override suspend fun close() {
+        closeRequested = true
         _isConnected.value = false
-        socket.close()
+        scope.cancel() // Completes any awaiting read() with null, even if socket.close() below throws.
+        withContext(NonCancellable + Dispatchers.IO) {
+            try {
+                socket.close() // Unblocks an in-flight readChunk.
+            } finally {
+                scope.coroutineContext.job.join()
+            }
+        }
     }
 }
 

--- a/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
@@ -138,6 +138,28 @@ public interface AndroidPeripheral : Peripheral {
     public suspend fun requestMtu(mtu: Int): Int
 
     /**
+     * Opens a secure (authenticated and encrypted) L2CAP channel to the peripheral on the given [psm],
+     * suspending until the channel is connected. The returned [L2CapSocket] is already connected.
+     *
+     * Requires [API level 29][Build.VERSION_CODES.Q] or higher.
+     *
+     * @see android.bluetooth.BluetoothDevice.createL2capChannel
+     * @throws L2CapException if the channel could not be opened.
+     */
+    public suspend fun openL2CapChannel(psm: Int): L2CapSocket
+
+    /**
+     * Opens an insecure (no authentication or encryption) L2CAP channel to the peripheral on the given
+     * [psm], suspending until the channel is connected. The returned [L2CapSocket] is already connected.
+     *
+     * Requires [API level 29][Build.VERSION_CODES.Q] or higher.
+     *
+     * @see android.bluetooth.BluetoothDevice.createInsecureL2capChannel
+     * @throws L2CapException if the channel could not be opened.
+     */
+    public suspend fun openInsecureL2CapChannel(psm: Int): L2CapSocket
+
+    /**
      * @see Peripheral.write
      * @throws NotConnectedException if invoked without an established [connection][connect].
      * @throws GattWriteException if underlying [BluetoothGatt] write operation call fails.

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -15,6 +15,9 @@ import android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
 import android.bluetooth.BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
 import android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+import android.bluetooth.BluetoothSocket
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.juul.kable.AndroidPeripheral.Priority
 import com.juul.kable.AndroidPeripheral.Type
 import com.juul.kable.State.Disconnected
@@ -34,6 +37,7 @@ import com.juul.kable.logs.Logging
 import com.juul.kable.logs.Logging.DataProcessor.Operation
 import com.juul.kable.logs.detail
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,6 +45,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 
@@ -190,6 +196,46 @@ internal class BluetoothDeviceAndroidPeripheral(
             detail("mtu", mtu)
         }
         return connectionOrThrow().requestMtu(mtu)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    override suspend fun openL2CapChannel(psm: Int): L2CapSocket {
+        connectionOrThrow()
+        return connectL2CapSocket { bluetoothDevice.createL2capChannel(psm) }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    override suspend fun openInsecureL2CapChannel(psm: Int): L2CapSocket {
+        connectionOrThrow()
+        return connectL2CapSocket { bluetoothDevice.createInsecureL2capChannel(psm) }
+    }
+
+    private suspend fun connectL2CapSocket(createSocket: () -> BluetoothSocket): L2CapSocket {
+        val socket = try {
+            createSocket()
+        } catch (e: IOException) {
+            throw e.toL2CapException()
+        }
+        try {
+            withContext(Dispatchers.IO) { socket.connect() }
+        } catch (e: CancellationException) {
+            socket.closeOrLog()
+            throw e
+        } catch (e: IOException) {
+            socket.closeOrLog()
+            throw e.toL2CapException()
+        }
+        return AndroidL2CapSocket(socket, logging)
+    }
+
+    // BluetoothSocket.close() aborts an in-progress connect, so a failed or cancelled open never leaks
+    // the socket (connect() is a blocking call that a cancelled coroutine cannot interrupt).
+    private fun BluetoothSocket.closeOrLog() {
+        try {
+            close()
+        } catch (e: IOException) {
+            logger.warn(e) { message = "Failed to close L2CAP socket" }
+        }
     }
 
     override suspend fun write(

--- a/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothDeviceAndroidPeripheral.kt
@@ -214,7 +214,7 @@ internal class BluetoothDeviceAndroidPeripheral(
         val socket = try {
             createSocket()
         } catch (e: IOException) {
-            throw e.toL2CapException()
+            throw e.wrapInL2CapException()
         }
         try {
             withContext(Dispatchers.IO) { socket.connect() }
@@ -223,13 +223,11 @@ internal class BluetoothDeviceAndroidPeripheral(
             throw e
         } catch (e: IOException) {
             socket.closeOrLog()
-            throw e.toL2CapException()
+            throw e.wrapInL2CapException()
         }
-        return AndroidL2CapSocket(socket, logging)
+        return AndroidL2CapSocket(socket, scope, logging)
     }
 
-    // BluetoothSocket.close() aborts an in-progress connect, so a failed or cancelled open never leaks
-    // the socket (connect() is a blocking call that a cancelled coroutine cannot interrupt).
     private fun BluetoothSocket.closeOrLog() {
         try {
             close()

--- a/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
+++ b/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
@@ -1,0 +1,428 @@
+@file:OptIn(ExperimentalForeignApi::class, NativeRuntimeApi::class)
+
+package com.juul.kable
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import platform.CoreBluetooth.CBL2CAPChannel
+import platform.CoreFoundation.CFRunLoopRef
+import platform.CoreFoundation.CFRunLoopWakeUp
+import platform.Foundation.NSDate
+import platform.Foundation.NSDefaultRunLoopMode
+import platform.Foundation.NSError
+import platform.Foundation.NSInputStream
+import platform.Foundation.NSLock
+import platform.Foundation.NSOutputStream
+import platform.Foundation.NSRunLoop
+import platform.Foundation.NSStream
+import platform.Foundation.NSStreamDelegateProtocol
+import platform.Foundation.NSStreamEvent
+import platform.Foundation.NSStreamEventEndEncountered
+import platform.Foundation.NSStreamEventErrorOccurred
+import platform.Foundation.NSStreamEventHasBytesAvailable
+import platform.Foundation.NSStreamEventHasSpaceAvailable
+import platform.Foundation.NSThread
+import platform.Foundation.dateWithTimeIntervalSinceNow
+import platform.Foundation.runMode
+import platform.darwin.NSObject
+import kotlin.native.runtime.GC
+import kotlin.native.runtime.NativeRuntimeApi
+
+// CBL2CAPChannel's NSStreams are not thread-safe: driving one from a rotating dispatcher thread pool
+// can make an output-stream write intermittently fail with EINVAL when a write lands on a different
+// thread than earlier stream operations. This socket therefore confines *every* stream operation to
+// one dedicated thread with a running NSRunLoop, the model Apple's CBL2CAPChannel sample uses:
+//   - Reads are event-driven. The NSStreamDelegate reads on HasBytesAvailable into an unbounded
+//     channel; read() only drains that channel, so it never touches the stream itself and a blocking
+//     read can never starve a write. The channel is unbounded so a slow reader applies backpressure by
+//     buffering rather than dropping inbound data.
+//   - Writes are queued from the caller's coroutine and pumped by the run-loop thread, so the write
+//     syscall only ever runs on the run-loop thread. Writability comes from the polled
+//     hasSpaceAvailable property when work is queued, with the HasSpaceAvailable event as the resume
+//     signal after backpressure — the event alone is an edge NSStream is not obliged to (re-)emit
+//     before the first write, so gating on it alone would deadlock the first outbound packet.
+// EOF/error sign conventions are the inverse of L2CapSocket's (NSInputStream: 0 = EOF, -1 = error),
+// normalised where the channel is closed. A read error closes the channel with a cause (drained, then
+// read() rethrows); EOF closes it without one (drained, then read() returns -1).
+private const val READ_CHUNK_SIZE = 8192
+
+// The run loop wakes on stream events for reads; this bounds how long a queued *write* waits when the
+// loop is otherwise idle. CFRunLoopWakeUp normally makes writes immediate — this is the safety net if a
+// wake is missed, so a queued write is never delayed by more than this interval.
+private const val RUN_LOOP_POLL_SECONDS = 0.1
+
+internal class AppleL2CapSocket(
+    channel: CBL2CAPChannel,
+) : L2CapSocket {
+
+    // Retained while the socket is in use: CoreBluetooth closes the underlying channel when the
+    // CBL2CAPChannel deallocates, and the streams are not documented to keep it alive. Unretained, the
+    // channel can be collected while still in use, dropping the link shortly after the first data burst.
+    // Nulled at teardown for the same reason in reverse: Kotlin/Native releases an Obj-C reference only
+    // when the GC collects it, and deallocation is also the only way CoreBluetooth *disconnects* the
+    // channel (closing the streams does not); a socket held by its caller must not keep the PSM
+    // connected, or reopening it fails with "L2CAP PSM already connected" until an incidental GC runs.
+    private var retainedChannel: CBL2CAPChannel? = channel
+
+    private val inputStream: NSInputStream = channel.inputStream ?: error("L2CAP channel has no input stream")
+    private val outputStream: NSOutputStream = channel.outputStream ?: error("L2CAP channel has no output stream")
+
+    // An NSStream delegate must be an Obj-C class, but L2CapSocket is a Kotlin interface and K/N forbids
+    // mixing the two supertypes on one class, so the delegate is its own object that forwards events here.
+    private val streamDelegate = StreamDelegate()
+
+    private val _isConnected = MutableStateFlow(true)
+    override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _hasReachedEof = MutableStateFlow(false)
+    override val hasReachedEof: StateFlow<Boolean> = _hasReachedEof.asStateFlow()
+
+    // Chunks read on the run-loop thread, drained by the single reader coroutine in read().
+    private val incoming = Channel<ByteArray>(Channel.UNLIMITED)
+
+    private class PendingWrite(val packet: ByteArray, val done: CompletableDeferred<Unit>)
+
+    // writeQueue and the two flags below are the only state shared with caller threads; NSLock guards
+    // them. Everything else (current/currentOffset/spaceAvailable/pendingWrites/terminal) is touched
+    // only on the run-loop thread.
+    private val lock = NSLock()
+    private val writeQueue = ArrayDeque<PendingWrite>()
+    private var stopRequested = false
+    private var acceptingWrites = true
+    private var cfRunLoop: CFRunLoopRef? = null
+
+    private val pendingWrites = ArrayDeque<PendingWrite>()
+    private var current: PendingWrite? = null
+    private var currentOffset = 0
+    private var spaceAvailable = false
+    private var terminal: Throwable? = null
+    private var streamsClosed = false
+
+    // Completed by the run-loop thread once the streams are closed and unscheduled, so close() can
+    // guarantee teardown finished rather than merely being requested.
+    private val closed = CompletableDeferred<Unit>()
+
+    private fun runLoop() {
+        try {
+            runLoopBody()
+        } finally {
+            // Unconditional so close() can never hang on a run-loop thread that died unexpectedly —
+            // in that case the streams may be left un-unscheduled, but the thread is gone and no
+            // further cleanup is possible.
+            closed.complete(Unit)
+        }
+    }
+
+    private fun runLoopBody() {
+        val runLoop = NSRunLoop.currentRunLoop
+        lock.lock()
+        cfRunLoop = runLoop.getCFRunLoop()
+        lock.unlock()
+
+        streamDelegate.onEvent = ::handleStreamEvent
+        inputStream.delegate = streamDelegate
+        outputStream.delegate = streamDelegate
+        inputStream.scheduleInRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
+        outputStream.scheduleInRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
+        inputStream.open()
+        outputStream.open()
+
+        while (true) {
+            if (processControlAndWrites()) break
+            runLoop.runMode(NSDefaultRunLoopMode, beforeDate = NSDate.dateWithTimeIntervalSinceNow(RUN_LOOP_POLL_SECONDS))
+            if (terminal != null) break
+        }
+
+        beginClose()
+        cleanup()
+        // Null the handle before the run loop is torn down with this thread, so a close()/write() racing
+        // in after the loop exits skips CFRunLoopWakeUp rather than waking a dangling run loop. wakeRunLoop
+        // reads and wakes under the same lock, so a wake can only fire while this section hasn't run yet.
+        lock.lock()
+        cfRunLoop = null
+        retainedChannel = null
+        lock.unlock()
+        // The channel disconnects on deallocation (see retainedChannel); ask for a collection so an
+        // abandoned socket — whose owner never gets to call close() — frees its PSM promptly too.
+        GC.schedule()
+    }
+
+    // Run-loop thread. Moves caller-enqueued writes into the run-loop-local queue and pumps them.
+    // Returns true when the loop should exit (graceful close requested, or the socket went terminal).
+    private fun processControlAndWrites(): Boolean {
+        if (terminal != null) return true
+        lock.lock()
+        val stop = stopRequested
+        val staged = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
+        lock.unlock()
+        if (stop) return true
+        if (staged.isNotEmpty()) pendingWrites.addAll(staged)
+        // HasSpaceAvailable is an edge signal: it may have fired before any write was queued (and is
+        // then spent) or not at all yet. With work pending, seed the flag from the polled property so
+        // a write never waits for an event that already passed; this re-runs every loop iteration, so
+        // even without the event a queued write proceeds within RUN_LOOP_POLL_SECONDS.
+        if ((current != null || pendingWrites.isNotEmpty()) && !spaceAvailable && outputStream.hasSpaceAvailable) {
+            spaceAvailable = true
+        }
+        pump()
+        return terminal != null
+    }
+
+    // Run-loop thread, via streamDelegate. Events can OR together, so each bit gets its own `if` —
+    // a `when` would handle only the first matching bit and silently drop the rest.
+    private fun handleStreamEvent(aStream: NSStream, event: NSStreamEvent) {
+        // Bit tests are written as `(event and bit) == bit` rather than `!= 0uL` so they hold on every
+        // Apple target: NSStreamEvent is a 32-bit UInt on watchosArm64 (arm64_32) and 64-bit elsewhere,
+        // and a fixed-width `0uL` literal would not compile against the narrow variant.
+        if (event and NSStreamEventHasBytesAvailable == NSStreamEventHasBytesAvailable) onBytesAvailable()
+        if (event and NSStreamEventHasSpaceAvailable == NSStreamEventHasSpaceAvailable) {
+            spaceAvailable = true
+            pump()
+        }
+        if (event and NSStreamEventErrorOccurred == NSStreamEventErrorOccurred) onError(aStream.streamError)
+        if (event and NSStreamEventEndEncountered == NSStreamEventEndEncountered) onEnd()
+    }
+
+    private fun onBytesAvailable() {
+        while (terminal == null && inputStream.hasBytesAvailable) {
+            val scratch = ByteArray(READ_CHUNK_SIZE)
+            // `.convert()` for the length and `.toLong()` on the result: NSInputStream.read's length is
+            // an NSUInteger and its return an NSInteger, both of which narrow to 32-bit on watchosArm64.
+            val read = scratch.usePinned { pinned ->
+                inputStream.read(pinned.addressOf(0).reinterpret(), READ_CHUNK_SIZE.convert())
+            }.toLong()
+            when {
+                read > 0L -> incoming.trySend(scratch.copyOf(read.toInt()))
+                read == 0L -> {
+                    onEnd()
+                    return
+                }
+                else -> {
+                    onError(inputStream.streamError)
+                    return
+                }
+            }
+        }
+    }
+
+    private fun pump() {
+        while (terminal == null && spaceAvailable) {
+            val write = current ?: pendingWrites.removeFirstOrNull()?.also {
+                current = it
+                currentOffset = 0
+            } ?: break
+            val packet = write.packet
+            val remaining = packet.size - currentOffset
+            val written = packet.usePinned { pinned ->
+                outputStream.write(pinned.addressOf(currentOffset).reinterpret(), remaining.convert())
+            }.toLong()
+            when {
+                written > 0L -> {
+                    currentOffset += written.toInt()
+                    if (currentOffset >= packet.size) {
+                        write.done.complete(Unit)
+                        current = null
+                        currentOffset = 0
+                    }
+                    if (!outputStream.hasSpaceAvailable) spaceAvailable = false
+                }
+                written == 0L -> spaceAvailable = false
+                else -> {
+                    onError(outputStream.streamError)
+                    return
+                }
+            }
+        }
+    }
+
+    // EOF: reader drains buffered chunks then read() returns -1. Writes can no longer complete, so fail
+    // any in flight. Idempotent — End and a 0-length read can both arrive.
+    private fun onEnd() {
+        if (terminal != null) return
+        // EOF is not an error for reads (the channel closes without a cause so read() returns -1), but
+        // it still ends the run loop and must fail any in-flight write against the now-dead channel.
+        terminal = L2CapException("L2CAP stream reached end of file", code = 0L)
+        _hasReachedEof.value = true
+        _isConnected.value = false
+        incoming.close()
+        failAllWrites(terminal!!)
+    }
+
+    private fun onError(error: NSError?) {
+        if (terminal != null) return
+        val exception = L2CapException(error?.localizedDescription ?: "L2CAP stream error", code = 0L)
+        terminal = exception
+        _isConnected.value = false
+        incoming.close(exception)
+        failAllWrites(exception)
+    }
+
+    private fun failAllWrites(cause: Throwable) {
+        current?.done?.completeExceptionally(cause)
+        current = null
+        currentOffset = 0
+        pendingWrites.forEach { it.done.completeExceptionally(cause) }
+        pendingWrites.clear()
+        lock.lock()
+        acceptingWrites = false
+        val queued = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
+        lock.unlock()
+        queued.forEach { it.done.completeExceptionally(cause) }
+    }
+
+    // Run-loop thread: unschedule and close the streams on the thread they live on. Idempotent.
+    private fun beginClose() {
+        if (streamsClosed) return
+        streamsClosed = true
+        val runLoop = NSRunLoop.currentRunLoop
+        inputStream.delegate = null
+        outputStream.delegate = null
+        // The socket owns the delegate, so it outlives the streams: clearing their reference to it is
+        // not enough to stop an event already in flight re-entering a socket that has closed.
+        streamDelegate.onEvent = null
+        inputStream.removeFromRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
+        outputStream.removeFromRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
+        inputStream.close()
+        outputStream.close()
+    }
+
+    private fun cleanup() {
+        val cause = terminal ?: L2CapException("L2CAP socket closed", code = 0L)
+        failAllWrites(cause)
+        if (!incoming.isClosedForSend) incoming.close()
+    }
+
+    // Reader-owned and unguarded: read() assumes the single reader coroutine its contract promises.
+    private var leftover: ByteArray? = null
+    private var leftoverOffset = 0
+
+    override suspend fun read(buffer: ByteArray): Int {
+        if (buffer.isEmpty()) return 0
+        leftover?.let { chunk ->
+            val count = minOf(buffer.size, chunk.size - leftoverOffset)
+            chunk.copyInto(buffer, destinationOffset = 0, startIndex = leftoverOffset, endIndex = leftoverOffset + count)
+            leftoverOffset += count
+            if (leftoverOffset >= chunk.size) {
+                leftover = null
+                leftoverOffset = 0
+            }
+            return count
+        }
+        val result = incoming.receiveCatching()
+        if (result.isClosed) {
+            // Cause is non-null only for a read error; a clean EOF closes the channel without one.
+            result.exceptionOrNull()?.let { throw it }
+            return -1
+        }
+        val chunk = result.getOrThrow()
+        val count = minOf(buffer.size, chunk.size)
+        chunk.copyInto(buffer, destinationOffset = 0, startIndex = 0, endIndex = count)
+        if (count < chunk.size) {
+            leftover = chunk
+            leftoverOffset = count
+        }
+        return count
+    }
+
+    override suspend fun write(packet: ByteArray) {
+        if (packet.isEmpty()) return
+        val done = CompletableDeferred<Unit>()
+        val pending = PendingWrite(packet, done)
+        lock.lock()
+        val accepted = acceptingWrites
+        if (accepted) writeQueue.addLast(pending)
+        lock.unlock()
+        if (!accepted) throw L2CapException("L2CAP socket is closed", code = 0L)
+        wakeRunLoop()
+        try {
+            done.await()
+        } catch (e: CancellationException) {
+            // The caller abandoned this write, so drop it if the run loop has not staged it yet
+            // rather than delivering a packet whose sender is already gone. One that is staged (or
+            // half-written) is past recall and still completes.
+            lock.lock()
+            writeQueue.remove(pending)
+            lock.unlock()
+            throw e
+        }
+    }
+
+    // Teardown for a socket whose owner never materialised: openL2CapChannel was cancelled while
+    // CoreBluetooth was still opening the channel, and the channel then arrived anyway. Unlike close()
+    // this does not await the run loop, so the delegate can call it from its non-suspending callback;
+    // the run loop's finally still completes `closed`.
+    internal fun abandon() {
+        _isConnected.value = false
+        lock.lock()
+        stopRequested = true
+        acceptingWrites = false
+        val queued = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
+        lock.unlock()
+        queued.forEach { it.done.completeExceptionally(L2CapException("L2CAP socket is closed", code = 0L)) }
+        wakeRunLoop()
+    }
+
+    override suspend fun close() {
+        _isConnected.value = false
+        lock.lock()
+        stopRequested = true
+        acceptingWrites = false
+        val queued = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
+        lock.unlock()
+        queued.forEach { it.done.completeExceptionally(L2CapException("L2CAP socket is closed", code = 0L)) }
+        wakeRunLoop()
+        // Close must not report done before it is: streams left live here are stale local L2CAP state
+        // that can poison a subsequent channel opened on the same PSM, so await full teardown — shielded
+        // from cancellation, which must not be able to skip the collection below.
+        withContext(NonCancellable) {
+            closed.await()
+            // Deterministic disconnect: the OS only tears the channel down when the CBL2CAPChannel
+            // deallocates (see retainedChannel), and Kotlin/Native releases it at collection time.
+            // Without this, close() returns with the PSM still connected and a reopen fails with
+            // "L2CAP PSM already connected" until an incidental GC happens to run.
+            GC.collect()
+        }
+    }
+
+    private fun wakeRunLoop() {
+        // Wake under the lock: while it is held, the run-loop thread cannot reach its final section that
+        // nulls cfRunLoop and lets the run loop deallocate, so a non-null handle here is alive to wake.
+        lock.lock()
+        cfRunLoop?.let { CFRunLoopWakeUp(it) }
+        lock.unlock()
+    }
+
+    // Last: every field above is initialized before the run-loop thread (which touches them) starts.
+    init {
+        // Connected up front: a consumer may gate on isConnected before its first read, and read() then
+        // suspends on `incoming` until the streams open and data arrives. Setting this on the run-loop
+        // thread instead would race that gate closed.
+        _isConnected.value = true
+        val thread = NSThread { runLoop() }
+        thread.name = "l2cap-runloop"
+        thread.start()
+    }
+}
+
+// NSStream delivers events to a delegate scheduled on the run loop. It forwards to the socket via a
+// callback so AppleL2CapSocket can stay a plain Kotlin L2CapSocket (K/N forbids one class extending both
+// an Obj-C type and a Kotlin interface). NSStream holds its delegate weakly, so the socket owns this.
+private class StreamDelegate : NSObject(), NSStreamDelegateProtocol {
+
+    var onEvent: ((NSStream, NSStreamEvent) -> Unit)? = null
+
+    override fun stream(aStream: NSStream, handleEvent: NSStreamEvent) {
+        onEvent?.invoke(aStream, handleEvent)
+    }
+}

--- a/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
+++ b/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
@@ -54,7 +54,7 @@ import kotlin.native.runtime.NativeRuntimeApi
 //     before the first write, so gating on it alone would deadlock the first outbound packet.
 // EOF/error sign conventions are the inverse of L2CapSocket's (NSInputStream: 0 = EOF, -1 = error),
 // normalised where the channel is closed. A read error closes the channel with a cause (drained, then
-// read() rethrows); EOF closes it without one (drained, then read() returns -1).
+// read() rethrows); EOF closes it without one (drained, then read() returns null).
 private const val READ_CHUNK_SIZE = 8192
 
 // The run loop wakes on stream events for reads; this bounds how long a queued *write* waits when the
@@ -85,11 +85,19 @@ internal class AppleL2CapSocket(
     private val _isConnected = MutableStateFlow(true)
     override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
-    private val _hasReachedEof = MutableStateFlow(false)
-    override val hasReachedEof: StateFlow<Boolean> = _hasReachedEof.asStateFlow()
+    // Chunks read on the run-loop thread, drained by the single reader coroutine in read(). A chunk
+    // orphaned by a cancelled read() (cancellation can win after the chunk left the channel) is stashed
+    // in undelivered, which the next read() drains first.
+    private val incoming = Channel<ByteArray>(
+        capacity = Channel.UNLIMITED,
+        onUndeliveredElement = { chunk ->
+            lock.lock()
+            undelivered = chunk
+            lock.unlock()
+        },
+    )
 
-    // Chunks read on the run-loop thread, drained by the single reader coroutine in read().
-    private val incoming = Channel<ByteArray>(Channel.UNLIMITED)
+    private var undelivered: ByteArray? = null // Guarded by lock.
 
     private class PendingWrite(val packet: ByteArray, val done: CompletableDeferred<Unit>)
 
@@ -246,14 +254,13 @@ internal class AppleL2CapSocket(
         }
     }
 
-    // EOF: reader drains buffered chunks then read() returns -1. Writes can no longer complete, so fail
+    // EOF: reader drains buffered chunks then read() returns null. Writes can no longer complete, so fail
     // any in flight. Idempotent — End and a 0-length read can both arrive.
     private fun onEnd() {
         if (terminal != null) return
-        // EOF is not an error for reads (the channel closes without a cause so read() returns -1), but
+        // EOF is not an error for reads (the channel closes without a cause so read() returns null), but
         // it still ends the run loop and must fail any in-flight write against the now-dead channel.
         terminal = L2CapException("L2CAP stream reached end of file", code = 0L)
-        _hasReachedEof.value = true
         _isConnected.value = false
         incoming.close()
         failAllWrites(terminal!!)
@@ -303,36 +310,19 @@ internal class AppleL2CapSocket(
         if (!incoming.isClosedForSend) incoming.close()
     }
 
-    // Reader-owned and unguarded: read() assumes the single reader coroutine its contract promises.
-    private var leftover: ByteArray? = null
-    private var leftoverOffset = 0
-
-    override suspend fun read(buffer: ByteArray): Int {
-        if (buffer.isEmpty()) return 0
-        leftover?.let { chunk ->
-            val count = minOf(buffer.size, chunk.size - leftoverOffset)
-            chunk.copyInto(buffer, destinationOffset = 0, startIndex = leftoverOffset, endIndex = leftoverOffset + count)
-            leftoverOffset += count
-            if (leftoverOffset >= chunk.size) {
-                leftover = null
-                leftoverOffset = 0
-            }
-            return count
-        }
+    override suspend fun read(): ByteArray? {
+        lock.lock()
+        val stashed = undelivered
+        undelivered = null
+        lock.unlock()
+        if (stashed != null) return stashed
         val result = incoming.receiveCatching()
         if (result.isClosed) {
             // Cause is non-null only for a read error; a clean EOF closes the channel without one.
             result.exceptionOrNull()?.let { throw it }
-            return -1
+            return null
         }
-        val chunk = result.getOrThrow()
-        val count = minOf(buffer.size, chunk.size)
-        chunk.copyInto(buffer, destinationOffset = 0, startIndex = 0, endIndex = count)
-        if (count < chunk.size) {
-            leftover = chunk
-            leftoverOffset = count
-        }
-        return count
+        return result.getOrThrow()
     }
 
     override suspend fun write(packet: ByteArray) {

--- a/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
+++ b/kable-core/src/appleMain/kotlin/AppleL2CapSocket.kt
@@ -11,9 +11,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.withContext
 import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreFoundation.CFRunLoopRef
@@ -39,77 +41,38 @@ import platform.darwin.NSObject
 import kotlin.native.runtime.GC
 import kotlin.native.runtime.NativeRuntimeApi
 
-// CBL2CAPChannel's NSStreams are not thread-safe: driving one from a rotating dispatcher thread pool
-// can make an output-stream write intermittently fail with EINVAL when a write lands on a different
-// thread than earlier stream operations. This socket therefore confines *every* stream operation to
-// one dedicated thread with a running NSRunLoop, the model Apple's CBL2CAPChannel sample uses:
-//   - Reads are event-driven. The NSStreamDelegate reads on HasBytesAvailable into an unbounded
-//     channel; read() only drains that channel, so it never touches the stream itself and a blocking
-//     read can never starve a write. The channel is unbounded so a slow reader applies backpressure by
-//     buffering rather than dropping inbound data.
-//   - Writes are queued from the caller's coroutine and pumped by the run-loop thread, so the write
-//     syscall only ever runs on the run-loop thread. Writability comes from the polled
-//     hasSpaceAvailable property when work is queued, with the HasSpaceAvailable event as the resume
-//     signal after backpressure — the event alone is an edge NSStream is not obliged to (re-)emit
-//     before the first write, so gating on it alone would deadlock the first outbound packet.
-// EOF/error sign conventions are the inverse of L2CapSocket's (NSInputStream: 0 = EOF, -1 = error),
-// normalised where the channel is closed. A read error closes the channel with a cause (drained, then
-// read() rethrows); EOF closes it without one (drained, then read() returns null).
 private const val READ_CHUNK_SIZE = 8192
-
-// The run loop wakes on stream events for reads; this bounds how long a queued *write* waits when the
-// loop is otherwise idle. CFRunLoopWakeUp normally makes writes immediate — this is the safety net if a
-// wake is missed, so a queued write is never delayed by more than this interval.
 private const val RUN_LOOP_POLL_SECONDS = 0.1
 
+// The channel's streams are not thread safe, so all stream access happens on one dedicated thread
+// running an NSRunLoop.
 internal class AppleL2CapSocket(
     channel: CBL2CAPChannel,
 ) : L2CapSocket {
 
-    // Retained while the socket is in use: CoreBluetooth closes the underlying channel when the
-    // CBL2CAPChannel deallocates, and the streams are not documented to keep it alive. Unretained, the
-    // channel can be collected while still in use, dropping the link shortly after the first data burst.
-    // Nulled at teardown for the same reason in reverse: Kotlin/Native releases an Obj-C reference only
-    // when the GC collects it, and deallocation is also the only way CoreBluetooth *disconnects* the
-    // channel (closing the streams does not); a socket held by its caller must not keep the PSM
-    // connected, or reopening it fails with "L2CAP PSM already connected" until an incidental GC runs.
+    // CoreBluetooth disconnects the channel when the CBL2CAPChannel is deallocated, and not before.
     private var retainedChannel: CBL2CAPChannel? = channel
 
     private val inputStream: NSInputStream = channel.inputStream ?: error("L2CAP channel has no input stream")
     private val outputStream: NSOutputStream = channel.outputStream ?: error("L2CAP channel has no output stream")
-
-    // An NSStream delegate must be an Obj-C class, but L2CapSocket is a Kotlin interface and K/N forbids
-    // mixing the two supertypes on one class, so the delegate is its own object that forwards events here.
     private val streamDelegate = StreamDelegate()
 
     private val _isConnected = MutableStateFlow(true)
     override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
-    // Chunks read on the run-loop thread, drained by the single reader coroutine in read(). A chunk
-    // orphaned by a cancelled read() (cancellation can win after the chunk left the channel) is stashed
-    // in undelivered, which the next read() drains first.
-    private val incoming = Channel<ByteArray>(
-        capacity = Channel.UNLIMITED,
-        onUndeliveredElement = { chunk ->
-            lock.lock()
-            undelivered = chunk
-            lock.unlock()
-        },
-    )
-
-    private var undelivered: ByteArray? = null // Guarded by lock.
+    private val chunks = Channel<ByteArray>(Channel.UNLIMITED)
+    override val incoming: Flow<ByteArray> = chunks.receiveAsFlow()
 
     private class PendingWrite(val packet: ByteArray, val done: CompletableDeferred<Unit>)
 
-    // writeQueue and the two flags below are the only state shared with caller threads; NSLock guards
-    // them. Everything else (current/currentOffset/spaceAvailable/pendingWrites/terminal) is touched
-    // only on the run-loop thread.
+    // Guarded by lock, shared with caller threads.
     private val lock = NSLock()
     private val writeQueue = ArrayDeque<PendingWrite>()
     private var stopRequested = false
     private var acceptingWrites = true
     private var cfRunLoop: CFRunLoopRef? = null
 
+    // Run loop thread only.
     private val pendingWrites = ArrayDeque<PendingWrite>()
     private var current: PendingWrite? = null
     private var currentOffset = 0
@@ -117,17 +80,12 @@ internal class AppleL2CapSocket(
     private var terminal: Throwable? = null
     private var streamsClosed = false
 
-    // Completed by the run-loop thread once the streams are closed and unscheduled, so close() can
-    // guarantee teardown finished rather than merely being requested.
     private val closed = CompletableDeferred<Unit>()
 
     private fun runLoop() {
         try {
             runLoopBody()
         } finally {
-            // Unconditional so close() can never hang on a run-loop thread that died unexpectedly —
-            // in that case the streams may be left un-unscheduled, but the thread is gone and no
-            // further cleanup is possible.
             closed.complete(Unit)
         }
     }
@@ -154,20 +112,13 @@ internal class AppleL2CapSocket(
 
         beginClose()
         cleanup()
-        // Null the handle before the run loop is torn down with this thread, so a close()/write() racing
-        // in after the loop exits skips CFRunLoopWakeUp rather than waking a dangling run loop. wakeRunLoop
-        // reads and wakes under the same lock, so a wake can only fire while this section hasn't run yet.
         lock.lock()
         cfRunLoop = null
         retainedChannel = null
         lock.unlock()
-        // The channel disconnects on deallocation (see retainedChannel); ask for a collection so an
-        // abandoned socket — whose owner never gets to call close() — frees its PSM promptly too.
         GC.schedule()
     }
 
-    // Run-loop thread. Moves caller-enqueued writes into the run-loop-local queue and pumps them.
-    // Returns true when the loop should exit (graceful close requested, or the socket went terminal).
     private fun processControlAndWrites(): Boolean {
         if (terminal != null) return true
         lock.lock()
@@ -176,10 +127,7 @@ internal class AppleL2CapSocket(
         lock.unlock()
         if (stop) return true
         if (staged.isNotEmpty()) pendingWrites.addAll(staged)
-        // HasSpaceAvailable is an edge signal: it may have fired before any write was queued (and is
-        // then spent) or not at all yet. With work pending, seed the flag from the polled property so
-        // a write never waits for an event that already passed; this re-runs every loop iteration, so
-        // even without the event a queued write proceeds within RUN_LOOP_POLL_SECONDS.
+        // HasSpaceAvailable may have fired before anything was queued, so also poll the property.
         if ((current != null || pendingWrites.isNotEmpty()) && !spaceAvailable && outputStream.hasSpaceAvailable) {
             spaceAvailable = true
         }
@@ -187,12 +135,7 @@ internal class AppleL2CapSocket(
         return terminal != null
     }
 
-    // Run-loop thread, via streamDelegate. Events can OR together, so each bit gets its own `if` —
-    // a `when` would handle only the first matching bit and silently drop the rest.
     private fun handleStreamEvent(aStream: NSStream, event: NSStreamEvent) {
-        // Bit tests are written as `(event and bit) == bit` rather than `!= 0uL` so they hold on every
-        // Apple target: NSStreamEvent is a 32-bit UInt on watchosArm64 (arm64_32) and 64-bit elsewhere,
-        // and a fixed-width `0uL` literal would not compile against the narrow variant.
         if (event and NSStreamEventHasBytesAvailable == NSStreamEventHasBytesAvailable) onBytesAvailable()
         if (event and NSStreamEventHasSpaceAvailable == NSStreamEventHasSpaceAvailable) {
             spaceAvailable = true
@@ -205,13 +148,11 @@ internal class AppleL2CapSocket(
     private fun onBytesAvailable() {
         while (terminal == null && inputStream.hasBytesAvailable) {
             val scratch = ByteArray(READ_CHUNK_SIZE)
-            // `.convert()` for the length and `.toLong()` on the result: NSInputStream.read's length is
-            // an NSUInteger and its return an NSInteger, both of which narrow to 32-bit on watchosArm64.
             val read = scratch.usePinned { pinned ->
                 inputStream.read(pinned.addressOf(0).reinterpret(), READ_CHUNK_SIZE.convert())
             }.toLong()
             when {
-                read > 0L -> incoming.trySend(scratch.copyOf(read.toInt()))
+                read > 0L -> chunks.trySend(scratch.copyOf(read.toInt()))
                 read == 0L -> {
                     onEnd()
                     return
@@ -254,24 +195,20 @@ internal class AppleL2CapSocket(
         }
     }
 
-    // EOF: reader drains buffered chunks then read() returns null. Writes can no longer complete, so fail
-    // any in flight. Idempotent — End and a 0-length read can both arrive.
     private fun onEnd() {
         if (terminal != null) return
-        // EOF is not an error for reads (the channel closes without a cause so read() returns null), but
-        // it still ends the run loop and must fail any in-flight write against the now-dead channel.
-        terminal = L2CapException("L2CAP stream reached end of file", code = 0L)
+        terminal = L2CapException("L2CAP stream reached end of file")
         _isConnected.value = false
-        incoming.close()
+        chunks.close()
         failAllWrites(terminal!!)
     }
 
     private fun onError(error: NSError?) {
         if (terminal != null) return
-        val exception = L2CapException(error?.localizedDescription ?: "L2CAP stream error", code = 0L)
+        val exception = L2CapException(error?.localizedDescription ?: "L2CAP stream error", code = error?.code?.toLong())
         terminal = exception
         _isConnected.value = false
-        incoming.close(exception)
+        chunks.close(exception)
         failAllWrites(exception)
     }
 
@@ -288,15 +225,12 @@ internal class AppleL2CapSocket(
         queued.forEach { it.done.completeExceptionally(cause) }
     }
 
-    // Run-loop thread: unschedule and close the streams on the thread they live on. Idempotent.
     private fun beginClose() {
         if (streamsClosed) return
         streamsClosed = true
         val runLoop = NSRunLoop.currentRunLoop
         inputStream.delegate = null
         outputStream.delegate = null
-        // The socket owns the delegate, so it outlives the streams: clearing their reference to it is
-        // not enough to stop an event already in flight re-entering a socket that has closed.
         streamDelegate.onEvent = null
         inputStream.removeFromRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
         outputStream.removeFromRunLoop(runLoop, forMode = NSDefaultRunLoopMode)
@@ -305,42 +239,24 @@ internal class AppleL2CapSocket(
     }
 
     private fun cleanup() {
-        val cause = terminal ?: L2CapException("L2CAP socket closed", code = 0L)
+        val cause = terminal ?: L2CapException("L2CAP socket closed")
         failAllWrites(cause)
-        if (!incoming.isClosedForSend) incoming.close()
-    }
-
-    override suspend fun read(): ByteArray? {
-        lock.lock()
-        val stashed = undelivered
-        undelivered = null
-        lock.unlock()
-        if (stashed != null) return stashed
-        val result = incoming.receiveCatching()
-        if (result.isClosed) {
-            // Cause is non-null only for a read error; a clean EOF closes the channel without one.
-            result.exceptionOrNull()?.let { throw it }
-            return null
-        }
-        return result.getOrThrow()
+        if (!chunks.isClosedForSend) chunks.close()
     }
 
     override suspend fun write(packet: ByteArray) {
-        if (packet.isEmpty()) return
+        require(packet.isNotEmpty()) { "Packet must not be empty" }
         val done = CompletableDeferred<Unit>()
         val pending = PendingWrite(packet, done)
         lock.lock()
         val accepted = acceptingWrites
         if (accepted) writeQueue.addLast(pending)
         lock.unlock()
-        if (!accepted) throw L2CapException("L2CAP socket is closed", code = 0L)
+        if (!accepted) throw L2CapException("L2CAP socket is closed")
         wakeRunLoop()
         try {
             done.await()
         } catch (e: CancellationException) {
-            // The caller abandoned this write, so drop it if the run loop has not staged it yet
-            // rather than delivering a packet whose sender is already gone. One that is staged (or
-            // half-written) is past recall and still completes.
             lock.lock()
             writeQueue.remove(pending)
             lock.unlock()
@@ -348,66 +264,42 @@ internal class AppleL2CapSocket(
         }
     }
 
-    // Teardown for a socket whose owner never materialised: openL2CapChannel was cancelled while
-    // CoreBluetooth was still opening the channel, and the channel then arrived anyway. Unlike close()
-    // this does not await the run loop, so the delegate can call it from its non-suspending callback;
-    // the run loop's finally still completes `closed`.
-    internal fun abandon() {
+    internal fun dispose() {
         _isConnected.value = false
         lock.lock()
         stopRequested = true
         acceptingWrites = false
         val queued = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
         lock.unlock()
-        queued.forEach { it.done.completeExceptionally(L2CapException("L2CAP socket is closed", code = 0L)) }
+        queued.forEach { it.done.completeExceptionally(L2CapException("L2CAP socket is closed")) }
         wakeRunLoop()
     }
 
     override suspend fun close() {
-        _isConnected.value = false
-        lock.lock()
-        stopRequested = true
-        acceptingWrites = false
-        val queued = if (writeQueue.isEmpty()) emptyList() else writeQueue.toList().also { writeQueue.clear() }
-        lock.unlock()
-        queued.forEach { it.done.completeExceptionally(L2CapException("L2CAP socket is closed", code = 0L)) }
-        wakeRunLoop()
-        // Close must not report done before it is: streams left live here are stale local L2CAP state
-        // that can poison a subsequent channel opened on the same PSM, so await full teardown — shielded
-        // from cancellation, which must not be able to skip the collection below.
+        dispose()
         withContext(NonCancellable) {
             closed.await()
-            // Deterministic disconnect: the OS only tears the channel down when the CBL2CAPChannel
-            // deallocates (see retainedChannel), and Kotlin/Native releases it at collection time.
-            // Without this, close() returns with the PSM still connected and a reopen fails with
-            // "L2CAP PSM already connected" until an incidental GC happens to run.
+            // Releases the CBL2CAPChannel now, so the PSM can be reopened right away.
             GC.collect()
         }
     }
 
     private fun wakeRunLoop() {
-        // Wake under the lock: while it is held, the run-loop thread cannot reach its final section that
-        // nulls cfRunLoop and lets the run loop deallocate, so a non-null handle here is alive to wake.
         lock.lock()
         cfRunLoop?.let { CFRunLoopWakeUp(it) }
         lock.unlock()
     }
 
-    // Last: every field above is initialized before the run-loop thread (which touches them) starts.
+    // Last, so every field is initialized before the run loop thread starts.
     init {
-        // Connected up front: a consumer may gate on isConnected before its first read, and read() then
-        // suspends on `incoming` until the streams open and data arrives. Setting this on the run-loop
-        // thread instead would race that gate closed.
-        _isConnected.value = true
         val thread = NSThread { runLoop() }
         thread.name = "l2cap-runloop"
         thread.start()
     }
 }
 
-// NSStream delivers events to a delegate scheduled on the run loop. It forwards to the socket via a
-// callback so AppleL2CapSocket can stay a plain Kotlin L2CapSocket (K/N forbids one class extending both
-// an Obj-C type and a Kotlin interface). NSStream holds its delegate weakly, so the socket owns this.
+// Kotlin/Native does not allow a class to extend NSObject and implement a Kotlin interface, so the
+// socket cannot be its own stream delegate.
 private class StreamDelegate : NSObject(), NSStreamDelegateProtocol {
 
     var onEvent: ((NSStream, NSStreamEvent) -> Unit)? = null

--- a/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CBPeripheralCoreBluetoothPeripheral.kt
@@ -392,6 +392,11 @@ internal class CBPeripheralCoreBluetoothPeripheral(
         cbPeripheral.identifier.UUIDString,
     )
 
+    override suspend fun openL2CapChannel(psm: Int): L2CapSocket {
+        require(psm in 0..UShort.MAX_VALUE.toInt()) { "psm $psm is outside the valid range 0..65535" }
+        return connectionOrThrow().openL2CapChannel(psm.toUShort())
+    }
+
     override fun close() {
         scope.cancel("$this closed")
     }

--- a/kable-core/src/appleMain/kotlin/Connection.kt
+++ b/kable-core/src/appleMain/kotlin/Connection.kt
@@ -8,6 +8,7 @@ import com.juul.kable.State.Disconnected
 import com.juul.kable.coroutines.childSupervisor
 import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -167,6 +169,72 @@ internal class Connection(
             ?: throw InternalError(
                 "Expected response type ${type.simpleName} but received ${response::class.simpleName}",
             )
+    }
+
+    // Not routed through `execute`: CoreBluetooth's `didOpenL2CAPChannel` carries no PSM, so it cannot be
+    // correlated to a request — the only safe model is one open at a time. `guard` provides that (shared
+    // with every other operation), and unlike `execute` this holds the guard until the callback is
+    // consumed even when the caller is cancelled, so a late channel is always torn down here rather than
+    // leaking or being misdelivered to the next open.
+    internal suspend fun openL2CapChannel(psm: UShort): L2CapSocket = guard.withLock {
+        val pending = delegate.beginL2CapOpen()
+        var executed = false
+        try {
+            withContext(dispatcher) {
+                peripheral.openL2CAPChannel(psm)
+                executed = true
+            }
+        } catch (e: CancellationException) {
+            if (executed) {
+                abandonL2CapChannelWhenDelivered(pending)
+            } else {
+                delegate.cancelL2CapOpen(pending, e.unwrapCancellationException())
+            }
+            throw e.unwrapCancellationException()
+        } catch (e: Throwable) {
+            delegate.cancelL2CapOpen(pending, e)
+            throw e
+        }
+
+        val result = try {
+            withContext(NonCancellable) { pending.await() }
+        } catch (e: Throwable) {
+            coroutineContext.ensureActive()
+            throw e
+        }
+
+        // Cancelled while awaiting the (uncancellable) callback: the channel arrived but has no owner.
+        // abandon(), not close(): close()'s deterministic collection is futile here, because this very
+        // frame still pins the channel (via `pending`/`result`) until it dies — the channel can only be
+        // collected after this function has thrown, which abandon()'s teardown-then-GC.schedule() allows.
+        if (!coroutineContext.isActive) {
+            result.channel?.let { AppleL2CapSocket(it).abandon() }
+            coroutineContext.ensureActive()
+        }
+
+        buildL2CapSocket(result)
+    }
+
+    private suspend fun abandonL2CapChannelWhenDelivered(
+        pending: CompletableDeferred<PeripheralDelegate.L2CapOpenResult>,
+    ) {
+        // abandon(), not close(): the caller's frame keeps `pending` (and through it the channel)
+        // reachable until the open throws, so a collection forced here cannot release the channel —
+        // abandon() tears down and GC.schedule()s, letting the release happen once the frame is gone.
+        val result = withContext(NonCancellable) { runCatching { pending.await() }.getOrNull() }
+        result?.channel?.let { AppleL2CapSocket(it).abandon() }
+    }
+
+    private fun buildL2CapSocket(result: PeripheralDelegate.L2CapOpenResult): L2CapSocket {
+        result.error?.let { error ->
+            // A failure should carry no channel, but abandon one if CoreBluetooth ever delivers both.
+            result.channel?.let { AppleL2CapSocket(it).abandon() }
+            // NSError.code is a 32-bit NSInteger on watchosArm64, so widen explicitly.
+            throw L2CapException(error.description, code = error.code.toLong())
+        }
+        val channel = result.channel
+            ?: throw L2CapException("couldn't open L2CAP channel", code = 0)
+        return AppleL2CapSocket(channel)
     }
 
     private suspend fun disconnect() {

--- a/kable-core/src/appleMain/kotlin/Connection.kt
+++ b/kable-core/src/appleMain/kotlin/Connection.kt
@@ -171,11 +171,9 @@ internal class Connection(
             )
     }
 
-    // Not routed through `execute`: CoreBluetooth's `didOpenL2CAPChannel` carries no PSM, so it cannot be
-    // correlated to a request — the only safe model is one open at a time. `guard` provides that (shared
-    // with every other operation), and unlike `execute` this holds the guard until the callback is
-    // consumed even when the caller is cancelled, so a late channel is always torn down here rather than
-    // leaking or being misdelivered to the next open.
+    // `didOpenL2CAPChannel` carries no PSM, so only one open can be in flight at a time. The guard is
+    // held until the callback arrives, even if the caller is cancelled, so a late channel is closed
+    // here rather than delivered to the next open.
     internal suspend fun openL2CapChannel(psm: UShort): L2CapSocket = guard.withLock {
         val pending = delegate.beginL2CapOpen()
         var executed = false
@@ -186,7 +184,7 @@ internal class Connection(
             }
         } catch (e: CancellationException) {
             if (executed) {
-                abandonL2CapChannelWhenDelivered(pending)
+                disposeL2CapChannelWhenDelivered(pending)
             } else {
                 delegate.cancelL2CapOpen(pending, e.unwrapCancellationException())
             }
@@ -203,37 +201,28 @@ internal class Connection(
             throw e
         }
 
-        // Cancelled while awaiting the (uncancellable) callback: the channel arrived but has no owner.
-        // abandon(), not close(): close()'s deterministic collection is futile here, because this very
-        // frame still pins the channel (via `pending`/`result`) until it dies — the channel can only be
-        // collected after this function has thrown, which abandon()'s teardown-then-GC.schedule() allows.
         if (!coroutineContext.isActive) {
-            result.channel?.let { AppleL2CapSocket(it).abandon() }
+            result.channel?.let { AppleL2CapSocket(it).dispose() }
             coroutineContext.ensureActive()
         }
 
         buildL2CapSocket(result)
     }
 
-    private suspend fun abandonL2CapChannelWhenDelivered(
+    private suspend fun disposeL2CapChannelWhenDelivered(
         pending: CompletableDeferred<PeripheralDelegate.L2CapOpenResult>,
     ) {
-        // abandon(), not close(): the caller's frame keeps `pending` (and through it the channel)
-        // reachable until the open throws, so a collection forced here cannot release the channel —
-        // abandon() tears down and GC.schedule()s, letting the release happen once the frame is gone.
         val result = withContext(NonCancellable) { runCatching { pending.await() }.getOrNull() }
-        result?.channel?.let { AppleL2CapSocket(it).abandon() }
+        result?.channel?.let { AppleL2CapSocket(it).dispose() }
     }
 
     private fun buildL2CapSocket(result: PeripheralDelegate.L2CapOpenResult): L2CapSocket {
         result.error?.let { error ->
-            // A failure should carry no channel, but abandon one if CoreBluetooth ever delivers both.
-            result.channel?.let { AppleL2CapSocket(it).abandon() }
-            // NSError.code is a 32-bit NSInteger on watchosArm64, so widen explicitly.
+            result.channel?.let { AppleL2CapSocket(it).dispose() }
             throw L2CapException(error.description, code = error.code.toLong())
         }
         val channel = result.channel
-            ?: throw L2CapException("couldn't open L2CAP channel", code = 0)
+            ?: throw L2CapException("couldn't open L2CAP channel")
         return AppleL2CapSocket(channel)
     }
 

--- a/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
@@ -31,4 +31,19 @@ public interface CoreBluetoothPeripheral : Peripheral {
 
     @Throws(CancellationException::class, IOException::class)
     public suspend fun readAsNSData(characteristic: Characteristic): NSData
+
+    /**
+     * Opens an L2CAP channel to the peripheral on the given [psm], suspending until CoreBluetooth
+     * reports the channel open. The returned [L2CapSocket] is already connected.
+     *
+     * The operating system may briefly report the [psm] as still connected ("L2CAP PSM already
+     * connected") when reopening shortly after a previous socket was closed — the disconnect handshake
+     * is asynchronous — or after a cancelled open. Callers reopening the same [psm] should be prepared
+     * to retry.
+     *
+     * @see platform.CoreBluetooth.CBPeripheral.openL2CAPChannel
+     * @throws L2CapException if the channel could not be opened.
+     */
+    @Throws(CancellationException::class, IOException::class)
+    public suspend fun openL2CapChannel(psm: Int): L2CapSocket
 }

--- a/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
+++ b/kable-core/src/appleMain/kotlin/CoreBluetoothPeripheral.kt
@@ -36,10 +36,9 @@ public interface CoreBluetoothPeripheral : Peripheral {
      * Opens an L2CAP channel to the peripheral on the given [psm], suspending until CoreBluetooth
      * reports the channel open. The returned [L2CapSocket] is already connected.
      *
-     * The operating system may briefly report the [psm] as still connected ("L2CAP PSM already
-     * connected") when reopening shortly after a previous socket was closed — the disconnect handshake
-     * is asynchronous — or after a cancelled open. Callers reopening the same [psm] should be prepared
-     * to retry.
+     * Reopening a [psm] shortly after its previous socket was closed can fail with an [L2CapException]
+     * ("L2CAP PSM already connected") while CoreBluetooth is still tearing the old channel down.
+     * Callers may retry.
      *
      * @see platform.CoreBluetooth.CBPeripheral.openL2CAPChannel
      * @throws L2CapException if the channel could not be opened.

--- a/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -10,7 +10,10 @@ import com.juul.kable.logs.Logger
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.Logging.DataProcessor.Operation.Change
 import com.juul.kable.logs.detail
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.cinterop.ObjCSignatureOverride
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -93,6 +96,39 @@ internal class PeripheralDelegate(
     val response: ReceiveChannel<Response> = _response
 
     val onServiceChanged = Channel<OnServiceChanged>(CONFLATED)
+
+    // Single-flight state for an in-progress `openL2CAPChannel`. CoreBluetooth's `didOpenL2CAPChannel`
+    // callback carries no PSM (and none at all on failure), so it cannot be correlated to a specific
+    // request; the caller (Connection.openL2CapChannel) instead holds a mutex so only one open is ever
+    // outstanding, and this single slot delivers that open's result. The lock guards the slot against the
+    // caller thread and the CoreBluetooth callback thread racing.
+    internal data class L2CapOpenResult(
+        val channel: CBL2CAPChannel?,
+        val error: NSError?,
+    )
+
+    private val l2CapOpenLock = SynchronizedObject()
+    private var pendingL2CapOpen: CompletableDeferred<L2CapOpenResult>? = null
+
+    internal fun beginL2CapOpen(): CompletableDeferred<L2CapOpenResult> =
+        synchronized(l2CapOpenLock) {
+            check(pendingL2CapOpen == null) { "An L2CAP open is already in progress" }
+            CompletableDeferred<L2CapOpenResult>().also { pendingL2CapOpen = it }
+        }
+
+    internal fun cancelL2CapOpen(pending: CompletableDeferred<L2CapOpenResult>, cause: Throwable) {
+        val cleared = synchronized(l2CapOpenLock) {
+            (pendingL2CapOpen === pending).also { if (it) pendingL2CapOpen = null }
+        }
+        if (cleared) pending.completeExceptionally(cause)
+    }
+
+    private fun completeL2CapOpen(result: L2CapOpenResult): Boolean {
+        val pending = synchronized(l2CapOpenLock) {
+            pendingL2CapOpen.also { pendingL2CapOpen = null }
+        }
+        return pending?.complete(result) == true
+    }
 
     private val logger = Logger(logging, tag = "Kable/Delegate", identifier = identifier)
 
@@ -317,13 +353,35 @@ internal class PeripheralDelegate(
         logger.debug(error) {
             message = "didOpenL2CAPChannel"
         }
-        // todo
+        val delivered = completeL2CapOpen(L2CapOpenResult(didOpenL2CAPChannel, error))
+        if (!delivered) {
+            // No waiter — the opening caller was already cancelled/disconnected. A channel handed over now
+            // has no owner, so tear it down rather than leak it (its streams would otherwise stay open).
+            didOpenL2CAPChannel?.let { AppleL2CapSocket(it).abandon() }
+            logger.warn { message = "Discarded unexpected didOpenL2CAPChannel callback" }
+            return
+        }
+        if (error == null && didOpenL2CAPChannel != null) {
+            logger.info {
+                message = "L2CAP channel open. Peer: ${didOpenL2CAPChannel.peer?.identifier}"
+            }
+        }
     }
 
     fun close(cause: Throwable?) {
+        // Fail an L2CAP open still in flight when the peripheral disconnects, otherwise its caller stays
+        // suspended forever — CoreBluetooth never delivers didOpenL2CAPChannel for a dropped connection.
+        cancelL2CapOpenInFlight(NotConnectedException(cause = cause))
         _response.close(NotConnectedException(cause = cause))
         characteristicChanges.emitBlocking(ObservationEvent.Disconnected)
         canSendWriteWithoutResponse.value = true
+    }
+
+    private fun cancelL2CapOpenInFlight(cause: Throwable) {
+        val pending = synchronized(l2CapOpenLock) {
+            pendingL2CapOpen.also { pendingL2CapOpen = null }
+        }
+        pending?.completeExceptionally(cause)
     }
 }
 

--- a/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
+++ b/kable-core/src/appleMain/kotlin/PeripheralDelegate.kt
@@ -97,11 +97,6 @@ internal class PeripheralDelegate(
 
     val onServiceChanged = Channel<OnServiceChanged>(CONFLATED)
 
-    // Single-flight state for an in-progress `openL2CAPChannel`. CoreBluetooth's `didOpenL2CAPChannel`
-    // callback carries no PSM (and none at all on failure), so it cannot be correlated to a specific
-    // request; the caller (Connection.openL2CapChannel) instead holds a mutex so only one open is ever
-    // outstanding, and this single slot delivers that open's result. The lock guards the slot against the
-    // caller thread and the CoreBluetooth callback thread racing.
     internal data class L2CapOpenResult(
         val channel: CBL2CAPChannel?,
         val error: NSError?,
@@ -355,9 +350,7 @@ internal class PeripheralDelegate(
         }
         val delivered = completeL2CapOpen(L2CapOpenResult(didOpenL2CAPChannel, error))
         if (!delivered) {
-            // No waiter — the opening caller was already cancelled/disconnected. A channel handed over now
-            // has no owner, so tear it down rather than leak it (its streams would otherwise stay open).
-            didOpenL2CAPChannel?.let { AppleL2CapSocket(it).abandon() }
+            didOpenL2CAPChannel?.let { AppleL2CapSocket(it).dispose() }
             logger.warn { message = "Discarded unexpected didOpenL2CAPChannel callback" }
             return
         }
@@ -369,8 +362,6 @@ internal class PeripheralDelegate(
     }
 
     fun close(cause: Throwable?) {
-        // Fail an L2CAP open still in flight when the peripheral disconnects, otherwise its caller stays
-        // suspended forever — CoreBluetooth never delivers didOpenL2CAPChannel for a dropped connection.
         cancelL2CapOpenInFlight(NotConnectedException(cause = cause))
         _response.close(NotConnectedException(cause = cause))
         characteristicChanges.emitBlocking(ObservationEvent.Disconnected)

--- a/kable-core/src/appleTest/kotlin/AppleL2CapSocketTests.kt
+++ b/kable-core/src/appleTest/kotlin/AppleL2CapSocketTests.kt
@@ -1,0 +1,155 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.juul.kable
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import platform.CoreBluetooth.CBL2CAPChannel
+import platform.CoreFoundation.CFReadStreamRefVar
+import platform.CoreFoundation.CFStreamCreateBoundPair
+import platform.CoreFoundation.CFWriteStreamRefVar
+import platform.Foundation.CFBridgingRelease
+import platform.Foundation.NSInputStream
+import platform.Foundation.NSOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+// An in-memory stand-in for the peer: data written to [output] becomes available on [input].
+// CFStreamCreateBoundPair because NSStream's bound-pair factory lives in a category the
+// Kotlin/Native bindings do not expose; the CF streams toll-free bridge to NSStreams.
+private class BoundStreamPair(bufferSize: Int) {
+    val input: NSInputStream
+    val output: NSOutputStream
+
+    init {
+        memScoped {
+            val readVar = alloc<CFReadStreamRefVar>()
+            val writeVar = alloc<CFWriteStreamRefVar>()
+            CFStreamCreateBoundPair(null, readVar.ptr, writeVar.ptr, bufferSize.convert())
+            input = CFBridgingRelease(readVar.value) as NSInputStream
+            output = CFBridgingRelease(writeVar.value) as NSOutputStream
+        }
+    }
+}
+
+// Holds both entire bound pairs — not just the socket-side ends — so the socket's retained
+// channel keeps the peer-side stream ends alive too. A peer-side end collected mid-test (the
+// Kotlin/Native GC is free to reclaim a local after its last use) deallocates half of a bound
+// pair, which CFStream reports to the surviving half as end-of-stream.
+private class FakeL2CapChannel(
+    private val toSocket: BoundStreamPair,
+    private val fromSocket: BoundStreamPair,
+) : CBL2CAPChannel() {
+    override fun inputStream(): NSInputStream? = toSocket.input
+    override fun outputStream(): NSOutputStream? = fromSocket.output
+}
+
+// Test-side handle on the socket's inbound traffic. [bufferSize] must exceed the total a test
+// sends without concurrent draining, as [send] fails rather than block on a full buffer.
+private class Peer(bufferSize: Int = 256 * 1024) {
+    private val toSocket = BoundStreamPair(bufferSize)
+    private val fromSocket = BoundStreamPair(bufferSize)
+
+    val channel = FakeL2CapChannel(toSocket, fromSocket)
+
+    init {
+        toSocket.output.open()
+    }
+
+    fun send(bytes: ByteArray) {
+        var offset = 0
+        while (offset < bytes.size) {
+            val written = bytes.usePinned { pinned ->
+                toSocket.output.write(pinned.addressOf(offset).reinterpret(), (bytes.size - offset).convert())
+            }.toLong()
+            check(written > 0L) { "Peer send failed: $written" }
+            offset += written.toInt()
+        }
+    }
+
+    fun endOfStream() {
+        toSocket.output.close()
+    }
+}
+
+class AppleL2CapSocketTests {
+
+    // The contract under test: cancelling read() never loses nor reorders data — a chunk orphaned
+    // by cancellation (won after the chunk left the internal channel) must be returned by the next
+    // read(). Cancellation racing delivery is inherently timing-dependent, so this hammers the race
+    // and asserts the invariant that holds regardless of which side wins each round.
+    @Test
+    fun cancelledReads_loseNoData() = runBlocking {
+        val total = 128 * 1024
+        val sent = ByteArray(total) { (it % 251).toByte() }
+        val peer = Peer()
+        val socket = AppleL2CapSocket(peer.channel)
+        try {
+            val sender = launch(Dispatchers.Default) {
+                var offset = 0
+                while (offset < total) {
+                    val burst = minOf(1024, total - offset)
+                    peer.send(sent.copyOfRange(offset, offset + burst))
+                    offset += burst
+                    delay(1)
+                }
+            }
+            val received = ByteArray(total)
+            var receivedCount = 0
+            withTimeout(30.seconds) {
+                // Reader and this loop share runBlocking's single thread, so receivedCount is
+                // not touched concurrently.
+                while (receivedCount < total) {
+                    val reader = launch {
+                        while (receivedCount < total) {
+                            val chunk = socket.read() ?: error("Unexpected end of stream")
+                            chunk.copyInto(received, receivedCount)
+                            receivedCount += chunk.size
+                        }
+                    }
+                    delay(2)
+                    reader.cancelAndJoin()
+                }
+                sender.join()
+            }
+            assertContentEquals(sent, received)
+        } finally {
+            socket.close()
+        }
+    }
+
+    @Test
+    fun read_afterEndOfStream_returnsNullAndStaysNull() = runBlocking {
+        val peer = Peer()
+        val socket = AppleL2CapSocket(peer.channel)
+        try {
+            val sent = byteArrayOf(6, 7, 8)
+            peer.send(sent)
+            peer.endOfStream()
+            // Data sent before end-of-stream is still delivered ahead of the null.
+            val received = withTimeout(5.seconds) { socket.read() }
+            assertContentEquals(sent, received)
+            assertNull(withTimeout(5.seconds) { socket.read() })
+            assertNull(withTimeout(5.seconds) { socket.read() })
+            assertFalse(socket.isConnected.value)
+        } finally {
+            socket.close()
+        }
+    }
+}

--- a/kable-core/src/appleTest/kotlin/AppleL2CapSocketTests.kt
+++ b/kable-core/src/appleTest/kotlin/AppleL2CapSocketTests.kt
@@ -11,12 +11,9 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.value
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import platform.CoreBluetooth.CBL2CAPChannel
 import platform.CoreFoundation.CFReadStreamRefVar
 import platform.CoreFoundation.CFStreamCreateBoundPair
@@ -27,12 +24,8 @@ import platform.Foundation.NSOutputStream
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.seconds
 
-// An in-memory stand-in for the peer: data written to [output] becomes available on [input].
-// CFStreamCreateBoundPair because NSStream's bound-pair factory lives in a category the
-// Kotlin/Native bindings do not expose; the CF streams toll-free bridge to NSStreams.
 private class BoundStreamPair(bufferSize: Int) {
     val input: NSInputStream
     val output: NSOutputStream
@@ -48,10 +41,7 @@ private class BoundStreamPair(bufferSize: Int) {
     }
 }
 
-// Holds both entire bound pairs — not just the socket-side ends — so the socket's retained
-// channel keeps the peer-side stream ends alive too. A peer-side end collected mid-test (the
-// Kotlin/Native GC is free to reclaim a local after its last use) deallocates half of a bound
-// pair, which CFStream reports to the surviving half as end-of-stream.
+// Holds both pairs, so the peer side stays alive as long as the channel does.
 private class FakeL2CapChannel(
     private val toSocket: BoundStreamPair,
     private val fromSocket: BoundStreamPair,
@@ -60,8 +50,6 @@ private class FakeL2CapChannel(
     override fun outputStream(): NSOutputStream? = fromSocket.output
 }
 
-// Test-side handle on the socket's inbound traffic. [bufferSize] must exceed the total a test
-// sends without concurrent draining, as [send] fails rather than block on a full buffer.
 private class Peer(bufferSize: Int = 256 * 1024) {
     private val toSocket = BoundStreamPair(bufferSize)
     private val fromSocket = BoundStreamPair(bufferSize)
@@ -90,64 +78,31 @@ private class Peer(bufferSize: Int = 256 * 1024) {
 
 class AppleL2CapSocketTests {
 
-    // The contract under test: cancelling read() never loses nor reorders data — a chunk orphaned
-    // by cancellation (won after the chunk left the internal channel) must be returned by the next
-    // read(). Cancellation racing delivery is inherently timing-dependent, so this hammers the race
-    // and asserts the invariant that holds regardless of which side wins each round.
     @Test
-    fun cancelledReads_loseNoData() = runBlocking {
-        val total = 128 * 1024
-        val sent = ByteArray(total) { (it % 251).toByte() }
-        val peer = Peer()
-        val socket = AppleL2CapSocket(peer.channel)
-        try {
-            val sender = launch(Dispatchers.Default) {
-                var offset = 0
-                while (offset < total) {
-                    val burst = minOf(1024, total - offset)
-                    peer.send(sent.copyOfRange(offset, offset + burst))
-                    offset += burst
-                    delay(1)
-                }
-            }
-            val received = ByteArray(total)
-            var receivedCount = 0
-            withTimeout(30.seconds) {
-                // Reader and this loop share runBlocking's single thread, so receivedCount is
-                // not touched concurrently.
-                while (receivedCount < total) {
-                    val reader = launch {
-                        while (receivedCount < total) {
-                            val chunk = socket.read() ?: error("Unexpected end of stream")
-                            chunk.copyInto(received, receivedCount)
-                            receivedCount += chunk.size
-                        }
-                    }
-                    delay(2)
-                    reader.cancelAndJoin()
-                }
-                sender.join()
-            }
-            assertContentEquals(sent, received)
-        } finally {
-            socket.close()
-        }
-    }
-
-    @Test
-    fun read_afterEndOfStream_returnsNullAndStaysNull() = runBlocking {
+    fun incoming_deliversDataThenCompletesAtEndOfStream() = runTest(timeout = 5.seconds) {
         val peer = Peer()
         val socket = AppleL2CapSocket(peer.channel)
         try {
             val sent = byteArrayOf(6, 7, 8)
             peer.send(sent)
             peer.endOfStream()
-            // Data sent before end-of-stream is still delivered ahead of the null.
-            val received = withTimeout(5.seconds) { socket.read() }
+            val received = socket.incoming.toList().reduce(ByteArray::plus)
             assertContentEquals(sent, received)
-            assertNull(withTimeout(5.seconds) { socket.read() })
-            assertNull(withTimeout(5.seconds) { socket.read() })
             assertFalse(socket.isConnected.value)
+        } finally {
+            socket.close()
+        }
+    }
+
+    @Test
+    fun incoming_collectedAgain_continuesWhereItLeftOff() = runTest(timeout = 5.seconds) {
+        val peer = Peer()
+        val socket = AppleL2CapSocket(peer.channel)
+        try {
+            peer.send(byteArrayOf(1))
+            assertContentEquals(byteArrayOf(1), socket.incoming.first())
+            peer.send(byteArrayOf(2))
+            assertContentEquals(byteArrayOf(2), socket.incoming.first())
         } finally {
             socket.close()
         }

--- a/kable-core/src/commonMain/kotlin/L2CapException.kt
+++ b/kable-core/src/commonMain/kotlin/L2CapException.kt
@@ -1,0 +1,14 @@
+package com.juul.kable
+
+import kotlinx.io.IOException
+
+/** Represents a failure while opening or communicating over an [L2CapSocket]. */
+public class L2CapException(
+    message: String? = null,
+    cause: Throwable? = null,
+    /**
+     * Platform error code associated with the failure: `BluetoothSocketException.errorCode` on Android
+     * (API 34+), `NSError.code` on Apple platforms, or `0` when no code is available.
+     */
+    public val code: Long,
+) : IOException(message, cause)

--- a/kable-core/src/commonMain/kotlin/L2CapException.kt
+++ b/kable-core/src/commonMain/kotlin/L2CapException.kt
@@ -2,13 +2,13 @@ package com.juul.kable
 
 import kotlinx.io.IOException
 
-/** Represents a failure while opening or communicating over an [L2CapSocket]. */
+/** A failure while opening or communicating over an [L2CapSocket]. */
 public class L2CapException(
     message: String? = null,
     cause: Throwable? = null,
     /**
-     * Platform error code associated with the failure: `BluetoothSocketException.errorCode` on Android
-     * (API 34+), `NSError.code` on Apple platforms, or `0` when no code is available.
+     * Platform error code, if any: `BluetoothSocketException.errorCode` on Android (API 34+) or
+     * `NSError.code` on Apple platforms.
      */
-    public val code: Long,
+    public val code: Long? = null,
 ) : IOException(message, cause)

--- a/kable-core/src/commonMain/kotlin/L2CapSocket.kt
+++ b/kable-core/src/commonMain/kotlin/L2CapSocket.kt
@@ -1,0 +1,57 @@
+package com.juul.kable
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * A connection-oriented L2CAP channel (CoC) to a connected [Peripheral].
+ *
+ * Obtain a socket from a platform-specific peripheral — [AndroidPeripheral.openL2CapChannel] /
+ * [AndroidPeripheral.openInsecureL2CapChannel] on Android, or [CoreBluetoothPeripheral.openL2CapChannel]
+ * on Apple platforms. The returned socket is already open and ready for I/O.
+ *
+ * Unlike GATT's message-based characteristics, an L2CAP channel is a bidirectional byte stream: it
+ * imposes no message boundaries, so callers are responsible for framing their own protocol.
+ *
+ * [read] is expected to be called from a single coroutine at a time; [write] may be called concurrently
+ * with [read].
+ */
+public interface L2CapSocket {
+
+    /**
+     * Whether the socket is currently open for reading and writing. Becomes `false` once the socket is
+     * [closed][close], or when the channel reaches end-of-stream or fails.
+     */
+    public val isConnected: StateFlow<Boolean>
+
+    /**
+     * Whether the read side has reached end-of-stream. Once `true`, [read] returns `-1` and no further
+     * data will arrive.
+     */
+    public val hasReachedEof: StateFlow<Boolean>
+
+    /**
+     * Reads bytes from the channel into [buffer]. Suspends until at least one byte is available,
+     * end-of-stream is reached, or an error occurs.
+     *
+     * @return the number of bytes read into [buffer] (at least `1`), `0` if [buffer] is empty, or `-1`
+     * once end-of-stream has been reached.
+     * @throws L2CapException if the channel fails while reading.
+     */
+    @Throws(CancellationException::class, IOException::class)
+    public suspend fun read(buffer: ByteArray): Int
+
+    /**
+     * Writes the entirety of [packet] to the channel, suspending until it has all been handed off to the
+     * operating system. A no-op if [packet] is empty.
+     *
+     * @throws L2CapException if the channel is closed or fails while writing.
+     */
+    @Throws(CancellationException::class, IOException::class)
+    public suspend fun write(packet: ByteArray)
+
+    /** Closes the channel and releases its resources, suspending until teardown is complete. */
+    @Throws(CancellationException::class, IOException::class)
+    public suspend fun close()
+}

--- a/kable-core/src/commonMain/kotlin/L2CapSocket.kt
+++ b/kable-core/src/commonMain/kotlin/L2CapSocket.kt
@@ -2,62 +2,37 @@ package com.juul.kable
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * A connection-oriented L2CAP channel (CoC) to a connected [Peripheral].
+ * A connection-oriented L2CAP channel (CoC) to a connected [Peripheral], opened with
+ * [AndroidPeripheral.openL2CapChannel], [AndroidPeripheral.openInsecureL2CapChannel] or
+ * [CoreBluetoothPeripheral.openL2CapChannel].
  *
- * Obtain a socket from a platform-specific peripheral — [AndroidPeripheral.openL2CapChannel] /
- * [AndroidPeripheral.openInsecureL2CapChannel] on Android, or [CoreBluetoothPeripheral.openL2CapChannel]
- * on Apple platforms. The returned socket is already open and ready for I/O.
- *
- * Unlike GATT's message-based characteristics, an L2CAP channel is a bidirectional byte stream: it
- * imposes no message boundaries, so callers are responsible for framing their own protocol. In
- * particular, the chunks returned by [read] are arbitrary runs of bytes — their sizes carry no meaning.
- *
- * [read] is expected to be called from a single coroutine at a time; [write] may be called concurrently
- * with [read].
+ * A channel is a byte stream with no message boundaries, so callers must frame their own protocol.
  */
 public interface L2CapSocket {
 
-    /**
-     * Whether the socket is currently open for reading and writing. Becomes `false` once the socket is
-     * [closed][close], or when the channel reaches end-of-stream or fails.
-     */
+    /** Whether the channel is open. Becomes `false` once [closed][close], at end of stream, or on failure. */
     public val isConnected: StateFlow<Boolean>
 
     /**
-     * Reads the next chunk of bytes from the channel. Suspends until at least one byte is available,
-     * end-of-stream is reached, or an error occurs. The returned array is freshly allocated and owned by
-     * the caller. Cancelling a read does not lose data: a chunk already being read is returned by the
-     * next call.
-     *
-     * @return the next chunk (at least one byte), or `null` once end-of-stream has been reached.
-     * @throws L2CapException if the channel fails while reading.
+     * Bytes received over the channel, in chunks of arbitrary size. Completes at end of stream and
+     * throws [L2CapException] if the channel fails. Each chunk is delivered to a single collector.
      */
-    @Throws(CancellationException::class, IOException::class)
-    public suspend fun read(): ByteArray?
+    public val incoming: Flow<ByteArray>
 
     /**
-     * Writes the entirety of [packet] to the channel, suspending until it has all been handed off to the
-     * operating system. A no-op if [packet] is empty.
+     * Writes all of [packet] to the channel.
      *
+     * @throws IllegalArgumentException if [packet] is empty.
      * @throws L2CapException if the channel is closed or fails while writing.
      */
     @Throws(CancellationException::class, IOException::class)
     public suspend fun write(packet: ByteArray)
 
-    /** Closes the channel and releases its resources, suspending until teardown is complete. */
+    /** Closes the channel, suspending until it is fully torn down. */
     @Throws(CancellationException::class, IOException::class)
     public suspend fun close()
-}
-
-/**
- * The channel's incoming bytes as a cold [Flow] of chunks, completing at end-of-stream. Collection
- * calls [read], so collect from at most one coroutine and do not call [read] while collecting.
- */
-public fun L2CapSocket.incoming(): Flow<ByteArray> = flow {
-    while (true) emit(read() ?: break)
 }

--- a/kable-core/src/commonMain/kotlin/L2CapSocket.kt
+++ b/kable-core/src/commonMain/kotlin/L2CapSocket.kt
@@ -1,6 +1,8 @@
 package com.juul.kable
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -12,7 +14,8 @@ import kotlin.coroutines.cancellation.CancellationException
  * on Apple platforms. The returned socket is already open and ready for I/O.
  *
  * Unlike GATT's message-based characteristics, an L2CAP channel is a bidirectional byte stream: it
- * imposes no message boundaries, so callers are responsible for framing their own protocol.
+ * imposes no message boundaries, so callers are responsible for framing their own protocol. In
+ * particular, the chunks returned by [read] are arbitrary runs of bytes — their sizes carry no meaning.
  *
  * [read] is expected to be called from a single coroutine at a time; [write] may be called concurrently
  * with [read].
@@ -26,21 +29,16 @@ public interface L2CapSocket {
     public val isConnected: StateFlow<Boolean>
 
     /**
-     * Whether the read side has reached end-of-stream. Once `true`, [read] returns `-1` and no further
-     * data will arrive.
-     */
-    public val hasReachedEof: StateFlow<Boolean>
-
-    /**
-     * Reads bytes from the channel into [buffer]. Suspends until at least one byte is available,
-     * end-of-stream is reached, or an error occurs.
+     * Reads the next chunk of bytes from the channel. Suspends until at least one byte is available,
+     * end-of-stream is reached, or an error occurs. The returned array is freshly allocated and owned by
+     * the caller. Cancelling a read does not lose data: a chunk already being read is returned by the
+     * next call.
      *
-     * @return the number of bytes read into [buffer] (at least `1`), `0` if [buffer] is empty, or `-1`
-     * once end-of-stream has been reached.
+     * @return the next chunk (at least one byte), or `null` once end-of-stream has been reached.
      * @throws L2CapException if the channel fails while reading.
      */
     @Throws(CancellationException::class, IOException::class)
-    public suspend fun read(buffer: ByteArray): Int
+    public suspend fun read(): ByteArray?
 
     /**
      * Writes the entirety of [packet] to the channel, suspending until it has all been handed off to the
@@ -54,4 +52,12 @@ public interface L2CapSocket {
     /** Closes the channel and releases its resources, suspending until teardown is complete. */
     @Throws(CancellationException::class, IOException::class)
     public suspend fun close()
+}
+
+/**
+ * The channel's incoming bytes as a cold [Flow] of chunks, completing at end-of-stream. Collection
+ * calls [read], so collect from at most one coroutine and do not call [read] while collecting.
+ */
+public fun L2CapSocket.incoming(): Flow<ByteArray> = flow {
+    while (true) emit(read() ?: break)
 }


### PR DESCRIPTION
Adapted from #1023, and completing the implementation for both iOS and Android. Tested on both platforms with real devices, and also from macOS to iOS. 

Adds `L2CapSocket`, a connection-oriented channel opened from a connected peripheral: `AndroidPeripheral.openL2CapChannel` / `openInsecureL2CapChannel` and `CoreBluetoothPeripheral.openL2CapChannel`. The socket is a bidirectional byte stream (`read` into a buffer, `write` a packet, `close`) exposing `isConnected` / `hasReachedEof` state; failures surface as `L2CapException`.

Android wraps `BluetoothDevice.createL2capChannel`, connecting on `Dispatchers.IO`. Apple confines the `CBL2CAPChannel` NSStreams to a single dedicated run-loop thread (they are not safe to drive from a rotating dispatcher pool) and serializes opens through the connection's guard, since CoreBluetooth's `didOpenL2CAPChannel` callback carries no PSM and so cannot be correlated to a request; a channel delivered to a cancelled or disconnected open is torn down rather than leaked.

Closes #810 #588 #1023.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New BLE transport path with non-trivial lifecycle (cancellation, single in-flight Apple opens, dedicated run-loop threading), but changes are additive and isolated from existing GATT APIs.
> 
> **Overview**
> Adds **L2CAP CoC** as a bidirectional byte stream alongside GATT, with a shared **`L2CapSocket`** API (`incoming` `Flow`, suspend `write`/`close`, `isConnected`) and **`L2CapException`** for open/I/O failures.
> 
> **Android (API 29+):** `AndroidPeripheral` gains `openL2CapChannel` and `openInsecureL2CapChannel`, connecting via `BluetoothSocket` on IO and wrapping **`AndroidL2CapSocket`** (back-pressure-friendly unbuffered reads).
> 
> **Apple:** `CoreBluetoothPeripheral.openL2CapChannel` routes through **`Connection.openL2CapChannel`**, which serializes opens under the connection mutex because `didOpenL2CAPChannel` has no PSM; **`PeripheralDelegate`** now completes pending opens and disposes stray channels on cancel/disconnect. **`AppleL2CapSocket`** drives `CBL2CAPChannel` streams on a dedicated run-loop thread.
> 
> README documents usage; JVM `.api` is updated; Robolectric and Apple unit tests cover read pacing, EOF, errors, and close behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f6ae150fe6d7c5ef958b597f7e5275908ffa56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->