### PR TITLE
Downgrade `core-ktx` to v1.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ tuulbox = "8.1.0"
 voyager = "2.2.21-1.10.3"
 
 [libraries]
-androidx-core = { module = "androidx.core:core-ktx", version = "1.19.0" }
+androidx-core = { module = "androidx.core:core-ktx", version = "1.16.0" }
 androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-common", version = "2.11.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2.0" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.33.0" }

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,11 +24,12 @@
     },
   ],
   packageRules: [
-    // Pin androidx.core (core-ktx) to 1.16.0. Newer releases (1.17.0+) bump the
-    // required Android Gradle plugin version, which would force consumers onto
-    // AGP 9. See https://github.com/JuulLabs/kable/issues/1206.
+    // Pin `androidx.core:core[-ktx]` to 1.16.0. Newer releases (1.17.0+) bump the required Android
+    // Gradle plugin version, which would force consumers onto AGP 9.
+    // See https://github.com/JuulLabs/kable/issues/1206.
     {
       matchPackageNames: [
+        'androidx.core:core',
         'androidx.core:core-ktx',
       ],
       allowedVersions: '1.16.0',

--- a/renovate.json5
+++ b/renovate.json5
@@ -23,4 +23,15 @@
       extractVersionTemplate: '^(?<version>[^+]+)',
     },
   ],
+  packageRules: [
+    // Pin androidx.core (core-ktx) to 1.16.0. Newer releases (1.17.0+) bump the
+    // required Android Gradle plugin version, which would force consumers onto
+    // AGP 9. See https://github.com/JuulLabs/kable/issues/1206.
+    {
+      matchPackageNames: [
+        'androidx.core:core-ktx',
+      ],
+      allowedVersions: '1.16.0',
+    },
+  ],
 }


### PR DESCRIPTION
In combination with #1243, fixes #1206.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version catalog and Renovate config only; no auth, security, or runtime code paths affected.
> 
> **Overview**
> **Pins `androidx.core:core-ktx` at 1.16.0** so Kable consumers are not pushed onto Android Gradle Plugin 9. The version catalog entry is changed from **1.19.0 → 1.16.0**, and Renovate gets a **`packageRules`** entry that only allows **1.16.0** for that artifact (documented with a link to issue #1206).
> 
> This is dependency/tooling policy only—no application or library runtime logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c060381f8d11055ce9e98f2b4dcbdba9e1c80401. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->