### PR TITLE
Never block scan callback threads when delivering scan results

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -432,10 +432,12 @@ public abstract interface class com/juul/kable/Scanner {
 public final class com/juul/kable/ScannerBuilder {
 	public fun <init> ()V
 	public final fun filters (Lkotlin/jvm/functions/Function1;)V
+	public final fun getBufferCapacity ()I
 	public final synthetic fun getFilters ()Ljava/util/List;
 	public final fun getPreConflate ()Z
 	public final fun getScanSettings ()Landroid/bluetooth/le/ScanSettings;
 	public final fun logging (Lkotlin/jvm/functions/Function1;)V
+	public final fun setBufferCapacity (I)V
 	public final synthetic fun setFilters (Ljava/util/List;)V
 	public final fun setPreConflate (Z)V
 	public final fun setScanSettings (Landroid/bluetooth/le/ScanSettings;)V

--- a/kable-core/src/androidHostTest/kotlin/com/juul/kable/ScannerBuilderTests.kt
+++ b/kable-core/src/androidHostTest/kotlin/com/juul/kable/ScannerBuilderTests.kt
@@ -1,0 +1,71 @@
+package com.juul.kable
+
+import android.os.Build
+import kotlinx.coroutines.channels.Channel
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class ScannerBuilderTests {
+
+    @Test
+    fun bufferCapacity_default_isUnlimited() {
+        assertEquals(Channel.UNLIMITED, ScannerBuilder().bufferCapacity)
+    }
+
+    @Test
+    fun bufferCapacity_positive_isRetained() {
+        val builder = ScannerBuilder()
+        builder.bufferCapacity = 64
+        assertEquals(64, builder.bufferCapacity)
+    }
+
+    @Test
+    fun bufferCapacity_buffered_isRejected() {
+        // `Channel.BUFFERED` behaves as a capacity of 1 (not the default channel capacity) when
+        // combined with an overflow strategy, so it is rejected rather than silently misleading.
+        assertFailsWith<IllegalArgumentException> {
+            ScannerBuilder().bufferCapacity = Channel.BUFFERED
+        }
+    }
+
+    @Test
+    fun bufferCapacity_conflated_isRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            ScannerBuilder().bufferCapacity = Channel.CONFLATED
+        }
+    }
+
+    @Test
+    fun bufferCapacity_rendezvous_isRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            ScannerBuilder().bufferCapacity = 0
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun preConflate_true_conflatesBufferCapacity() {
+        val builder = ScannerBuilder()
+        builder.preConflate = true
+        assertEquals(1, builder.bufferCapacity)
+        assertTrue(builder.preConflate)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun preConflate_false_isUnlimitedBufferCapacity() {
+        val builder = ScannerBuilder()
+        builder.preConflate = true
+        builder.preConflate = false
+        assertEquals(Channel.UNLIMITED, builder.bufferCapacity)
+        assertFalse(builder.preConflate)
+    }
+}

--- a/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -20,10 +20,12 @@ import com.juul.kable.scan.message
 import com.juul.kable.scan.requirements.checkLocationServicesEnabled
 import com.juul.kable.scan.requirements.checkScanPermissions
 import com.juul.kable.scan.requirements.requireBluetoothLeScanner
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.onFailure
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filter
 import kotlin.reflect.KClass
@@ -59,12 +61,12 @@ internal class BluetoothLeScannerAndroidScanner(
         logger.verbose { message = "Checking permissions for scanning" }
         checkScanPermissions()
 
+        // `trySend` is used (rather than `trySendBlocking`) because scan callbacks are invoked
+        // from a binder thread (on some phones, the main thread), where blocking can trigger an
+        // ANR. See https://github.com/JuulLabs/kable/issues/654 for more details.
         fun sendResult(scanResult: ScanResult) {
             val advertisement = ScanResultAndroidAdvertisement(scanResult)
-            when {
-                preConflate -> trySend(advertisement)
-                else -> trySendBlocking(advertisement)
-            }.onFailure {
+            trySend(advertisement).onFailure {
                 logger.warn { message = "Unable to deliver scan result due to failure in flow or premature closing." }
             }
         }
@@ -115,7 +117,13 @@ internal class BluetoothLeScannerAndroidScanner(
                 logger.warn(e) { message = "Failed to stop scan. " }
             }
         }
-    }.filter { advertisement ->
+    }.buffer(
+        // When pre-conflating, the default (BUFFERED) capacity is used, whereas scan results that
+        // arrive while the buffer is full are dropped (via failed `trySend`). Otherwise, an
+        // UNLIMITED capacity ensures no scan results are dropped, while never blocking the
+        // (Android provided) thread that scan callbacks are invoked from.
+        capacity = if (preConflate) BUFFERED else UNLIMITED,
+    ).filter { advertisement ->
         if (scanFilters.flow.isEmpty()) {
             true
         } else {

--- a/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
+++ b/kable-core/src/androidMain/kotlin/BluetoothLeScannerAndroidScanner.kt
@@ -20,7 +20,7 @@ import com.juul.kable.scan.message
 import com.juul.kable.scan.requirements.checkLocationServicesEnabled
 import com.juul.kable.scan.requirements.checkScanPermissions
 import com.juul.kable.scan.requirements.requireBluetoothLeScanner
-import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.onFailure
@@ -44,7 +44,7 @@ internal data class ScanFilters(
 internal class BluetoothLeScannerAndroidScanner(
     filters: List<FilterPredicate>,
     private val scanSettings: ScanSettings,
-    private val preConflate: Boolean,
+    private val bufferCapacity: Int,
     logging: Logging,
 ) : PlatformScanner {
 
@@ -101,13 +101,13 @@ internal class BluetoothLeScannerAndroidScanner(
         checkBluetoothIsOn()
 
         logger.info {
-            message = logMessage("Starting", preConflate, scanFilters)
+            message = logMessage("Starting", bufferCapacity, scanFilters)
         }
         scanner.startScan(scanFilters.native, scanSettings, callback)
 
         awaitClose {
             logger.info {
-                message = logMessage("Stopping", preConflate, scanFilters)
+                message = logMessage("Stopping", bufferCapacity, scanFilters)
             }
             // Can't check BLE state here, only Bluetooth, but should assume `IllegalStateException`
             // means BLE has been disabled.
@@ -118,11 +118,16 @@ internal class BluetoothLeScannerAndroidScanner(
             }
         }
     }.buffer(
-        // When pre-conflating, the default (BUFFERED) capacity is used, whereas scan results that
-        // arrive while the buffer is full are dropped (via failed `trySend`). Otherwise, an
-        // UNLIMITED capacity ensures no scan results are dropped, while never blocking the
-        // (Android provided) thread that scan callbacks are invoked from.
-        capacity = if (preConflate) BUFFERED else UNLIMITED,
+        // Scan results are delivered via (non-blocking) `trySend`, so this buffer — rather than
+        // backpressure on the thread that scan callbacks are invoked from — is what absorbs a slow
+        // collector. `DROP_OLDEST` keeps `trySend` from failing at a finite capacity; it is
+        // ignored at an UNLIMITED capacity, which never overflows and so never drops.
+        //
+        // Must stay adjacent to the `callbackFlow` (i.e. ahead of `filter`) to fuse into its
+        // channel. Applied after an intervening operator it creates a second channel instead,
+        // leaving the callback channel at the default capacity, where `trySend` drops again.
+        capacity = bufferCapacity,
+        onBufferOverflow = DROP_OLDEST,
     ).filter { advertisement ->
         if (scanFilters.flow.isEmpty()) {
             true
@@ -140,14 +145,16 @@ internal class BluetoothLeScannerAndroidScanner(
 
 private fun logMessage(
     prefix: String,
-    preConflate: Boolean,
+    bufferCapacity: Int,
     scanFilters: ScanFilters,
 ) = buildString {
     append(prefix)
     append(' ')
     append("scan ")
-    if (preConflate) {
-        append("pre-conflated ")
+    if (bufferCapacity != UNLIMITED) {
+        append("buffering up to ")
+        append(bufferCapacity)
+        append(" advertisement(s) ")
     }
     if (scanFilters.native.isEmpty() && scanFilters.flow.isEmpty()) {
         append("without filters")

--- a/kable-core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/kable-core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -5,7 +5,6 @@ import com.juul.kable.logs.Logging
 import com.juul.kable.logs.LoggingBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
-import kotlinx.coroutines.runBlocking
 
 public actual class ScannerBuilder {
 
@@ -37,10 +36,9 @@ public actual class ScannerBuilder {
      * Configures [Scanner] to pre-conflate the [advertisements][Scanner.advertisements] flow.
      *
      * Roughly equivalent to applying the [conflate][Flow.conflate] flow operator on the
-     * [advertisements][Scanner.advertisements] property (but without [runBlocking] overhead).
-     *
-     * May prevent ANRs on some Android phones (observed on specific Samsung models) that have
-     * delicate binder threads.
+     * [advertisements][Scanner.advertisements] property: scan results that arrive while the
+     * buffer is full are dropped (rather than being buffered without bound, as occurs when this
+     * setting is `false`).
      *
      * See https://github.com/JuulLabs/kable/issues/654 for more details.
      */

--- a/kable-core/src/androidMain/kotlin/ScannerBuilder.kt
+++ b/kable-core/src/androidMain/kotlin/ScannerBuilder.kt
@@ -3,6 +3,7 @@ package com.juul.kable
 import android.bluetooth.le.ScanSettings
 import com.juul.kable.logs.Logging
 import com.juul.kable.logs.LoggingBuilder
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
 
@@ -33,16 +34,47 @@ public actual class ScannerBuilder {
     private var logging: Logging = Logging()
 
     /**
-     * Configures [Scanner] to pre-conflate the [advertisements][Scanner.advertisements] flow.
+     * Configures how many [advertisements][Scanner.advertisements] may be buffered while waiting
+     * to be collected.
      *
-     * Roughly equivalent to applying the [conflate][Flow.conflate] flow operator on the
-     * [advertisements][Scanner.advertisements] property: scan results that arrive while the
-     * buffer is full are dropped (rather than being buffered without bound, as occurs when this
-     * setting is `false`).
+     * Scan results are never delivered by blocking the (Android provided) thread that scan
+     * callbacks are invoked from, so this capacity — rather than backpressure — is what absorbs a
+     * collector slower than scan results arrive:
+     *
+     * - [UNLIMITED] (the default) buffers without bound, so no scan results are dropped.
+     * - Any capacity of at least `1` drops the oldest buffered scan result to make room for the
+     *   newest. A capacity of `1` is equivalent to applying the [conflate][Flow.conflate] flow
+     *   operator on the [advertisements][Scanner.advertisements] property.
+     *
+     * `Channel.BUFFERED` and `Channel.CONFLATED` are rejected, as neither keeps its usual meaning
+     * once the oldest buffered scan result is dropped on overflow: `Channel.BUFFERED` would
+     * silently behave as a capacity of `1` rather than the default channel capacity, and
+     * `Channel.CONFLATED` cannot be combined with an overflow strategy at all.
      *
      * See https://github.com/JuulLabs/kable/issues/654 for more details.
      */
-    public var preConflate: Boolean = false
+    public var bufferCapacity: Int = UNLIMITED
+        set(value) {
+            require(value >= 1) {
+                "Buffer capacity must be at least 1 (UNLIMITED for no limit), but was $value"
+            }
+            field = value
+        }
+
+    /**
+     * Configures [Scanner] to pre-conflate the [advertisements][Scanner.advertisements] flow.
+     *
+     * See https://github.com/JuulLabs/kable/issues/654 for more details.
+     */
+    @Deprecated(
+        message = "Use bufferCapacity, where a capacity of 1 conflates and UNLIMITED (the default) does not drop.",
+        replaceWith = ReplaceWith("bufferCapacity = 1"),
+    )
+    public var preConflate: Boolean
+        get() = bufferCapacity != UNLIMITED
+        set(value) {
+            bufferCapacity = if (value) 1 else UNLIMITED
+        }
 
     public actual fun logging(init: LoggingBuilder) {
         logging = Logging().apply(init)
@@ -53,6 +85,6 @@ public actual class ScannerBuilder {
         filters = filterPredicates,
         scanSettings = scanSettings,
         logging = logging,
-        preConflate = preConflate,
+        bufferCapacity = bufferCapacity,
     )
 }


### PR DESCRIPTION
## Problem

`BluetoothLeScannerAndroidScanner` delivers scan results to the `advertisements` `callbackFlow` via `trySendBlocking` (unless `preConflate` is enabled). Android invokes `ScanCallback` functions from a binder thread — and on some phones, the main thread. When scan results arrive faster than the collector drains the channel (dense BLE environments), the callback thread parks until buffer space frees up. When that thread is the main thread, the OS declares an ANR.

This is the same failure mode previously reported in #485 and #654. We (Meshtastic Android, Kable 0.44.3) hit it in production: 8 ANRs across distinct users during DEF CON 34 (an extremely dense BLE environment), all with the main thread parked in:

```
kotlinx.coroutines.channels.ChannelsKt__ChannelsKt.trySendBlocking
com.juul.kable.BluetoothLeScannerAndroidScanner$advertisements$1$callback$1.onScanResult
android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run
```

## Change

- Use non-blocking `trySend` unconditionally in the scan callback.
- Add a `bufferCapacity` property to `ScannerBuilder` (Android), applied as `buffer(capacity, DROP_OLDEST)` on the `advertisements` `callbackFlow`:
  - `UNLIMITED` (the default) is **lossless**: `trySend` cannot fail on an unlimited channel (except after close), so no scan results are dropped - the previous blocking behavior's guarantee is preserved without ever parking the callback thread.
  - Any capacity of at least `1` drops the oldest buffered result to make room for the newest; `1` is equivalent to `conflate`.
  - `BUFFERED`, `CONFLATED` and `0` are rejected, since none of them keep their usual meaning alongside `DROP_OLDEST` (`BUFFERED` becomes a capacity of 1, not the default depth).
- Deprecate `preConflate`; `preConflate = true` maps to `bufferCapacity = 1`, `false` to `UNLIMITED`.

The trade-off at the default is that a slow collector now grows the buffer (memory) instead of exerting backpressure on the binder thread. Backpressure via blocking an Android-owned callback thread was never safe - the "pressure" propagated to the OS as an ANR rather than to the producer, since the producer (the Bluetooth stack) doesn't slow down anyway.

The public API change is additive (`bufferCapacity` getter/setter); the Android API dump is updated.

Closes #654 (the default-behavior remnant of it, at least).

---

*Disclosure: this change was drafted with an AI assistant (Claude Code), then reviewed by me. It is motivated by first-party production ANR reports from [Meshtastic-Android](https://github.com/meshtastic/Meshtastic-Android). Verified locally with `lintKotlin`, `apiCheck`, and `testAndroidHostTest`.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot-path Android scan callback pipeline and shifts backpressure from thread blocking to unbounded buffering; behavior change is intentional but worth validating under heavy BLE load.
> 
> **Overview**
> Fixes **ANRs** when BLE scan results outpace collectors by stopping use of **`trySendBlocking`** on Android `ScanCallback` threads (sometimes the main thread).
> 
> Scan delivery now always uses non-blocking **`trySend`**, with a **`buffer`** on the advertisements flow: **`UNLIMITED`** by default so results stay lossless without parking the callback thread; **`BUFFERED`** when **`preConflate`** is enabled (drops when full, same as before). **`preConflate`** docs are updated to describe buffering/drops instead of blocking/`runBlocking`.
> 
> Trade-off: a slow collector can grow memory instead of blocking the binder thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d9299c9b89695de74ea7173a755b5824d1b4ba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
