### PR TITLE
Drop `tuulbox` dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ mockk = { module = "io.mockk:mockk", version = "1.14.11" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.11.0" }
 tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version = "0.5.0" }
-tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
 voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -88,7 +88,6 @@ kotlin {
             implementation(libs.androidx.core)
             implementation(libs.androidx.startup)
             implementation(libs.kotlin.parcelize.runtime)
-            implementation(libs.tuulbox.coroutines)
         }
 
         named("androidHostTest").dependencies {

--- a/kable-core/src/androidMain/kotlin/BluetoothState.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothState.kt
@@ -4,7 +4,6 @@ import android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED
 import android.bluetooth.BluetoothAdapter.ERROR
 import android.bluetooth.BluetoothAdapter.EXTRA_STATE
 import android.content.IntentFilter
-import com.juul.tuulbox.coroutines.flow.broadcastReceiverFlow
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed

--- a/kable-core/src/androidMain/kotlin/BroadcastReceiverFlow.kt
+++ b/kable-core/src/androidMain/kotlin/BroadcastReceiverFlow.kt
@@ -1,0 +1,27 @@
+package com.juul.kable
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
+import androidx.core.content.ContextCompat.RegisterReceiverFlags
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+// Copied from Tuulbox.
+// https://github.com/JuulLabs/tuulbox/blob/8.1.0/coroutines/src/androidMain/kotlin/flow/BroadcastReceiverFlow.kt
+internal fun broadcastReceiverFlow(
+    intentFilter: IntentFilter,
+    @RegisterReceiverFlags flags: Int = RECEIVER_NOT_EXPORTED,
+): Flow<Intent> = callbackFlow {
+    val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            trySend(intent)
+        }
+    }
+    ContextCompat.registerReceiver(applicationContext, broadcastReceiver, intentFilter, flags)
+    awaitClose { applicationContext.unregisterReceiver(broadcastReceiver) }
+}

--- a/samples/sensortag/bluetooth/build.gradle.kts
+++ b/samples/sensortag/bluetooth/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.compose.activity)
-            implementation(libs.tuulbox.coroutines)
         }
     }
 }


### PR DESCRIPTION
Tuulbox is transitively pulling in `core-ktx` causing undesirable version bumps (see #1206 for more details); because it is minimally used, dropping it entirely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-aligned copy of existing Tuulbox code with no auth or data-path changes; main risk is drift if the upstream helper changes.
> 
> **Overview**
> Removes the **tuulbox-coroutines** dependency from the version catalog, **kable-core**, and the sensortag Bluetooth sample to avoid transitive **core-ktx** version pressure.
> 
> Android Bluetooth state observation still uses **`broadcastReceiverFlow`**, but that helper is now an **internal** copy in **kable-core** (same `callbackFlow` + `ContextCompat.registerReceiver` with **`RECEIVER_NOT_EXPORTED`**), and **`BluetoothState.kt`** imports it from the local module instead of Tuulbox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7e88aa18acbc5fc8a098aa64af88ae8ca04521. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->