### PR TITLE
Update `tuulbox` to v8.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ jna = "5.19.1"
 jvm-toolchain = "17"
 kotlin = "2.4.10"
 krayon = "0.24.0"
-tuulbox = "8.1.0"
 voyager = "2.2.21-1.10.3"
 
 [libraries]
@@ -43,7 +42,7 @@ mockk = { module = "io.mockk:mockk", version = "1.14.11" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.11.0" }
 tomlkt = { module = "net.peanuuutz.tomlkt:tomlkt", version = "0.5.0" }
-tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
+tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version = "8.1.1" }
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
 voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }


### PR DESCRIPTION
In combination with #1240, fixes #1206; as [Tuulbox 8.1.1](https://github.com/JuulLabs/tuulbox/releases/tag/8.1.1) includes fixes so it no longer imposes AGP requirements on its consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Gradle catalog version bump for an Android coroutines helper dependency; no logic or API changes in this repo.
> 
> **Overview**
> Bumps **`com.juul.tuulbox:coroutines`** from **8.1.0** to **8.1.1** in `gradle/libs.versions.toml`, and drops the shared `tuulbox` version catalog entry in favor of pinning that version on the library alias.
> 
> This is a dependency-only change (no application code edits). Together with related work in #1240, it addresses consumers being forced to meet **AGP** requirements pulled in by older Tuulbox releases (#1206).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02eb315f33e64b92d6a6f620b111bff75a2a4564. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->