### PR TITLE
Simplify Dokka configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
           tar
           --verbose
           --dereference --hard-dereference
-          --directory build/dokkaHtmlMultiModule
+          --directory build/dokka/html
           --create --file '${{ runner.temp }}/artifact.tar'
           --exclude=.git
           --exclude=.github

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,15 +15,9 @@ plugins {
     alias(libs.plugins.maven.publish) apply false
 }
 
-dokka {
-    dokkaPublications.html {
-        outputDirectory.set(layout.buildDirectory.dir("dokkaHtmlMultiModule"))
-    }
-}
-
 dependencies {
-    dokka(project(":kable-core"))
-    dokka(project(":kable-log-engine-khronicle"))
+    dokka(project("kable-core"))
+    dokka(project("kable-log-engine-khronicle"))
 }
 
 apiValidation {

--- a/kable-core/src/androidMain/kotlin/Connection.kt
+++ b/kable-core/src/androidMain/kotlin/Connection.kt
@@ -53,9 +53,9 @@ private val GattSuccess = GattStatus(GATT_SUCCESS)
  * To disconnect: simply call [disconnect] ([Connection] will be implicitly [closed][close] at the
  * end of the [disconnect] sequence).
  *
- * If [scope], or parent [CoroutineContext] is cancelled prior to [disconnecting][disconnect], then
- * [Connection] will be abruptly [closed][close] (upon completion of [job]) without a prior
- * [disconnect] sequence.
+ * If [connectionScope], or parent [CoroutineContext] is canceled prior to
+ * [disconnecting][disconnect], then [Connection] will be abruptly [closed][close] (upon completion
+ * of [job]) without a prior [disconnect] sequence.
  */
 internal class Connection(
     parentContext: CoroutineContext,

--- a/kable-core/src/commonMain/kotlin/Peripheral.kt
+++ b/kable-core/src/commonMain/kotlin/Peripheral.kt
@@ -6,7 +6,6 @@ package com.juul.kable
 import com.juul.kable.State.Disconnecting
 import com.juul.kable.WriteType.WithoutResponse
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -14,6 +13,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmName
+import kotlin.uuid.Uuid
 
 internal typealias OnSubscriptionAction = suspend () -> Unit
 
@@ -158,7 +158,7 @@ public interface Peripheral : AutoCloseable {
      * type, so no guarantees are provided on the validity of the objects beyond a connection. If a
      * reconnect occurs, it is recommended to retrieve the desired object from [services] again. Any
      * references to objects obtained from this tree should be cleared upon [disconnect] or disposal
-     * (when [Peripheral] is [cancelled][Peripheral.cancel]).
+     * (when [Peripheral] is [cancelled][close]).
      *
      * @return [discovered services][DiscoveredService], or `null` until services have been discovered.
      */
@@ -167,7 +167,7 @@ public interface Peripheral : AutoCloseable {
     /**
      * Return the current ATT MTU size, minus the size of the ATT headers (3 bytes).
      *
-     * On Android, this will be the default (23 - 3) unless you called [requestMtu] when connecting.
+     * On Android, this will be the default (23 - 3) unless you called `requestMtu` when connecting.
      * For iOS, this is automatically negotiated, and can also vary depending on the writeType.
      * On JavaScript, this will return the default (23 - 3) every time as there is no ATT MTU property available.
      */


### PR DESCRIPTION
- Removed custom output folder for Dokka (leaning on defaults instead)
- Fixed some broken KDoc links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI packaging path only; no runtime or API behavior changes.
> 
> **Overview**
> **Dokka** no longer overrides the HTML output directory in the root `build.gradle.kts`; GitHub Pages packaging now archives **`build/dokka/html`** instead of the old **`build/dokkaHtmlMultiModule`** path.
> 
> **KDoc** updates fix broken references: Android `Connection` docs now point at **`connectionScope`** (not `scope`), and `Peripheral` docs use **`[close]`** instead of a non-existent `Peripheral.cancel`, plus inline `` `requestMtu` `` instead of a bad `[requestMtu]` link. Unused `cancel` import removed from `Peripheral.kt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53cb49de1be4c2f2e792876e20bea72929612fba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->