### PR TITLE
Use stdlib `toHexString`

### DIFF
--- a/kable-core/src/commonMain/kotlin/ByteArray.kt
+++ b/kable-core/src/commonMain/kotlin/ByteArray.kt
@@ -3,28 +3,6 @@ package com.juul.kable
 import com.juul.kable.Endianness.BigEndian
 import com.juul.kable.Endianness.LittleEndian
 
-/**
- * Copied from Tuulbox.
- * https://github.com/JuulLabs/tuulbox/blob/fde4eb74d2aeb37b6aaac2002bccc553adc02c5a/encoding/src/commonMain/kotlin/HexString.kt
- */
-internal fun ByteArray.toHexString(
-    separator: String? = null,
-    prefix: String? = null,
-    lowerCase: Boolean = false,
-): String {
-    if (isEmpty()) return ""
-    val hexCode = if (lowerCase) "0123456789abcdef" else "0123456789ABCDEF"
-    val capacity = size * (2 + (prefix?.length ?: 0)) + (size - 1) * (separator?.length ?: 0)
-    val r = StringBuilder(capacity)
-    for (b in this) {
-        if (separator != null && r.isNotEmpty()) r.append(separator)
-        if (prefix != null) r.append(prefix)
-        r.append(hexCode[b.toInt() shr 4 and 0xF])
-        r.append(hexCode[b.toInt() and 0xF])
-    }
-    return r.toString()
-}
-
 internal fun ByteArray.toShort(): Int {
     require(size == 2) { "ByteArray must be size of 2 to be converted to a short, was $size" }
     return this[0] and 0xFF shl 8 or (this[1] and 0xFF)

--- a/kable-core/src/commonMain/kotlin/Filter.kt
+++ b/kable-core/src/commonMain/kotlin/Filter.kt
@@ -3,7 +3,6 @@ package com.juul.kable
 import com.juul.kable.Filter.Name.Exact
 import com.juul.kable.Filter.Name.Prefix
 import kotlin.experimental.and
-import kotlin.text.HexFormat.Companion.UpperCase
 import kotlin.uuid.Uuid
 
 /**
@@ -127,7 +126,7 @@ public sealed class Filter {
         }
 
         override fun toString(): String =
-            "ManufacturerData(id=$id, data=${data?.toHexString(UpperCase)}, dataMask=${dataMask?.toHexString()})"
+            "ManufacturerData(id=$id, data=${data?.toHexString()}, dataMask=${dataMask?.toHexString()})"
     }
 
     /**

--- a/kable-core/src/commonMain/kotlin/Filter.kt
+++ b/kable-core/src/commonMain/kotlin/Filter.kt
@@ -3,6 +3,7 @@ package com.juul.kable
 import com.juul.kable.Filter.Name.Exact
 import com.juul.kable.Filter.Name.Prefix
 import kotlin.experimental.and
+import kotlin.text.HexFormat.Companion.UpperCase
 import kotlin.uuid.Uuid
 
 /**
@@ -126,7 +127,7 @@ public sealed class Filter {
         }
 
         override fun toString(): String =
-            "ManufacturerData(id=$id, data=${data?.toHexString()}, dataMask=${dataMask?.toHexString()})"
+            "ManufacturerData(id=$id, data=${data?.toHexString(UpperCase)}, dataMask=${dataMask?.toHexString()})"
     }
 
     /**

--- a/kable-core/src/commonMain/kotlin/logs/Hex.kt
+++ b/kable-core/src/commonMain/kotlin/logs/Hex.kt
@@ -1,7 +1,5 @@
 package com.juul.kable.logs
 
-import com.juul.kable.toHexString
-
 public val Hex: Logging.DataProcessor = Hex()
 
 public class HexBuilder internal constructor() {
@@ -15,7 +13,13 @@ public class HexBuilder internal constructor() {
 
 public fun Hex(init: HexBuilder.() -> Unit = {}): Logging.DataProcessor {
     val config = HexBuilder().apply(init)
+    val format = HexFormat {
+        upperCase = !config.lowerCase
+        bytes {
+            byteSeparator = config.separator
+        }
+    }
     return Logging.DataProcessor { data, _, _, _, _ ->
-        data.toHexString(separator = config.separator, lowerCase = config.lowerCase)
+        data.toHexString(format)
     }
 }

--- a/kable-core/src/commonTest/kotlin/HexTests.kt
+++ b/kable-core/src/commonTest/kotlin/HexTests.kt
@@ -1,0 +1,94 @@
+package com.juul.kable
+
+import com.juul.kable.logs.Hex
+import com.juul.kable.logs.Logging.DataProcessor
+import com.juul.kable.logs.Logging.DataProcessor.Operation.Read
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ObsoleteKableApi::class)
+class HexTests {
+
+    private fun process(
+        processor: DataProcessor,
+        data: ByteArray,
+    ): String = processor.process(
+        data = data,
+        operation = Read,
+        serviceUuid = null,
+        characteristicUuid = null,
+        descriptorUuid = null,
+    )
+
+    @Test
+    fun defaultHex_emptyData_returnsEmptyString() {
+        assertEquals(
+            expected = "",
+            actual = process(Hex, byteArrayOf()),
+        )
+    }
+
+    @Test
+    fun defaultHex_singleByte_returnsUpperCaseHex() {
+        assertEquals(
+            expected = "0A",
+            actual = process(Hex, byteArrayOf(0x0A)),
+        )
+    }
+
+    @Test
+    fun defaultHex_multipleBytes_defaultsToSpaceSeparatorAndUpperCase() {
+        assertEquals(
+            expected = "00 01 0F 10 FF",
+            actual = process(Hex, byteArrayOf(0x00, 0x01, 0x0F, 0x10, 0xFF.toByte())),
+        )
+    }
+
+    @Test
+    fun lowerCase_multipleBytes_returnsLowerCaseHex() {
+        val hex = Hex { lowerCase = true }
+        assertEquals(
+            expected = "00 01 0f 10 ff",
+            actual = process(hex, byteArrayOf(0x00, 0x01, 0x0F, 0x10, 0xFF.toByte())),
+        )
+    }
+
+    @Test
+    fun customSeparator_multipleBytes_usesConfiguredSeparator() {
+        val hex = Hex { separator = ":" }
+        assertEquals(
+            expected = "DE:AD:BE:EF",
+            actual = process(hex, byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())),
+        )
+    }
+
+    @Test
+    fun emptySeparator_multipleBytes_producesContiguousHex() {
+        val hex = Hex { separator = "" }
+        assertEquals(
+            expected = "DEADBEEF",
+            actual = process(hex, byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())),
+        )
+    }
+
+    @Test
+    fun customSeparatorAndLowerCase_combined() {
+        val hex = Hex {
+            separator = "-"
+            lowerCase = true
+        }
+        assertEquals(
+            expected = "de-ad-be-ef",
+            actual = process(hex, byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())),
+        )
+    }
+
+    @Test
+    fun customSeparator_singleByte_hasNoSeparator() {
+        val hex = Hex { separator = ":" }
+        assertEquals(
+            expected = "FF",
+            actual = process(hex, byteArrayOf(0xFF.toByte())),
+        )
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> `ManufacturerData` and `ServiceData` `toString` outputs will now have lowercase hex (previously was uppercase).
> This is more aligned with the default `toHexString` format provided by the stdlib, but should be called out in the release notes when this ships.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display/logging-only refactor with no BLE filtering or I/O behavior changes; minor `toString()` formatting differences possible where default hex casing differs from the old helper.
> 
> **Overview**
> Replaces the internal Tuulbox-style `ByteArray.toHexString` helper with Kotlin stdlib `toHexString` / `HexFormat`.
> 
> **Logging hex output** (`logs/Hex.kt`) now builds a `HexFormat` from existing `HexBuilder` options (byte separator and upper vs lower case) and passes it to `data.toHexString(format)`.
> 
> **Filter debug strings** for `ManufacturerData` use `HexFormat.UpperCase` for `data` so those fields stay uppercase in `toString()`; `dataMask` uses the default format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfa4b5cc3046caf05ec039c55080cbfb62606de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->